### PR TITLE
Draft: Web section config refactoring

### DIFF
--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -62,7 +62,7 @@ class ApiService(asab.Service):
 	def _initialize_web(self):
 		websvc = self.App.get_service("asab.WebService")
 
-		container = websvc.Container
+		container = websvc.Containers.get(websvc.WebConfigName)
 
 		# TODO: Logging level configurable via config file
 		self.APILogHandler = WebApiLoggingHandler(self.App, level=logging.NOTSET)

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -62,7 +62,7 @@ class ApiService(asab.Service):
 	def _initialize_web(self):
 		websvc = self.App.get_service("asab.WebService")
 
-		container = websvc.Containers.get(websvc.WebConfigName)
+		container = websvc.WebApp.Container
 
 		# TODO: Logging level configurable via config file
 		self.APILogHandler = WebApiLoggingHandler(self.App, level=logging.NOTSET)

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -22,8 +22,7 @@ class ApiService(asab.Service):
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
 
-		listen = asab.Config["asab:web"]["listen"]
-		self.WebContainer = self._initialize_web(listen)
+		self.WebContainer = self._initialize_web()
 
 		if len(asab.Config["asab:zookeeper"]["servers"]) > 0:
 			self.ZkContainer = self._initialize_zookeeper()
@@ -60,14 +59,10 @@ class ApiService(asab.Service):
 		return adv_data
 
 
-	def _initialize_web(self, listen):
+	def _initialize_web(self):
 		websvc = self.App.get_service("asab.WebService")
 
-		# Create a dedicated web container
-		container = asab.web.WebContainer(
-			websvc, "asab:web",
-			config={"listen": listen}
-		)
+		container = websvc.Containers.get(websvc.WebConfigName)
 		# TODO: refactor to use custom config section, instead of explicitly passing "listen" param?
 
 		# TODO: Logging level configurable via config file

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -62,8 +62,7 @@ class ApiService(asab.Service):
 	def _initialize_web(self):
 		websvc = self.App.get_service("asab.WebService")
 
-		container = websvc.Containers.get(websvc.WebConfigName)
-		# TODO: refactor to use custom config section, instead of explicitly passing "listen" param?
+		container = websvc.Container
 
 		# TODO: Logging level configurable via config file
 		self.APILogHandler = WebApiLoggingHandler(self.App, level=logging.NOTSET)

--- a/asab/application.py
+++ b/asab/application.py
@@ -129,7 +129,8 @@ class Application(metaclass=Singleton):
 
 		# Setup ASAB API
 		web_config = Config.get("web")
-		if web_config is None:
+		if web_config is None or len(web_config["listen"]) == 0:
+			# Backward compatibility: try fallback to "asab:web"
 			web_config = Config.get("asab:web")
 		if len(web_config["listen"]) > 0:
 			from asab.api import Module

--- a/asab/application.py
+++ b/asab/application.py
@@ -128,11 +128,11 @@ class Application(metaclass=Singleton):
 		self.TaskService = TaskService(self)
 
 		# Setup ASAB API
-		web_config = Config.get("web")
-		if web_config is None or len(web_config["listen"]) == 0:
+		if (
+			Config.has_option("web", "listen") and len(Config.get("web", "listen")) > 0
 			# Backward compatibility: try fallback to "asab:web"
-			web_config = Config.get("asab:web")
-		if len(web_config["listen"]) > 0:
+			or Config.has_option("asab:web", "listen") and len(Config.get("asab:web", "listen")) > 0
+		):
 			from asab.api import Module
 			self.add_module(Module)
 

--- a/asab/application.py
+++ b/asab/application.py
@@ -129,9 +129,9 @@ class Application(metaclass=Singleton):
 
 		# Setup ASAB API
 		if (
-			Config.has_option("web", "listen") and len(Config.get("web", "listen")) > 0
+			(Config.has_option("web", "listen") and len(Config.get("web", "listen")) > 0)
 			# Backward compatibility: try fallback to "asab:web"
-			or Config.has_option("asab:web", "listen") and len(Config.get("asab:web", "listen")) > 0
+			or (Config.has_option("asab:web", "listen") and len(Config.get("asab:web", "listen")) > 0)
 		):
 			from asab.api import Module
 			self.add_module(Module)

--- a/asab/application.py
+++ b/asab/application.py
@@ -128,7 +128,10 @@ class Application(metaclass=Singleton):
 		self.TaskService = TaskService(self)
 
 		# Setup ASAB API
-		if len(Config['asab:web']["listen"]) > 0:
+		web_config = Config.get("web")
+		if web_config is None:
+			web_config = Config.get("asab:web")
+		if len(web_config["listen"]) > 0:
 			from asab.api import Module
 			self.add_module(Module)
 
@@ -195,7 +198,7 @@ class Application(metaclass=Singleton):
 			Config._default_values['logging:file']['path'] = args.log_file
 
 		if args.web_api:
-				Config._default_values['asab:web']['listen'] = args.web_api
+			Config._default_values['web']['listen'] = args.web_api
 		return args
 
 

--- a/asab/config.py
+++ b/asab/config.py
@@ -68,7 +68,7 @@ class ConfigParser(configparser.ConfigParser):
 			"rotate_every": "",
 		},
 
-		"asab:web": {
+		"web": {
 			"listen": "",
 		},
 

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -124,7 +124,9 @@ want to allow OPTIONS method for preflight requests.
 				elif param.startswith('ssl'):
 					ssl_context = SSLContextBuilder("<none>", config=self.Config).build()
 				else:
-					raise RuntimeError("Unknown asab:web listen parameter: '{}'".format(param))
+					raise RuntimeError(
+						"Unknown listen parameter in section [{}]: {}".format(config_section_name, param)
+					)
 			self._listen.append((addr, port, ssl_context))
 
 		self.WebApp = aiohttp.web.Application(loop=websvc.App.Loop)

--- a/asab/web/service.py
+++ b/asab/web/service.py
@@ -12,6 +12,7 @@ class WebService(asab.Service):
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
 
+		self.WebConfigName = "web"
 		self.Containers = {}
 		self.App = app
 
@@ -31,14 +32,12 @@ class WebService(asab.Service):
 		'''
 		This is here to maintain backward compatibility.
 		'''
-		if "web" in asab.Config.sections():
-			# The WebContainer should be configured in the config section [web]
-			config_section_name = "web"
-		else:
-			# Supporting other section names for backwards compatibility
+		# The WebContainer should be configured in the config section [web]
+		if self.WebConfigName not in asab.Config.sections():
+			# If there is no [web] section, try other aliases for backwards compatibility
 			for alias in self.ObsoleteConfigAliases:
 				if alias in asab.Config.sections():
-					config_section_name = alias
+					self.WebConfigName = alias
 					L.warning("Using obsolete web config alias [{}]. Preferred section name is [web]. ".format(alias))
 					break
 			else:

--- a/asab/web/service.py
+++ b/asab/web/service.py
@@ -44,7 +44,7 @@ class WebService(asab.Service):
 				raise RuntimeError("No [web] section configured.")
 
 		try:
-			return self.Containers[config_section_name].WebApp
+			return self.Containers[self.WebConfigName].WebApp
 		except KeyError:
 			from .container import WebContainer
-			return WebContainer(self, config_section_name).WebApp
+			return WebContainer(self, self.WebConfigName).WebApp


### PR DESCRIPTION
**`BREAKING`** The web configuration section has been renamed from `asab:web` to `web`.

`asab:web` was added to obsolete aliases for backwards compatibility.