### PR TITLE
OpenMetrics & Prometheus support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -6,6 +6,8 @@ import aiohttp.web
 class APIWebHandler(object):
 
 	def __init__(self, app, webapp, log_handler):
+		self.App = app
+
 		# Add routes
 		webapp.router.add_get('/asab/v1/environ', self.environ)
 		webapp.router.add_get('/asab/v1/config', self.config)
@@ -14,6 +16,48 @@ class APIWebHandler(object):
 		webapp.router.add_get('/asab/v1/logws', log_handler.ws)
 
 		webapp.router.add_get('/asab/v1/changelog', self.changelog)
+
+		webapp.router.add_get('/asab/v1/metrics', self.metrics)
+
+	async def metrics(self, request):
+		metrics_service = self.App.get_service('asab.MetricsService')
+		print(request)
+		if metrics_service is None:
+			raise RuntimeError('asab.MetricsService is not available')
+
+		# lines = []
+		# lines.append('# TYPE asab_response summary')
+		# lines.append('# UNIT asab_response seconds')	
+
+		# for mname, metrics in metrics_service.Metrics.items():
+		# 	lines.append(metrics.build_openmetrics_line())
+
+		# lines.append('# EOF')
+
+		# text = '\n'.join(lines)
+		# print(request)
+		# return aiohttp.web.Response(text=text, content_type='text/plain')
+
+		for mname, metrics in metrics_service.Metrics.items():
+			if isinstance(metrics, asab.metrics.metrics.Counter):
+				print("counter!")
+				type = "counter"
+				counter_info = metrics.rest_get()
+				name = counter_info.get("Name")
+				tags = counter_info.get("Tags")
+				if "unit" in tags.keys():
+					unit = tags.get("unit")
+				for vname, value in counter_info.get("Values").items():
+					result_name = "_".join([name, vname])
+					lines = []
+					lines.append("# TYPE {} {}".format(result_name, type))
+					lines.append("# UNIT {} {}".format(result_name, unit))
+					lines.append("{} {}".format(result_name, value))
+					lines.append("# EOF")
+					text = '\n'.join(lines)
+					print(text)
+					return aiohttp.web.Response(text=text, content_type='text/plain')
+
 
 
 	async def changelog(self, request):

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -4,62 +4,62 @@ import aiohttp.web
 
 
 class APIWebHandler(object):
-    def __init__(self, app, webapp, log_handler):
-        self.App = app
+	def __init__(self, app, webapp, log_handler):
+		self.App = app
 
-        # Add routes
-        webapp.router.add_get("/asab/v1/environ", self.environ)
-        webapp.router.add_get("/asab/v1/config", self.config)
+		# Add routes
+		webapp.router.add_get("/asab/v1/environ", self.environ)
+		webapp.router.add_get("/asab/v1/config", self.config)
 
-        webapp.router.add_get("/asab/v1/logs", log_handler.get_logs)
-        webapp.router.add_get("/asab/v1/logws", log_handler.ws)
+		webapp.router.add_get("/asab/v1/logs", log_handler.get_logs)
+		webapp.router.add_get("/asab/v1/logws", log_handler.ws)
 
-        webapp.router.add_get("/asab/v1/changelog", self.changelog)
+		webapp.router.add_get("/asab/v1/changelog", self.changelog)
 
-        webapp.router.add_get("/asab/v1/metrics", self.metrics)
+		webapp.router.add_get("/asab/v1/metrics", self.metrics)
 
-    async def metrics(self, request):
-        metrics_service = self.App.get_service("asab.MetricsService")
-        if metrics_service is None:
-            raise RuntimeError("asab.MetricsService is not available")
+	async def metrics(self, request):
+		metrics_service = self.App.get_service("asab.MetricsService")
+		if metrics_service is None:
+			raise RuntimeError("asab.MetricsService is not available")
 
-        from asab.metrics.prometheus import to_openmetrics
+		from asab.metrics.prometheus import to_openmetrics
 
-        text = to_openmetrics(metrics_service)
+		text = to_openmetrics(metrics_service)
 
-        return aiohttp.web.Response(
-            text=text,
-            content_type="text/plain",
-            charset="utf-8",
-        )
+		return aiohttp.web.Response(
+			text=text,
+			content_type="text/plain",
+			charset="utf-8",
+		)
 
-    async def changelog(self, request):
-        path = asab.Config.get("general", "changelog_path")
-        if not os.path.isfile(path):
-            if os.path.isfile("/CHANGELOG.md"):
-                path = "/CHANGELOG.md"
-            elif os.path.isfile("CHANGELOG.md"):
-                path = "CHANGELOG.md"
-            else:
-                return aiohttp.web.HTTPNotFound()
+	async def changelog(self, request):
+		path = asab.Config.get("general", "changelog_path")
+		if not os.path.isfile(path):
+			if os.path.isfile("/CHANGELOG.md"):
+				path = "/CHANGELOG.md"
+			elif os.path.isfile("CHANGELOG.md"):
+				path = "CHANGELOG.md"
+			else:
+				return aiohttp.web.HTTPNotFound()
 
-        with open(path) as f:
-            result = f.read()
+		with open(path) as f:
+			result = f.read()
 
-        return aiohttp.web.Response(text=result, content_type="text/markdown")
+		return aiohttp.web.Response(text=result, content_type="text/markdown")
 
-    async def environ(self, request):
-        return asab.web.rest.json_response(request, dict(os.environ))
+	async def environ(self, request):
+		return asab.web.rest.json_response(request, dict(os.environ))
 
-    async def config(self, request):
-        # Copy the config and erase all passwords
-        result = {}
-        for section in asab.Config.sections():
-            result[section] = {}
-            # Access items in the raw mode (they are not interpolated)
-            for option, value in asab.Config.items(section, raw=True):
-                if section == "passwords":
-                    result[section][option] = "***"
-                else:
-                    result[section][option] = value
-        return asab.web.rest.json_response(request, result)
+	async def config(self, request):
+		# Copy the config and erase all passwords
+		result = {}
+		for section in asab.Config.sections():
+			result[section] = {}
+			# Access items in the raw mode (they are not interpolated)
+			for option, value in asab.Config.items(section, raw=True):
+				if section == "passwords":
+					result[section][option] = "***"
+				else:
+					result[section][option] = value
+		return asab.web.rest.json_response(request, result)

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -23,10 +23,9 @@ class APIWebHandler(object):
 		metrics_service = self.App.get_service('asab.MetricsService')
 		if metrics_service is None:
 			raise RuntimeError('asab.MetricsService is not available')
-		
+
 		from asab.metrics.prometheus import to_openmetrics
 		text = to_openmetrics(metrics_service)
-		print(text)
 
 		return aiohttp.web.Response(text=text, content_type='text/plain')
 

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -4,62 +4,62 @@ import aiohttp.web
 
 
 class APIWebHandler(object):
+    def __init__(self, app, webapp, log_handler):
+        self.App = app
 
-	def __init__(self, app, webapp, log_handler):
-		self.App = app
+        # Add routes
+        webapp.router.add_get("/asab/v1/environ", self.environ)
+        webapp.router.add_get("/asab/v1/config", self.config)
 
-		# Add routes
-		webapp.router.add_get('/asab/v1/environ', self.environ)
-		webapp.router.add_get('/asab/v1/config', self.config)
+        webapp.router.add_get("/asab/v1/logs", log_handler.get_logs)
+        webapp.router.add_get("/asab/v1/logws", log_handler.ws)
 
-		webapp.router.add_get('/asab/v1/logs', log_handler.get_logs)
-		webapp.router.add_get('/asab/v1/logws', log_handler.ws)
+        webapp.router.add_get("/asab/v1/changelog", self.changelog)
 
-		webapp.router.add_get('/asab/v1/changelog', self.changelog)
+        webapp.router.add_get("/asab/v1/metrics", self.metrics)
 
-		webapp.router.add_get('/asab/v1/metrics', self.metrics)
+    async def metrics(self, request):
+        metrics_service = self.App.get_service("asab.MetricsService")
+        if metrics_service is None:
+            raise RuntimeError("asab.MetricsService is not available")
 
-	async def metrics(self, request):
-		metrics_service = self.App.get_service('asab.MetricsService')
-		if metrics_service is None:
-			raise RuntimeError('asab.MetricsService is not available')
+        from asab.metrics.prometheus import to_openmetrics
 
-		from asab.metrics.prometheus import to_openmetrics
-		text = to_openmetrics(metrics_service)
+        text = to_openmetrics(metrics_service)
 
-		return aiohttp.web.Response(text=text, content_type='text/plain')
+        return aiohttp.web.Response(
+            text=text,
+            content_type="text/plain",
+            charset="utf-8",
+        )
 
+    async def changelog(self, request):
+        path = asab.Config.get("general", "changelog_path")
+        if not os.path.isfile(path):
+            if os.path.isfile("/CHANGELOG.md"):
+                path = "/CHANGELOG.md"
+            elif os.path.isfile("CHANGELOG.md"):
+                path = "CHANGELOG.md"
+            else:
+                return aiohttp.web.HTTPNotFound()
 
+        with open(path) as f:
+            result = f.read()
 
-	async def changelog(self, request):
-		path = asab.Config.get('general', 'changelog_path')
-		if not os.path.isfile(path):
-			if os.path.isfile('/CHANGELOG.md'):
-				path = '/CHANGELOG.md'
-			elif os.path.isfile('CHANGELOG.md'):
-				path = 'CHANGELOG.md'
-			else:
-				return aiohttp.web.HTTPNotFound()
+        return aiohttp.web.Response(text=result, content_type="text/markdown")
 
-		with open(path) as f:
-			result = f.read()
+    async def environ(self, request):
+        return asab.web.rest.json_response(request, dict(os.environ))
 
-		return aiohttp.web.Response(text=result, content_type='text/markdown')
-
-
-	async def environ(self, request):
-		return asab.web.rest.json_response(request, dict(os.environ))
-
-
-	async def config(self, request):
-		# Copy the config and erase all passwords
-		result = {}
-		for section in asab.Config.sections():
-			result[section] = {}
-			# Access items in the raw mode (they are not interpolated)
-			for option, value in asab.Config.items(section, raw=True):
-				if section == "passwords":
-					result[section][option] = "***"
-				else:
-					result[section][option] = value
-		return asab.web.rest.json_response(request, result)
+    async def config(self, request):
+        # Copy the config and erase all passwords
+        result = {}
+        for section in asab.Config.sections():
+            result[section] = {}
+            # Access items in the raw mode (they are not interpolated)
+            for option, value in asab.Config.items(section, raw=True):
+                if section == "passwords":
+                    result[section][option] = "***"
+                else:
+                    result[section][option] = value
+        return asab.web.rest.json_response(request, result)

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -7,105 +7,105 @@ L = logging.getLogger(__name__)
 
 
 def validate_format(name):
-    regex = r"[a-zA-Z:][a-zA-Z0-9_:]*"
-    match = re.fullmatch(regex, name)
-    if match is None:
-        L.warning("Invalid Prometheus format. {} must match the regex [a-zA-Z:][a-zA-Z0-9_:]*".format(name))
-        regex_sub = r"[^a-zA-Z0-9_:]"
-        name = re.sub(regex_sub, "_", name)
-        name = name.lstrip("_0123456789")
-        if name.endswith(("total", "created")):
-            L.warning("Invalid OpenMetrics format. Name MUST NOT end with total or created.")
-    return name
+	regex = r"[a-zA-Z:][a-zA-Z0-9_:]*"
+	match = re.fullmatch(regex, name)
+	if match is None:
+		L.warning("Invalid Prometheus format. {} must match the regex [a-zA-Z:][a-zA-Z0-9_:]*".format(name))
+		regex_sub = r"[^a-zA-Z0-9_:]"
+		name = re.sub(regex_sub, "_", name)
+		name = name.lstrip("_0123456789")
+		if name.endswith(("total", "created")):
+			L.warning("Invalid OpenMetrics format. Name MUST NOT end with total or created.")
+	return name
 
 
 def validate_value(value):
-    return isinstance(value, [int, float])
+	return isinstance(value, [int, float])
 
 
 def get_labels(tags):
-    labels_str = "{"
-    for tag in tags.keys():
-        if tag in {"host", "unit", "help"}:
-            continue
-        else:
-            label_name = validate_format(tag)
-            label_value = validate_format(tags.get(tag))
-            labels_str += '{}="{}",'.format(label_name, label_value)
-    labels_str = labels_str.rstrip(",")
-    labels_str += "}"
-    if len(labels_str) <= 2:
-        return None
-    else:
-        return labels_str
+	labels_str = "{"
+	for tag in tags.keys():
+		if tag in {"host", "unit", "help"}:
+			continue
+		else:
+			label_name = validate_format(tag)
+			label_value = validate_format(tags.get(tag))
+			labels_str += '{}="{}",'.format(label_name, label_value)
+	labels_str = labels_str.rstrip(",")
+	labels_str += "}"
+	if len(labels_str) <= 2:
+		return None
+	else:
+		return labels_str
 
 
 def metric_to_text(metric, type):
-    metric_lines = []
-    m_name = metric.get("Name")
-    tags = metric.get("Tags")
-    labels_str = get_labels(tags)
+	metric_lines = []
+	m_name = metric.get("Name")
+	tags = metric.get("Tags")
+	labels_str = get_labels(tags)
 
-    for v_name, value in metric.get("Values").items():
-        if validate_value is False:
-            L.warning("Invalid OpenMetrics format. Value must be float or integer. {} omitted.".format(m_name))
-            continue
-        else:
-            name = "_".join([m_name, v_name])
-            name = validate_format(name)
-            # If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
-            if tags.get("unit"):
-                unit = tags.get("unit")
-                unit = validate_format(unit)
-                name += "_{}".format(unit)
-                metric_lines.append("# TYPE {} {}".format(name, type))
-                metric_lines.append("# UNIT {} {}".format(name, unit))
-            else:
-                unit = None
-                metric_lines.append("# TYPE {} {}".format(name, type))
-                L.warning("Invalid OpenMetrics format. Please, add 'unit' in 'Tags'.")
+	for v_name, value in metric.get("Values").items():
+		if validate_value is False:
+			L.warning("Invalid OpenMetrics format. Value must be float or integer. {} omitted.".format(m_name))
+			continue
+		else:
+			name = "_".join([m_name, v_name])
+			name = validate_format(name)
+			# If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
+			if tags.get("unit"):
+				unit = tags.get("unit")
+				unit = validate_format(unit)
+				name += "_{}".format(unit)
+				metric_lines.append("# TYPE {} {}".format(name, type))
+				metric_lines.append("# UNIT {} {}".format(name, unit))
+			else:
+				unit = None
+				metric_lines.append("# TYPE {} {}".format(name, type))
+				L.warning("Invalid OpenMetrics format. Please, add 'unit' in 'Tags'.")
 
-            if tags.get("help"):
-                metric_lines.append("# HELP {} {}".format(name, tags.get("help")))
-            else:
-                L.warning("Invalid OpenMetrics format. Please, add 'help' in 'Tags'.")
+			if tags.get("help"):
+				metric_lines.append("# HELP {} {}".format(name, tags.get("help")))
+			else:
+				L.warning("Invalid OpenMetrics format. Please, add 'help' in 'Tags'.")
 
-            if type == "counter":
-                metricpoint = "_total"
-            if type == "gauge":
-                metricpoint = ""
-            if labels_str:
-                metric_lines.append("{}{}{} {}".format(name, metricpoint, labels_str, value))
-            else:
-                metric_lines.append("{}{} {}".format(name, metricpoint, value))
-    metric_text = '\n'.join(metric_lines)
-    return metric_text
+			if type == "counter":
+				metricpoint = "_total"
+			if type == "gauge":
+				metricpoint = ""
+			if labels_str:
+				metric_lines.append("{}{}{} {}".format(name, metricpoint, labels_str, value))
+			else:
+				metric_lines.append("{}{} {}".format(name, metricpoint, value))
+	metric_text = '\n'.join(metric_lines)
+	return metric_text
 
 
 def to_openmetrics(metrics_service):
-    lines = []
-    for mname, metrics in metrics_service.Metrics.items():
-        if isinstance(metrics, asab.metrics.metrics.Counter):
-            counter_text = metric_to_text(metrics.rest_get(), type="counter")
-            lines.append(counter_text)
+	lines = []
+	for mname, metrics in metrics_service.Metrics.items():
+		if isinstance(metrics, asab.metrics.metrics.Counter):
+			counter_text = metric_to_text(metrics.rest_get(), type="counter")
+			lines.append(counter_text)
 
-        if isinstance(metrics, asab.metrics.metrics.Gauge):
-            gauge_text = metric_to_text(metrics.rest_get(), type="gauge")
-            lines.append(gauge_text)
+		if isinstance(metrics, asab.metrics.metrics.Gauge):
+			gauge_text = metric_to_text(metrics.rest_get(), type="gauge")
+			lines.append(gauge_text)
 
-    lines.append("# EOF\n")
-    text = '\n'.join(lines)
-    return text
+	lines.append("# EOF\n")
+	text = '\n'.join(lines)
+	return text
 
 
 # HOW TO FULLFIL OPEMETRICS STANDARD
 
-# ONLY Gauge and Counters translated into Prometheus. Other Metrics are omitted.
+# ONLY Gauge and Counters are translated into Prometheus. Other Metrics are omitted.
 # Metrics MUST have "unit" and "help" Tags
 # Help is a string and SHOULD be non-empty. It is used to give a brief description of the MetricFamily for human consumption and SHOULD be short enough to be used as a tooltip.
 # Metrics MUST have Lables - also added as items in Tags
 # Values MUST be float or integer. Boolean values MUST follow 1==true, 0==false.
-# Colons in MetricFamily names are RESERVED to signal that the MetricFamily is the result of a calculation or aggregation of a general purpose monitoring system. MetricFamily names beginning with underscores are RESERVED and MUST NOT be used unless specified by this standard. - Anything that is not A-Z, a-z or digit is transformed into "_" and leading "_" is stripped.
+# Colons in MetricFamily names are RESERVED to signal that the MetricFamily is the result of a calculation or aggregation of a general purpose monitoring system. MetricFamily names beginning with underscores are RESERVED and MUST NOT be used unless specified by OpenMetric standard. - Anything that is not A-Z, a-z or digit is transformed into "_" and leading "_" is stripped.
 # NaN is a number like any other in OpenMetrics, usually resulting from a division by zero such as for a summary quantile if there have been no observations recently. NaN does not have any special meaning in OpenMetrics, and in particular MUST NOT be used as a marker for missing or otherwise bad data.
 
-# Feel free to read more about OpenMetrics standard from here: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
+# Feel free to read more about OpenMetrics standard here: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -1,0 +1,70 @@
+import asab
+
+		# lines = []
+		# lines.append('# TYPE asab_response summary')
+		# lines.append('# UNIT asab_response seconds')	
+
+		# for mname, metrics in metrics_service.Metrics.items():
+		# 	lines.append(metrics.build_openmetrics_line())
+
+		# lines.append('# EOF')
+
+		# text = '\n'.join(lines)
+		# print(request)
+		# return aiohttp.web.Response(text=text, content_type='text/plain')
+
+def counter_to_om(counter):
+    counter_lines = []
+    type = "counter"
+    
+    m_name = counter.get("Name")
+    tags = counter.get("Tags")
+    
+    labels = {}
+    for tag in tags.keys():
+        if tag == "host" or tag == "unit" or tag == "help":
+            continue
+        else:
+            labels[tag] = tags.get(tag)
+    labels_str = "{"
+    for l_name, label in labels.items():
+        labels_str += '{}="{}",'.format(l_name, label)
+    labels_str = labels_str.rstrip(",")
+    labels_str += "}"
+    
+    for v_name, value in counter.get("Values").items():
+        name = "_".join([m_name, v_name])
+        # If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
+        if tags.get("unit"):
+            unit = tags.get("unit")
+            name += "_{}".format(unit)
+            counter_lines.append("# TYPE {} {}".format(name, type))
+            counter_lines.append("# UNIT {} {}".format(name, unit))
+        else:
+            unit = None
+            counter_lines.append("# TYPE {} {}".format(name, type))
+
+        if tags.get("help"):
+            help = tags.get("help")
+            counter_lines.append("# HELP {} {}".format(name, help))
+
+        if labels == {}:
+            counter_lines.append("{}_total {}".format(name, value))
+        else:
+            counter_lines.append("{}_total{} {}".format(name, labels_str, value))
+    counter_text = '\n'.join(counter_lines)
+    return counter_text
+
+
+def to_openmetrics(metrics_service):
+    lines = []
+    for mname, metrics in metrics_service.Metrics.items():
+        if isinstance(metrics, asab.metrics.metrics.Counter):
+            print("counter!")
+            counter_info = metrics.rest_get()
+            counter_text = counter_to_om(counter_info)
+            lines.append(counter_text)
+
+    lines.append("# EOF\n")
+    text = '\n'.join(lines)
+    return text

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -1,5 +1,9 @@
 import asab
 import re
+import logging
+
+
+L = logging.getLogger(__name__)
 
 
 def validate_format(name):
@@ -7,7 +11,16 @@ def validate_format(name):
     regex = r"[\WÁ-ž]+"
     subst = "_"
     result = re.sub(regex, subst, name)
+    result = result.lstrip("_")
+    if result.endswith("total") or result.endswith("created"):
+        L.warning("Invalid OpenMetrics format. Name MUST NOT end with total or created.")
+        result = result.rstrip("total")
+        result = result.rstrip("created")
     return result
+
+
+def validate_value(value):
+    return isinstance(value, [int, float])
 
 
 def get_labels(tags):
@@ -16,7 +29,9 @@ def get_labels(tags):
         if tag == "host" or tag == "unit" or tag == "help":
             continue
         else:
-            labels_str += '{}="{}",'.format(validate_format(tag), validate_format(tags.get(tag)))
+            if tag.startswith("_"):
+                tag = tag.lstrip("_")
+            labels_str += '{}="{}",'.format(tag, tags.get(tag))
     labels_str = labels_str.rstrip(",")
     labels_str += "}"
     if labels_str == "{}":
@@ -33,27 +48,34 @@ def counter_to_om(counter):
     labels_str = get_labels(tags)
 
     for v_name, value in counter.get("Values").items():
-        name = "_".join([m_name, v_name])
-        name = validate_format(name)
-        # If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
-        if tags.get("unit"):
-            unit = tags.get("unit")
-            unit = validate_format(unit)
-            name += "_{}".format(unit)
-            counter_lines.append("# TYPE {} {}".format(name, type))
-            counter_lines.append("# UNIT {} {}".format(name, unit))
+        if validate_value is False:
+            L.warning("Invalid OpenMetrics format. Value must be float or integer.")
+            continue
         else:
-            unit = None
-            counter_lines.append("# TYPE {} {}".format(name, type))
+            name = "_".join([m_name, v_name])
+            name = validate_format(name)
+            # If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
+            if tags.get("unit"):
+                unit = tags.get("unit")
+                unit = validate_format(unit)
+                name += "_{}".format(unit)
+                counter_lines.append("# TYPE {} {}".format(name, type))
+                counter_lines.append("# UNIT {} {}".format(name, unit))
+            else:
+                unit = None
+                counter_lines.append("# TYPE {} {}".format(name, type))
+                L.warning("Invalid OpenMetrics format. Please, add 'unit' in 'Tags'.")
 
-        if tags.get("help"):
-            help = tags.get("help")
-            counter_lines.append("# HELP {} {}".format(name, help))
+            if tags.get("help"):
+                help = tags.get("help")
+                counter_lines.append("# HELP {} {}".format(name, help))
+            else:
+                L.warning("Invalid OpenMetrics format. Please, add 'help' in 'Tags'.")
 
-        if labels_str:
-            counter_lines.append("{}_total{} {}".format(name, labels_str, value))
-        else:
-            counter_lines.append("{}_total {}".format(name, value))
+            if labels_str:
+                counter_lines.append("{}_total{} {}".format(name, labels_str, value))
+            else:
+                counter_lines.append("{}_total {}".format(name, value))
     counter_text = '\n'.join(counter_lines)
     return counter_text
 
@@ -70,3 +92,25 @@ def to_openmetrics(metrics_service):
     lines.append("# EOF\n")
     text = '\n'.join(lines)
     return text
+
+
+# HOW TO FULLFIL OPEMETRICS STANDARD
+
+# ONLY Gauge and Counter are possible to translate into Prometheus. Other Metrics are omitted. 
+# Metrics MUST have "unit" and "help" Tags
+# Help is a string and SHOULD be non-empty. It is used to give a brief description of the MetricFamily for human consumption and SHOULD be short enough to be used as a tooltip.
+# Metrics MUST have Lables - also added as items in Tags
+# Values MUST be float or integer. Boolean values MUST follow 1==true, 0==false.
+# Label names beginning with underscores are RESERVED and MUST NOT be used.
+# Colons in MetricFamily names are RESERVED to signal that the MetricFamily is the result of a calculation or aggregation of a general purpose monitoring system. MetricFamily names beginning with underscores are RESERVED and MUST NOT be used unless specified by this standard. - Basically - anything that is not A-Z, a-z or digit is transformed into "_" and leading "_" is stripped.
+
+# Feel free to learn more about OpenMetrics standard from here: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
+
+
+# TO DO
+# The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 characters. Other characters in the text rendering of an exemplar such as ",= are not included in this limit for implementation simplicity and for consistency between the text and proto formats.
+# A MetricPoint in a Metric's Counter's Total MAY reset to 0. If present, the corresponding Created time MUST also be set to the timestamp of the reset.
+# All exposers SHOULD be able to emit data secured with TLS 1.2 or later.
+# UTF-8 MUST be used. Byte order markers (BOMs) MUST NOT be used. As an important reminder for implementers, byte 0 is valid UTF-8 while, for example, byte 255 is not.
+# The content type MUST be: application/openmetrics-text; version=1.0.0; charset=utf-8
+# NaN is a number like any other in OpenMetrics, usually resulting from a division by zero such as for a summary quantile if there have been no observations recently. NaN does not have any special meaning in OpenMetrics, and in particular MUST NOT be used as a marker for missing or otherwise bad data.

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -1,39 +1,31 @@
 import asab
 
-		# lines = []
-		# lines.append('# TYPE asab_response summary')
-		# lines.append('# UNIT asab_response seconds')	
-
-		# for mname, metrics in metrics_service.Metrics.items():
-		# 	lines.append(metrics.build_openmetrics_line())
-
-		# lines.append('# EOF')
-
-		# text = '\n'.join(lines)
-		# print(request)
-		# return aiohttp.web.Response(text=text, content_type='text/plain')
-
-def counter_to_om(counter):
-    counter_lines = []
-    type = "counter"
-    
-    m_name = counter.get("Name")
-    tags = counter.get("Tags")
-    
-    labels = {}
+def get_labels(tags):
+    labels_str = "{"
     for tag in tags.keys():
         if tag == "host" or tag == "unit" or tag == "help":
             continue
         else:
-            labels[tag] = tags.get(tag)
-    labels_str = "{"
-    for l_name, label in labels.items():
-        labels_str += '{}="{}",'.format(l_name, label)
+            labels_str += '{}="{}",'.format(tag, tags.get(tag))
     labels_str = labels_str.rstrip(",")
     labels_str += "}"
+    if labels_str == "{}":
+        return None
+    else:
+        return labels_str
+
+
+
+def counter_to_om(counter):
+    counter_lines = []
+    type = "counter"
+    m_name = counter.get("Name")
+    tags = counter.get("Tags")
+    labels_str = get_labels(tags)
     
     for v_name, value in counter.get("Values").items():
         name = "_".join([m_name, v_name])
+
         # If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
         if tags.get("unit"):
             unit = tags.get("unit")
@@ -48,10 +40,10 @@ def counter_to_om(counter):
             help = tags.get("help")
             counter_lines.append("# HELP {} {}".format(name, help))
 
-        if labels == {}:
-            counter_lines.append("{}_total {}".format(name, value))
-        else:
+        if labels_str:
             counter_lines.append("{}_total{} {}".format(name, labels_str, value))
+        else:
+            counter_lines.append("{}_total {}".format(name, value))
     counter_text = '\n'.join(counter_lines)
     return counter_text
 

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -40,14 +40,13 @@ def get_labels(tags):
         return labels_str
 
 
-def counter_to_om(counter):
-    counter_lines = []
-    type = "counter"
-    m_name = counter.get("Name")
-    tags = counter.get("Tags")
+def metric_to_text(metric, type):
+    metric_lines = []
+    m_name = metric.get("Name")
+    tags = metric.get("Tags")
     labels_str = get_labels(tags)
 
-    for v_name, value in counter.get("Values").items():
+    for v_name, value in metric.get("Values").items():
         if validate_value is False:
             L.warning("Invalid OpenMetrics format. Value must be float or integer.")
             continue
@@ -59,35 +58,41 @@ def counter_to_om(counter):
                 unit = tags.get("unit")
                 unit = validate_format(unit)
                 name += "_{}".format(unit)
-                counter_lines.append("# TYPE {} {}".format(name, type))
-                counter_lines.append("# UNIT {} {}".format(name, unit))
+                metric_lines.append("# TYPE {} {}".format(name, type))
+                metric_lines.append("# UNIT {} {}".format(name, unit))
             else:
                 unit = None
-                counter_lines.append("# TYPE {} {}".format(name, type))
+                metric_lines.append("# TYPE {} {}".format(name, type))
                 L.warning("Invalid OpenMetrics format. Please, add 'unit' in 'Tags'.")
 
             if tags.get("help"):
                 help = tags.get("help")
-                counter_lines.append("# HELP {} {}".format(name, help))
+                metric_lines.append("# HELP {} {}".format(name, help))
             else:
                 L.warning("Invalid OpenMetrics format. Please, add 'help' in 'Tags'.")
 
+            if type == "counter":
+                metricpoint = "_total"
+            if type == "gauge":
+                metricpoint = ""
             if labels_str:
-                counter_lines.append("{}_total{} {}".format(name, labels_str, value))
+                metric_lines.append("{}{}{} {}".format(name, metricpoint, labels_str, value))
             else:
-                counter_lines.append("{}_total {}".format(name, value))
-    counter_text = '\n'.join(counter_lines)
-    return counter_text
+                metric_lines.append("{}{} {}".format(name, metricpoint, value))
+    metric_text = '\n'.join(metric_lines)
+    return metric_text
 
 
 def to_openmetrics(metrics_service):
     lines = []
     for mname, metrics in metrics_service.Metrics.items():
         if isinstance(metrics, asab.metrics.metrics.Counter):
-            print("counter!")
-            counter_info = metrics.rest_get()
-            counter_text = counter_to_om(counter_info)
+            counter_text = metric_to_text(metrics.rest_get(), type="counter")
             lines.append(counter_text)
+
+        if isinstance(metrics, asab.metrics.metrics.Gauge):
+            gauge_text = metric_to_text(metrics.rest_get(), type="gauge")
+            lines.append(gauge_text)
 
     lines.append("# EOF\n")
     text = '\n'.join(lines)
@@ -96,7 +101,7 @@ def to_openmetrics(metrics_service):
 
 # HOW TO FULLFIL OPEMETRICS STANDARD
 
-# ONLY Gauge and Counter are possible to translate into Prometheus. Other Metrics are omitted. 
+# ONLY Gauge and Counter translated into Prometheus. Other Metrics are omitted.
 # Metrics MUST have "unit" and "help" Tags
 # Help is a string and SHOULD be non-empty. It is used to give a brief description of the MetricFamily for human consumption and SHOULD be short enough to be used as a tooltip.
 # Metrics MUST have Lables - also added as items in Tags
@@ -105,12 +110,3 @@ def to_openmetrics(metrics_service):
 # Colons in MetricFamily names are RESERVED to signal that the MetricFamily is the result of a calculation or aggregation of a general purpose monitoring system. MetricFamily names beginning with underscores are RESERVED and MUST NOT be used unless specified by this standard. - Basically - anything that is not A-Z, a-z or digit is transformed into "_" and leading "_" is stripped.
 
 # Feel free to learn more about OpenMetrics standard from here: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
-
-
-# TO DO
-# The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 characters. Other characters in the text rendering of an exemplar such as ",= are not included in this limit for implementation simplicity and for consistency between the text and proto formats.
-# A MetricPoint in a Metric's Counter's Total MAY reset to 0. If present, the corresponding Created time MUST also be set to the timestamp of the reset.
-# All exposers SHOULD be able to emit data secured with TLS 1.2 or later.
-# UTF-8 MUST be used. Byte order markers (BOMs) MUST NOT be used. As an important reminder for implementers, byte 0 is valid UTF-8 while, for example, byte 255 is not.
-# The content type MUST be: application/openmetrics-text; version=1.0.0; charset=utf-8
-# NaN is a number like any other in OpenMetrics, usually resulting from a division by zero such as for a summary quantile if there have been no observations recently. NaN does not have any special meaning in OpenMetrics, and in particular MUST NOT be used as a marker for missing or otherwise bad data.

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -1,4 +1,14 @@
 import asab
+import re
+
+
+def validate_format(name):
+    name = name.lower()
+    regex = r"[\WÁ-ž]+"
+    subst = "_"
+    result = re.sub(regex, subst, name)
+    return result
+
 
 def get_labels(tags):
     labels_str = "{"
@@ -6,7 +16,7 @@ def get_labels(tags):
         if tag == "host" or tag == "unit" or tag == "help":
             continue
         else:
-            labels_str += '{}="{}",'.format(tag, tags.get(tag))
+            labels_str += '{}="{}",'.format(validate_format(tag), validate_format(tags.get(tag)))
     labels_str = labels_str.rstrip(",")
     labels_str += "}"
     if labels_str == "{}":
@@ -15,20 +25,20 @@ def get_labels(tags):
         return labels_str
 
 
-
 def counter_to_om(counter):
     counter_lines = []
     type = "counter"
     m_name = counter.get("Name")
     tags = counter.get("Tags")
     labels_str = get_labels(tags)
-    
+
     for v_name, value in counter.get("Values").items():
         name = "_".join([m_name, v_name])
-
+        name = validate_format(name)
         # If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
         if tags.get("unit"):
             unit = tags.get("unit")
+            unit = validate_format(unit)
             name += "_{}".format(unit)
             counter_lines.append("# TYPE {} {}".format(name, type))
             counter_lines.append("# UNIT {} {}".format(name, unit))

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,5 @@
+from .test_prometheus import TestPrometheus
+
+__all__ = [
+    "TestPrometheus",
+]

--- a/test/test_prometheus.py
+++ b/test/test_prometheus.py
@@ -1,0 +1,14 @@
+import unittest
+import json
+from asab.metrics.prometheus import counter_to_om
+
+class TestPrometheus(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestPrometheus, self).__init__(*args, **kwargs)
+
+    def test_counter_to_om(self):
+        input_counter = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label':'sth', 'other_label':'sth_else'}, 'Values': {'v1': 10, 'v2': 5}}
+
+        expected_output ='# TYPE mycounter_v1_bytes counter\n# UNIT mycounter_v1_bytes bytes\n# HELP mycounter_v1_bytes The most important counter ever.\nmycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10\n# TYPE mycounter_v2_bytes counter\n# UNIT mycounter_v2_bytes bytes\n# HELP mycounter_v2_bytes The most important counter ever.\nmycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5'
+        output = counter_to_om(input_counter)
+        self.assertEqual(expected_output, output)

--- a/test/test_prometheus.py
+++ b/test/test_prometheus.py
@@ -1,22 +1,22 @@
 import unittest
-from asab.metrics.prometheus import counter_to_om, get_labels, validate_format
+from asab.metrics.prometheus import metric_to_text, get_labels, validate_format
 
 
 class TestPrometheus(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestPrometheus, self).__init__(*args, **kwargs)
 
-    def test_counter_to_om(self):
+    def test_metric_to_text(self):
         input_counter = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label': 'sth', 'other_label': 'sth_else'}, 'Values': {'v1': 10, 'v2': 5}}
 
         expected_output = '# TYPE mycounter_v1_bytes counter\n# UNIT mycounter_v1_bytes bytes\n# HELP mycounter_v1_bytes The most important counter ever.\nmycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10\n# TYPE mycounter_v2_bytes counter\n# UNIT mycounter_v2_bytes bytes\n# HELP mycounter_v2_bytes The most important counter ever.\nmycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5'
-        output = counter_to_om(input_counter)
+        output = metric_to_text(input_counter, type="counter")
         self.assertEqual(expected_output, output)
 
         # missing labels and units
         input_counter2 = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'help': 'The most important counter ever.'}, 'Values': {'v1': 10, 'v2': 5}}
         expected_output2 = '# TYPE mycounter_v1 counter\n# HELP mycounter_v1 The most important counter ever.\nmycounter_v1_total 10\n# TYPE mycounter_v2 counter\n# HELP mycounter_v2 The most important counter ever.\nmycounter_v2_total 5'
-        output2 = counter_to_om(input_counter2)
+        output2 = metric_to_text(input_counter2, type="counter")
         self.assertEqual(expected_output2, output2)
 
     def test_get_labels(self):

--- a/test/test_prometheus.py
+++ b/test/test_prometheus.py
@@ -1,25 +1,26 @@
 import unittest
-from asab.metrics.prometheus import counter_to_om, get_labels
+from asab.metrics.prometheus import counter_to_om, get_labels, validate_format
+
 
 class TestPrometheus(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestPrometheus, self).__init__(*args, **kwargs)
 
     def test_counter_to_om(self):
-        input_counter = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label':'sth', 'other_label':'sth_else'}, 'Values': {'v1': 10, 'v2': 5}}
+        input_counter = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label': 'sth', 'other_label': 'sth_else'}, 'Values': {'v1': 10, 'v2': 5}}
 
-        expected_output ='# TYPE mycounter_v1_bytes counter\n# UNIT mycounter_v1_bytes bytes\n# HELP mycounter_v1_bytes The most important counter ever.\nmycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10\n# TYPE mycounter_v2_bytes counter\n# UNIT mycounter_v2_bytes bytes\n# HELP mycounter_v2_bytes The most important counter ever.\nmycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5'
+        expected_output = '# TYPE mycounter_v1_bytes counter\n# UNIT mycounter_v1_bytes bytes\n# HELP mycounter_v1_bytes The most important counter ever.\nmycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10\n# TYPE mycounter_v2_bytes counter\n# UNIT mycounter_v2_bytes bytes\n# HELP mycounter_v2_bytes The most important counter ever.\nmycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5'
         output = counter_to_om(input_counter)
         self.assertEqual(expected_output, output)
 
         # missing labels and units
         input_counter2 = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'help': 'The most important counter ever.'}, 'Values': {'v1': 10, 'v2': 5}}
-        expected_output2 ='# TYPE mycounter_v1 counter\n# HELP mycounter_v1 The most important counter ever.\nmycounter_v1_total 10\n# TYPE mycounter_v2 counter\n# HELP mycounter_v2 The most important counter ever.\nmycounter_v2_total 5'
+        expected_output2 = '# TYPE mycounter_v1 counter\n# HELP mycounter_v1 The most important counter ever.\nmycounter_v1_total 10\n# TYPE mycounter_v2 counter\n# HELP mycounter_v2 The most important counter ever.\nmycounter_v2_total 5'
         output2 = counter_to_om(input_counter2)
         self.assertEqual(expected_output2, output2)
 
     def test_get_labels(self):
-        input_tags = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label':'sth', 'other_label':'sth_else'}
+        input_tags = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label': 'sth', 'other_label': 'sth_else'}
         expected_output = '{label="sth",other_label="sth_else"}'
         output = get_labels(input_tags)
         self.assertEqual(expected_output, output)
@@ -28,3 +29,9 @@ class TestPrometheus(unittest.TestCase):
         input_tags2 = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.'}
         output2 = get_labels(input_tags2)
         self.assertIsNone(output2)
+
+    def test_validate_format(self):
+        input_name = "Moje.metrička"
+        expected_output = "moje_metri_ka"
+        output = validate_format(input_name)
+        self.assertEqual(expected_output, output)

--- a/test/test_prometheus.py
+++ b/test/test_prometheus.py
@@ -1,6 +1,5 @@
 import unittest
-import json
-from asab.metrics.prometheus import counter_to_om
+from asab.metrics.prometheus import counter_to_om, get_labels
 
 class TestPrometheus(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -12,3 +11,20 @@ class TestPrometheus(unittest.TestCase):
         expected_output ='# TYPE mycounter_v1_bytes counter\n# UNIT mycounter_v1_bytes bytes\n# HELP mycounter_v1_bytes The most important counter ever.\nmycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10\n# TYPE mycounter_v2_bytes counter\n# UNIT mycounter_v2_bytes bytes\n# HELP mycounter_v2_bytes The most important counter ever.\nmycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5'
         output = counter_to_om(input_counter)
         self.assertEqual(expected_output, output)
+
+        # missing labels and units
+        input_counter2 = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'help': 'The most important counter ever.'}, 'Values': {'v1': 10, 'v2': 5}}
+        expected_output2 ='# TYPE mycounter_v1 counter\n# HELP mycounter_v1 The most important counter ever.\nmycounter_v1_total 10\n# TYPE mycounter_v2 counter\n# HELP mycounter_v2 The most important counter ever.\nmycounter_v2_total 5'
+        output2 = counter_to_om(input_counter2)
+        self.assertEqual(expected_output2, output2)
+
+    def test_get_labels(self):
+        input_tags = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label':'sth', 'other_label':'sth_else'}
+        expected_output = '{label="sth",other_label="sth_else"}'
+        output = get_labels(input_tags)
+        self.assertEqual(expected_output, output)
+
+        # no labels
+        input_tags2 = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.'}
+        output2 = get_labels(input_tags2)
+        self.assertIsNone(output2)

--- a/test/test_prometheus.py
+++ b/test/test_prometheus.py
@@ -7,31 +7,70 @@ class TestPrometheus(unittest.TestCase):
         super(TestPrometheus, self).__init__(*args, **kwargs)
 
     def test_metric_to_text(self):
-        input_counter = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label': 'sth', 'other_label': 'sth_else'}, 'Values': {'v1': 10, 'v2': 5}}
+        input_counter = {
+            "Name": "mycounter",
+            "Tags": {
+                "host": "DESKTOP-6J7LEI1",
+                "unit": "bytes",
+                "help": "The most important counter ever.",
+                "label": "sth",
+                "other_label": "sth_else",
+            },
+            "Values": {"v1": 10, "v2": 5},
+        }
 
-        expected_output = '# TYPE mycounter_v1_bytes counter\n# UNIT mycounter_v1_bytes bytes\n# HELP mycounter_v1_bytes The most important counter ever.\nmycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10\n# TYPE mycounter_v2_bytes counter\n# UNIT mycounter_v2_bytes bytes\n# HELP mycounter_v2_bytes The most important counter ever.\nmycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5'
+        expected_output = """# TYPE mycounter_v1_bytes counter
+# UNIT mycounter_v1_bytes bytes
+# HELP mycounter_v1_bytes The most important counter ever.
+mycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10
+# TYPE mycounter_v2_bytes counter
+# UNIT mycounter_v2_bytes bytes
+# HELP mycounter_v2_bytes The most important counter ever.
+mycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5"""
         output = metric_to_text(input_counter, type="counter")
         self.assertEqual(expected_output, output)
 
         # missing labels and units
-        input_counter2 = {'Name': 'mycounter', 'Tags': {'host': 'DESKTOP-6J7LEI1', 'help': 'The most important counter ever.'}, 'Values': {'v1': 10, 'v2': 5}}
-        expected_output2 = '# TYPE mycounter_v1 counter\n# HELP mycounter_v1 The most important counter ever.\nmycounter_v1_total 10\n# TYPE mycounter_v2 counter\n# HELP mycounter_v2 The most important counter ever.\nmycounter_v2_total 5'
+        input_counter2 = {
+            "Name": "_mycounter",
+            "Tags": {
+                "host": "DESKTOP-6J7LEI1",
+                "help": "The most important counter ever.",
+            },
+            "Values": {"v1": 10, "v2": 5},
+        }
+        expected_output2 = """# TYPE mycounter_v1 counter
+# HELP mycounter_v1 The most important counter ever.
+mycounter_v1_total 10
+# TYPE mycounter_v2 counter
+# HELP mycounter_v2 The most important counter ever.
+mycounter_v2_total 5"""
         output2 = metric_to_text(input_counter2, type="counter")
         self.assertEqual(expected_output2, output2)
 
     def test_get_labels(self):
-        input_tags = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.', 'label': 'sth', 'other_label': 'sth_else'}
-        expected_output = '{label="sth",other_label="sth_else"}'
+        input_tags = {
+            "host": "DESKTOP-6J7LEI1",
+            "unit": "bytes",
+            "help": "The most important counter ever.",
+            "label": "sth.",
+            "other_label": "_sth_Else",
+        }
+        expected_output = '{label="sth_",other_label="sth_Else"}'
         output = get_labels(input_tags)
         self.assertEqual(expected_output, output)
 
         # no labels
-        input_tags2 = {'host': 'DESKTOP-6J7LEI1', 'unit': 'bytes', 'help': 'The most important counter ever.'}
+        input_tags2 = {
+            "host": "DESKTOP-6J7LEI1",
+            "unit": "bytes",
+            "help": "The most important counter ever.",
+        }
         output2 = get_labels(input_tags2)
         self.assertIsNone(output2)
 
     def test_validate_format(self):
-        input_name = "Moje.metrička"
-        expected_output = "moje_metri_ka"
+        input_name = "__My.metrics"
+        expected_output = "My_metrics"
         output = validate_format(input_name)
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
I'd like to ensure my understanding of asab metrics and their representation in Prometheus is right. One metric in asab can store several values. 
After some considerations every asab-counter value is translated into separate metric in Prometheus. However, this strategy might not fit the needs. 

asab counter:
```
{
    'Name': 'mycounter',
    'Tags': {
        'host': 'DESKTOP-6J7LEI1',
        'unit': 'bytes',
        'help': 'Example counter.',
        'label': 'sth',
        'other_label': 'sth_else'
    },
    'Values': {
        'v1': 10,
        'v2': 5
    }
}
```
OpenMetrics output:
```
# TYPE mycounter_v1_bytes counter
# UNIT mycounter_v1_bytes bytes
# HELP mycounter_v1_bytes Example counter.
mycounter_v1_bytes_total{label="sth",other_label="sth_else"} 10
# TYPE mycounter_v2_bytes counter
# UNIT mycounter_v2_bytes bytes
# HELP mycounter_v2_bytes Example counter.
mycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5
```