### PR TITLE
Zookeeper container initialize returns zookeeper client.

### DIFF
--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -40,6 +40,7 @@ class ZooKeeperContainer(ConfigObject):
 
 		# Force advertisement immediatelly after initialization
 		self.App.PubSub.publish("ZooKeeper.advertise!")
+		return self.ZooKeeper
 
 
 	async def finalize(self, app):


### PR DESCRIPTION
For example:

This will be used in the asab-config zookeeper provider and microservice monitor.