### PR TITLE
JSONDumper: interpret naive datetime as UTC

### DIFF
--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -30,12 +30,12 @@ class JSONDumper(object):
 			return m()
 
 		if isinstance(o, datetime.datetime):
-			if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
-				# The datetime object is timezone-naive -> interpret it as UTC
-				return o.isoformat() + "Z"
-			else:
+			if o.tzinfo is not None and o.tzinfo.utcoffset(o) is not None:
 				# The datetime object is timezone-aware
 				return o.isoformat()
+			else:
+				# The datetime object is timezone-naive -> interpret it as UTC
+				return o.isoformat() + "Z"
 
 		elif isinstance(o, bytes):
 			return o.hex()

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -30,7 +30,12 @@ class JSONDumper(object):
 			return m()
 
 		if isinstance(o, datetime.datetime):
-			return o.isoformat()
+			if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
+				# The datetime object is timezone-naive -> interpret it as UTC
+				return o.isoformat() + "Z"
+			else:
+				# The datetime object is timezone-aware
+				return o.isoformat()
 
 		elif isinstance(o, bytes):
 			return o.hex()


### PR DESCRIPTION
If a datetime object has no timezone info, it is interpreted as UTC and the "Z" suffix is appended to it.

All non-UTC datetimes need to be made timezone-aware to be dumped correctly.

Example:
```python
response = {
    "naive_utcnow": datetime.datetime.utcnow(),
    "aware_utcnow":pytz.timezone('UTC').localize(datetime.datetime.utcnow()),
    "naive_now": datetime.datetime.now(),  # this is wrong and should not be used
    "prague_now": datetime.datetime.now().astimezone(pytz.timezone("Europe/Prague"))
}
```
will be dumped as
```json
{
	"naive_utcnow": "2021-09-09T07:43:58.225941Z",
	"aware_utcnow": "2021-09-09T07:43:58.225946+00:00",
	"naive_now": "2021-09-09T09:43:58.225988Z", 
	"prague_now": "2021-09-09T09:43:58.225991+02:00"
}
```