### PR TITLE
Fix 'mesage' typo in json response

### DIFF
--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -74,7 +74,7 @@ async def JsonExceptionMiddleware(request, handler):
 	except aiohttp.web.HTTPError as ex:
 		respdict = {
 			'status': ex.status,
-			'mesage': ex.text[5:]
+			'message': ex.text[5:]
 		}
 		if ex.status >= 400:
 			euuid = uuid.uuid4()


### PR DESCRIPTION
This is fixing typo in json error response

Original:
```
{
    "mesage": "Bad Request",
    "status": 400,
    "uuid": "1c632c9a-b807-43df-9178-8cbb192f0c60"
}
```

Fixed:
```
{
    "message": "Bad Request",
    "status": 400,
    "uuid": "1c632c9a-b807-43df-9178-8cbb192f0c60"
}
```