### PR TITLE
Return 400 if JSON request cannot be decoded

### DIFF
--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -184,7 +184,10 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 			# the validation function for validating JSON schema
 			request = args[-1]
 			if request.content_type == 'application/json':
-				data = await request.json()
+				try:
+					data = await request.json()
+				except json.decoder.JSONDecodeError:
+					raise aiohttp.web.HTTPBadRequest(reason=f"JSON decode error")
 			elif request.content_type in form_content_types:
 				multi_dict = await request.post()
 				data = {k: v for k, v in multi_dict.items()}

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -187,7 +187,7 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 				try:
 					data = await request.json()
 				except json.decoder.JSONDecodeError:
-					raise aiohttp.web.HTTPBadRequest(reason="JSON Decode Error")
+					raise aiohttp.web.HTTPBadRequest(reason="Failed to parse JSON request")
 			elif request.content_type in form_content_types:
 				multi_dict = await request.post()
 				data = {k: v for k, v in multi_dict.items()}

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -187,7 +187,7 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 				try:
 					data = await request.json()
 				except json.decoder.JSONDecodeError:
-					raise aiohttp.web.HTTPBadRequest(reason=f"JSON decode error")
+					raise aiohttp.web.HTTPBadRequest(reason="JSON Decode Error")
 			elif request.content_type in form_content_types:
 				multi_dict = await request.post()
 				data = {k: v for k, v in multi_dict.items()}


### PR DESCRIPTION
Issue: The app responds with 500 Server Error when it receives a request with malformed JSON body.

Fix: Catch the error and respond with 400 JSON Decode Error.