### PR TITLE
PLUM-1178: Initialize authorize_any and authorize_all handler

### DIFF
--- a/asab/web/authn/__init__.py
+++ b/asab/web/authn/__init__.py
@@ -1,10 +1,13 @@
 from .middleware import authn_middleware_factory
-from .middleware import authn_required_handler
 from .middleware import authn_optional_handler
-
+from .middleware import authn_required_handler
+from .middleware import authorize_all
+from .middleware import authorize_any
 
 __all__ = (
 	'authn_middleware_factory',
-	'authn_required_handler',
 	'authn_optional_handler',
+	'authn_required_handler',
+	'authorize_all',
+	'authorize_any',
 )

--- a/asab/web/authn/middleware.py
+++ b/asab/web/authn/middleware.py
@@ -79,7 +79,7 @@ def authorize_any(*authorizations):
 
 	Example:
 		@asab.web.authn.authorize_any(my_custom_authorization, allow_admin)
-		async def handler(self, request, *, authorized_prefixes):
+		async def handler(self, request, *):
 			...
 
 	:param authorizations: List of authorization functions
@@ -88,10 +88,9 @@ def authorize_any(*authorizations):
 
 		@functools.wraps(func)
 		async def wrapper_authorize_any(*args, **kwargs):
-			authorized_prefixes = {}
-			result = [await auth(*args, **kwargs, authorized_prefixes=authorized_prefixes) for auth in authorizations]
+			result = [await auth(args, kwargs) for auth in authorizations]
 			if any(result):
-				return await func(*args, **kwargs, authorized_prefixes=authorized_prefixes)
+				return await func(*args, **kwargs)
 			else:
 				raise aiohttp.web.HTTPForbidden()
 
@@ -106,7 +105,7 @@ def authorize_all(*authorizations):
 
 	Example:
 		@asab.web.authn.authorize_all(my_custom_authorization, allow_admin)
-		async def handler(self, request, *, authorized_prefixes):
+		async def handler(self, request, *):
 			...
 
 	:param authorizations: List of authorization functions
@@ -115,10 +114,9 @@ def authorize_all(*authorizations):
 
 		@functools.wraps(func)
 		async def wrapper_authorize_all(*args, **kwargs):
-			authorized_prefixes = {}
-			result = [await auth(*args, **kwargs, authorized_prefixes=authorized_prefixes) for auth in authorizations]
+			result = [await auth(args, kwargs) for auth in authorizations]
 			if all(result):
-				return await func(*args, **kwargs, authorized_prefixes=authorized_prefixes)
+				return await func(*args, **kwargs)
 			else:
 				raise aiohttp.web.HTTPForbidden()
 

--- a/asab/web/authn/middleware.py
+++ b/asab/web/authn/middleware.py
@@ -1,3 +1,5 @@
+import functools
+
 import aiohttp
 import aiohttp.web
 
@@ -69,3 +71,57 @@ def authn_optional_handler(func):
 		return await func(*args, **kargs)
 
 	return wrapper
+
+
+def authorize_any(*authorizations):
+	"""
+	The web handler that checks if ANY *authorizations* passed successfully.
+
+	Example:
+		@asab.web.authn.authorize_any(my_custom_authorization, allow_admin)
+		async def handler(self, request, *, authorized_prefixes):
+			...
+
+	:param authorizations: List of authorization functions
+	"""
+	def decorator_authorize_any(func):
+
+		@functools.wraps(func)
+		async def wrapper_authorize_any(*args, **kwargs):
+			authorized_prefixes = {}
+			result = [await auth(*args, **kwargs, authorized_prefixes=authorized_prefixes) for auth in authorizations]
+			if any(result):
+				return await func(*args, **kwargs, authorized_prefixes=authorized_prefixes)
+			else:
+				raise aiohttp.web.HTTPForbidden()
+
+		return wrapper_authorize_any
+
+	return decorator_authorize_any
+
+
+def authorize_all(*authorizations):
+	"""
+	The web handler that checks if ALL *authorizations* passed successfully.
+
+	Example:
+		@asab.web.authn.authorize_all(my_custom_authorization, allow_admin)
+		async def handler(self, request, *, authorized_prefixes):
+			...
+
+	:param authorizations: List of authorization functions
+	"""
+	def decorator_authorize_all(func):
+
+		@functools.wraps(func)
+		async def wrapper_authorize_all(*args, **kwargs):
+			authorized_prefixes = {}
+			result = [await auth(*args, **kwargs, authorized_prefixes=authorized_prefixes) for auth in authorizations]
+			if all(result):
+				return await func(*args, **kwargs, authorized_prefixes=authorized_prefixes)
+			else:
+				raise aiohttp.web.HTTPForbidden()
+
+		return wrapper_authorize_all
+
+	return decorator_authorize_all


### PR DESCRIPTION
@ateska I don't think `authorized_prefixes` is correct name. Shouldn't we use something more generic here?

Thanks.