### PR TITLE
Smarter ASAB storage selector

### DIFF
--- a/asab/storage/__init__.py
+++ b/asab/storage/__init__.py
@@ -7,14 +7,6 @@ L = logging.getLogger(__name__)
 
 #
 
-asab.Config.add_defaults(
-	{
-		'asab:storage': {
-			'type': 'inmemory',
-		}
-	}
-)
-
 
 class Module(asab.Module):
 

--- a/examples/inmemory_storage.py
+++ b/examples/inmemory_storage.py
@@ -4,13 +4,13 @@ import asab
 import asab.storage
 
 
-'''
-../etc/site.conf
-
-[asab:storage]
-type=inmemory
-
-'''
+asab.Config.add_defaults(
+	{
+		'asab:storage': {
+			'type': 'inmemory',
+		}
+	}
+)
 
 
 class MyApplication(asab.Application):

--- a/examples/mongodb_storage.py
+++ b/examples/mongodb_storage.py
@@ -4,14 +4,19 @@ import asab
 import asab.storage
 
 
+asab.Config.add_defaults(
+	{
+		'asab:storage': {
+			'type': 'mongodb',
+		}
+	}
+)
+
+
 class MyApplication(asab.Application):
 
 	async def initialize(self):
-		# Fake config file
-		asab.Config.read_string("""
-[asab:storage]
-type=mongodb
-				""")
+
 		# Loading the web service module
 		self.add_module(asab.storage.Module)
 


### PR DESCRIPTION
ASAB storage was very sensitive on the order of configuration vs. module import and initialization.
This is now fixed and it should work nicely.