### PR TITLE
Log conflicting key in Mongo duplicate error

### DIFF
--- a/asab/storage/exceptions.py
+++ b/asab/storage/exceptions.py
@@ -1,6 +1,7 @@
 
 class DuplicateError(RuntimeError):
 
-	def __init__(self, message, obj_id):
+	def __init__(self, message, obj_id, key_value=None):
 		super().__init__(message)
 		self.ObjId = obj_id
+		self.KeyValue = key_value


### PR DESCRIPTION
Add optional `KeyValue` attribute to `asab.storage.exceptions.DuplicateError`.