### PR TITLE
Json exception middleware: Add "result" to responses

### DIFF
--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -71,14 +71,6 @@ async def JsonExceptionMiddleware(request, handler):
 
 	websvc.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
 	'''
-	result_names = {
-		400: "BAD-REQUEST",
-		401: "NOT-AUTHORIZED",
-		403: "FORBIDDEN",
-		404: "NOT-FOUND",
-		405: "NOT-ALLOWED",
-		500: "SERVER-ERROR",
-	}
 
 	try:
 		response = await handler(request)
@@ -87,7 +79,7 @@ async def JsonExceptionMiddleware(request, handler):
 	# HTTP errors to JSON
 	except aiohttp.web.HTTPError as ex:
 		respdict = {
-			'result': result_names.get(ex.status, "FAILED"),
+			'result': "ERROR",
 			'message': ex.text[5:]
 		}
 		if ex.status >= 400:
@@ -117,7 +109,7 @@ async def JsonExceptionMiddleware(request, handler):
 
 		return aiohttp.web.Response(
 			text=json.dumps({
-				"result": result_names.get(404),
+				"result": "NOT-FOUND",
 				"message": message,
 				"uuid": str(euuid),
 			}, indent=4),
@@ -131,7 +123,7 @@ async def JsonExceptionMiddleware(request, handler):
 		Lex.exception("Exception when handling web request", exc_info=e, struct_data={'uuid': str(euuid)})
 		return aiohttp.web.Response(
 			text=json.dumps({
-				"result": result_names.get(500),
+				"result": "ERROR",
 				"message": "Internal Server Error",
 				"uuid": str(euuid),
 			}, indent=4),

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -71,6 +71,14 @@ async def JsonExceptionMiddleware(request, handler):
 
 	websvc.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
 	'''
+	result_names = {
+		400: "BAD-REQUEST",
+		401: "NOT-AUTHORIZED",
+		403: "FORBIDDEN",
+		404: "NOT-FOUND",
+		405: "NOT-ALLOWED",
+		500: "SERVER-ERROR",
+	}
 
 	try:
 		response = await handler(request)
@@ -79,7 +87,7 @@ async def JsonExceptionMiddleware(request, handler):
 	# HTTP errors to JSON
 	except aiohttp.web.HTTPError as ex:
 		respdict = {
-			'status': ex.status,
+			'result': result_names.get(ex.status, "FAILED"),
 			'message': ex.text[5:]
 		}
 		if ex.status >= 400:
@@ -109,7 +117,7 @@ async def JsonExceptionMiddleware(request, handler):
 
 		return aiohttp.web.Response(
 			text=json.dumps({
-				"status": 404,
+				"result": result_names.get(404),
 				"message": message,
 				"uuid": str(euuid),
 			}, indent=4),
@@ -123,7 +131,7 @@ async def JsonExceptionMiddleware(request, handler):
 		Lex.exception("Exception when handling web request", exc_info=e, struct_data={'uuid': str(euuid)})
 		return aiohttp.web.Response(
 			text=json.dumps({
-				"status": 500,
+				"result": result_names.get(500),
 				"message": "Internal Server Error",
 				"uuid": str(euuid),
 			}, indent=4),

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -78,8 +78,15 @@ async def JsonExceptionMiddleware(request, handler):
 
 	# HTTP errors to JSON
 	except aiohttp.web.HTTPError as ex:
+		if ex.status == 401:
+			result = "NOT-AUTHORIZED"
+		elif ex.status == 404:
+			result = "NOT-FOUND"
+		else:
+			result = "ERROR"
+
 		respdict = {
-			'result': "ERROR",
+			'result': result,
 			'message': ex.text[5:]
 		}
 		if ex.status >= 400:


### PR DESCRIPTION
Remove `status` code from JSON body, add `result` message instead.

Example response:
```json
HTTP 404
{
  "result": "NOT-FOUND",
  "uuid": "1234-5678-9abcd",
  "message": "Field 'name' not found"
}
```