### PR TITLE
Mongo upsertor: Raise KeyError if DB object changes

### DIFF
--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -154,6 +154,10 @@ class MongoDBUpsertor(UpsertorABC):
 
 				raise DuplicateError("Already exists", self.ObjId)
 
+			if ret is None:
+				# Object might have been changed in the meantime
+				raise KeyError("NOT-FOUND")
+
 			self.ObjId = ret[id_name]
 
 		# for k, v in self.ModPull.items():


### PR DESCRIPTION
Issue: Sometimes there are multiple async requests to update the same DB object. Only the first one succeeds, the others crash with unintentional TypeError.

This raises KeyError instead.