### PR TITLE
PLUM-764: Align versioning with bspump - from a git tag

### DIFF
--- a/asab/__init__.py
+++ b/asab/__init__.py
@@ -1,13 +1,12 @@
-__version__ = '19.07'
-
-from .log import _StructuredDataLogger, LOG_NOTICE
-from .application import Application
-from .abc.service import Service
 from .abc.module import Module
+from .abc.service import Service
 from .abc.singleton import Singleton
+from .application import Application
 from .config import Config, ConfigObject
-from .pubsub import subscribe, PubSub, Subscriber
+from .log import _StructuredDataLogger, LOG_NOTICE
 from .pdict import PersistentDict
+from .pubsub import subscribe, PubSub, Subscriber
+from .socket import StreamSocketServerService
 from .timer import Timer
 
-from .socket import StreamSocketServerService
+from .__version__ import __version__, __build__

--- a/asab/__version__.py
+++ b/asab/__version__.py
@@ -1,0 +1,12 @@
+# THIS-FILE-WILL-BE-REPLACED !!! DO NOT CHANGE OR MODIFY THIS FILE !!!
+
+# During `setup.py build_py`, this file is overwritten
+# __version__ = '[git describe --abbrev=7 --tags --dirty=+dirty --always]
+# __build__ = '[git rev-parse HEAD]'
+
+# PEP 440 -- Version Identification and Dependency Specification
+# https://www.python.org/dev/peps/pep-0440/
+
+
+__version__ = 'devel'
+__build__ = 'devel'


### PR DESCRIPTION
`python -c 'import asab;print(asab.__version__)'` will print out `devel`

After creating a git tag (`git tag -a v19.10 -m "Release of asab v19.10" && git checkout v19.10`) following command will create a distribution package and replace `__version__` and `__build__` in `__version__.py`

`python setup.py sdist bdist_wheel`

Preview of `build/lib/asab/__version__.py` file
```py
__version__ = '19.10'
__build__ = 'da693b1b8de6ae448f5ff94dd79ebc538493c069'


```