### PR TITLE
ASAB Config loading from ZooKeeper

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -131,7 +131,6 @@ class ConfigParser(configparser.ConfigParser):
 				continue
 
 			if include_glob.startswith('zookeeper://'):
-			#	removexoo = include_glob[12:]
 				self._include_from_zookeeper(include_glob)
 				continue
 
@@ -190,6 +189,7 @@ class ConfigParser(configparser.ConfigParser):
 		from urllib.parse import urlparse
 
 		loop = asyncio.get_event_loop()
+
 		#parse include value into hostname and path
 		url_pieces = urlparse(zkurl)
 		url_path = url_pieces.path
@@ -206,16 +206,11 @@ class ConfigParser(configparser.ConfigParser):
 			data = await zk.get_data(url_path)
 			#convert bytes to string
 			encode_config = str(data,'utf-8')
-
-			#print("THIS IS ENCODED DATA" + encodeconfig)
 			self.read_string(encode_config)
 			await zk.close()
 
 
 		loop.run_until_complete(download_from_zookeeper())
-		print(self["connection:SSHConnection2"]["host"])
-		sections = self.sections()
-		print(sections)
 
 
 class _Interpolation(configparser.ExtendedInterpolation):

--- a/asab/config.py
+++ b/asab/config.py
@@ -228,7 +228,6 @@ class ConfigParser(configparser.ConfigParser):
 				encode_config = str(data,'utf-8')
 				self.read_string(encode_config)
 				await zk.close()
-				return  data
 			except Exception as e:
 				L.warning("Connection to zookeeper could not be established: '{}'.".format(e))
 				sys.exit(1)

--- a/asab/config.py
+++ b/asab/config.py
@@ -190,7 +190,11 @@ class ConfigParser(configparser.ConfigParser):
 		loop = asyncio.get_event_loop()
 
 		async def download_from_zookeeper():
-			zk = aiozk.ZKClient('server1:2181,server2:2181,server3:2181')
+			zk = aiozk.ZKClient(
+				'server1:2181,server2:2181,server3:2181'
+				allow_read_only=True,
+				read_timeout=60,  # seconds
+			)
 			await zk.start()
 			data = await zk.get_data('/greeting/to/world')
 			self.read_string(data)

--- a/asab/config.py
+++ b/asab/config.py
@@ -6,6 +6,7 @@ import logging
 import inspect
 import platform
 import configparser
+from urllib.parse import urlparse , urlunparse
 from collections.abc import MutableMapping
 
 
@@ -118,7 +119,6 @@ class ConfigParser(configparser.ConfigParser):
 
 	def _traverse_includes(self, includes, this_dir):
 		""" Reads included config files. Supports nested including. """
-
 		if '\n' in includes:
 			sep = '\n'
 		else:
@@ -130,9 +130,14 @@ class ConfigParser(configparser.ConfigParser):
 			if len(include_glob) == 0:
 				continue
 
-			if include_glob.startswith('zookeeper://'):
-				self._include_from_zookeeper(include_glob)
-				continue
+			if include_glob.startswith("zookeeper"):
+
+				if include_glob.rfind("//") == 10:
+					self._include_from_zookeeper(include_glob)
+
+				else:
+					get_url = self._from_include_build_url(include_glob)
+					self._include_from_zookeeper(get_url)
 
 			include_glob = os.path.expandvars(include_glob.strip())
 
@@ -183,35 +188,52 @@ class ConfigParser(configparser.ConfigParser):
 
 		del self._load_dir_stack
 
+	def _from_include_build_url(self, purl):
+
+		parse_include = urlparse(purl)
+		url_path = parse_include.path
+		url_scheme = parse_include.scheme
+		url_netloc = self["asab.zookeeper"]["url"]
+
+		if purl.rfind("///") == 10:
+			url_comp = (url_scheme, url_netloc, url_path, '', '', '')
+
+		elif purl.rfind(":.") == 9:
+			new_url_path = self["asab.zookeeper"]["path"] + url_path[1:]
+			url_comp = (url_scheme, url_netloc, new_url_path, '', '', '')
+
+		#unparse  components into proper URL
+		url_built = urlunparse(url_comp)
+		return  url_built
 
 	def _include_from_zookeeper(self, zkurl):
 		import aiozk
-		from urllib.parse import urlparse
 
 		loop = asyncio.get_event_loop()
-
 		#parse include value into hostname and path
 		url_pieces = urlparse(zkurl)
 		url_path = url_pieces.path
 		url_netloc = url_pieces.netloc
 
 		async def download_from_zookeeper():
-			zk = aiozk.ZKClient(
-				url_netloc,
-				allow_read_only=True,
-				read_timeout=60,  # seconds
-			)
-			await zk.start()
-
-			data = await zk.get_data(url_path)
-			#convert bytes to string
-			encode_config = str(data,'utf-8')
-			self.read_string(encode_config)
-			await zk.close()
-
+			try:
+				zk = aiozk.ZKClient(
+					url_netloc,
+					allow_read_only=True,
+					read_timeout=60,  # seconds #
+			   	)
+				await zk.start()
+				data = await zk.get_data(url_path)
+				#convert bytes to string
+				encode_config = str(data,'utf-8')
+				self.read_string(encode_config)
+				await zk.close()
+				return  data
+			except Exception as e:
+				L.warning("Connection to zookeeper could not be established: '{}'.".format(e))
+				sys.exit(1)
 
 		loop.run_until_complete(download_from_zookeeper())
-
 
 class _Interpolation(configparser.ExtendedInterpolation):
 	"""Interpolation which expands environment variables in values."""

--- a/asab/config.py
+++ b/asab/config.py
@@ -188,8 +188,9 @@ class ConfigParser(configparser.ConfigParser):
 	def _include_from_zookeeper(self, zkurl):
 		import aiozk
 		from urllib.parse import urlparse
-		loop = asyncio.get_event_loop()
 
+		loop = asyncio.get_event_loop()
+		#parse include value into hostname and path
 		url_pieces = urlparse(zkurl)
 		url_path = url_pieces.path
 		url_netloc = url_pieces.netloc
@@ -201,19 +202,20 @@ class ConfigParser(configparser.ConfigParser):
 				read_timeout=60,  # seconds
 			)
 			await zk.start()
+
 			data = await zk.get_data(url_path)
-			encodeconfig = str(data,'utf-8')
+			#convert bytes to string
+			encode_config = str(data,'utf-8')
+
 			#print("THIS IS ENCODED DATA" + encodeconfig)
-			self.read_string(encodeconfig)
+			self.read_string(encode_config)
 			await zk.close()
 
 
 		loop.run_until_complete(download_from_zookeeper())
 		print(self["connection:SSHConnection2"]["host"])
 		sections = self.sections()
-		#opt = self.options(sections)
 		print(sections)
-		#print("This is options " + opt)
 
 
 class _Interpolation(configparser.ExtendedInterpolation):

--- a/examples/zookeeper.conf
+++ b/examples/zookeeper.conf
@@ -1,0 +1,4 @@
+[general]
+
+include=
+	zookeeper://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/asab/etc/zk-site.conf

--- a/examples/zookeeper.py
+++ b/examples/zookeeper.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import logging
+
+import asab
+
+L = logging.getLogger(__name__)
+
+
+class MyApplication(asab.Application):
+	'''
+	Run this with:
+	python3 ./zookeeper.py -c ./zookeeper.conf
+
+	It downloads the configuration file from a zookeeper
+	'''
+
+
+	def __init__(self):
+		super().__init__()
+
+
+if __name__ == "__main__":
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION
Further development:

- [ ] Allow sharing of the ZooKeeper configuration with ASAB (see bellow)
- [ ] Test various failure scenarios (how this react when zookeeper is not available)
- [ ] Allow "recursive" includes from ZooKeeper (this one will be postponed into a dedicated pull request, deliver later)

**Reuse of the ZooKeeper config**

```
[asab.zookeeper]
url=server1 server2 server3

[general]
include=zookeeper:///asab/etc/zk-site.conf
```

The server part of the URL is empty - it means that the URL from `asab.zookeeper` section should be used.


With the path in:


```
[asab.zookeeper]
url=server1 server2 server3
path=/myfolder

[general]
include=zookeeper:./etc/zk-site.conf
```

=> zookeeper://server1,server2, server3/myfolder/etc/zk-site.conf