### PR TITLE
Allow custom dumps on json_response

### DIFF
--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -40,16 +40,17 @@ class _Dumper(object):
 			return "{}".format(o)
 
 
-def json_response(request, data, pretty=None, dumps=None, **kwargs):
+def json_response(request, data, pretty=None, dumps=_Dumper, **kwargs):
 	'''
 	## Pretty Result
 	When appending ?pretty=true to any request made, the JSON returned will be pretty formatted (use it for debugging only!).
 	'''
+	assert issubclass(dumps, _Dumper)
 	pretty = request.query.get('pretty', 'no').lower() in frozenset(['true', '1', 't', 'y', 'yes']) or pretty
 
 	return aiohttp.web.json_response(
 		data,
-		dumps=dumps or _Dumper(pretty),
+		dumps=dumps(pretty),
 		**kwargs
 	)
 

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -12,7 +12,7 @@ Lex = logging.getLogger("asab.web")
 
 #
 
-class _Dumper(object):
+class JSONDumper(object):
 
 	def __init__(self, pretty):
 		self.pretty = pretty
@@ -40,12 +40,12 @@ class _Dumper(object):
 			return "{}".format(o)
 
 
-def json_response(request, data, pretty=None, dumps=_Dumper, **kwargs):
+def json_response(request, data, pretty=None, dumps=JSONDumper, **kwargs):
 	'''
 	## Pretty Result
 	When appending ?pretty=true to any request made, the JSON returned will be pretty formatted (use it for debugging only!).
 	'''
-	assert issubclass(dumps, _Dumper)
+	assert issubclass(dumps, JSONDumper)
 	pretty = request.query.get('pretty', 'no').lower() in frozenset(['true', '1', 't', 'y', 'yes']) or pretty
 
 	return aiohttp.web.json_response(

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -40,7 +40,7 @@ class _Dumper(object):
 			return "{}".format(o)
 
 
-def json_response(request, data, pretty=None, **kwargs):
+def json_response(request, data, pretty=None, dumps=None, **kwargs):
 	'''
 	## Pretty Result
 	When appending ?pretty=true to any request made, the JSON returned will be pretty formatted (use it for debugging only!).
@@ -49,7 +49,7 @@ def json_response(request, data, pretty=None, **kwargs):
 
 	return aiohttp.web.json_response(
 		data,
-		dumps=_Dumper(pretty),
+		dumps=dumps or _Dumper(pretty),
 		**kwargs
 	)
 


### PR DESCRIPTION
When using `asab.web.rest.json_response` with data from MongoDB it throws error `Object of type 'ObjectId' is not JSON serializable` (`ObjectId` is MongoDB identificator - `<class 'bson.objectid.ObjectId'>`)

This is to allow implementation of custom dumps object.

Example of usage `json_response(..., dumps=bson.json_util.dumps)`
