### PR TITLE
Making RootLogger's logging level configurable.

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -39,7 +39,7 @@ class ConfigParser(configparser.ConfigParser):
 		"logging": {
 			'verbose': os.environ.get('ASAB_VERBOSE', False),
 			"app_name": os.path.basename(sys.argv[0]),
-			"sd_id": "sd",  # Structured data id, see RFC5424,
+			"sd_id": "sd",  # Structured data id, see RFC5424
 			"level": "NOTICE",
 		},
 

--- a/asab/config.py
+++ b/asab/config.py
@@ -39,7 +39,8 @@ class ConfigParser(configparser.ConfigParser):
 		"logging": {
 			'verbose': os.environ.get('ASAB_VERBOSE', False),
 			"app_name": os.path.basename(sys.argv[0]),
-			"sd_id": "sd",  # Structured data id, see RFC5424
+			"sd_id": "sd",  # Structured data id, see RFC5424,
+			"level": "NOTICE",
 		},
 
 		"logging:console": {

--- a/asab/log.py
+++ b/asab/log.py
@@ -137,7 +137,7 @@ class Logging(object):
 		if Config["logging"].getboolean("verbose"):
 			self.RootLogger.setLevel(logging.DEBUG)
 		else:
-			self.RootLogger.setLevel(LOG_NOTICE)
+			self.RootLogger.setLevel(Config["logging"]["level"])
 
 
 	def rotate(self):


### PR DESCRIPTION
As a user I want to be able to configure logging level of the RootLogger.

In configuration:
```
[logging]
level=INFO
```