### PR TITLE
Fix counters presentation to Prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.vscode
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -23,9 +23,9 @@ class APIWebHandler(object):
 		if metrics_service is None:
 			raise RuntimeError("asab.MetricsService is not available")
 
-		from asab.metrics.prometheus import to_openmetrics
-
-		text = to_openmetrics(metrics_service)
+		for target in metrics_service.Targets:
+			if isinstance(target, asab.metrics.prometheus.PrometheusTarget):
+				text = target.rest_get()
 
 		return aiohttp.web.Response(
 			text=text,

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -18,13 +18,14 @@ class APIWebHandler(object):
 		webapp.router.add_get("/asab/v1/changelog", self.changelog)
 
 		if "asab:metrics:prometheus" in asab.Config.sections():
-			self.metrics_service = self.App.get_service("asab.MetricsService")
-			if self.metrics_service is None:
+			self.MetricsService = self.App.get_service("asab.MetricsService")
+			if self.MetricsService is None:
 				raise RuntimeError("asab.MetricsService is not available")
-			webapp.router.add_get("/asab/v1/metrics", self.metrics)
+			if self.MetricsService.PrometheusTarget is not None:
+				webapp.router.add_get("/asab/v1/metrics", self.metrics)
 
 	async def metrics(self, request):
-		text = self.metrics_service.PrometheusTarget.get_open_metric()
+		text = self.MetricsService.PrometheusTarget.get_open_metric()
 
 		return aiohttp.web.Response(
 			text=text,

--- a/asab/metrics/metrics.py
+++ b/asab/metrics/metrics.py
@@ -1,5 +1,6 @@
 import abc
 import time
+from .prometheus import metric_to_text
 
 
 class Metric(abc.ABC):
@@ -13,6 +14,10 @@ class Metric(abc.ABC):
 
 	@abc.abstractmethod
 	def flush(self) -> dict:
+		pass
+
+	@abc.abstractmethod
+	def get_open_metric(self) -> str:
 		pass
 
 	def rest_get(self):
@@ -42,6 +47,9 @@ class Gauge(Metric):
 		rest = super().rest_get()
 		rest['Values'] = self.Values
 		return rest
+
+	def get_open_metric(self, **kwargs):
+		return metric_to_text(self.rest_get(), "gauge")
 
 
 class Counter(Metric):
@@ -101,6 +109,9 @@ class Counter(Metric):
 		rest = super().rest_get()
 		rest['Values'] = self.Values
 		return rest
+
+	def get_open_metric(self, **kwargs):
+		return metric_to_text(self.rest_get(), "counter", kwargs["values"], kwargs["created"])
 
 
 class EPSCounter(Counter):
@@ -202,3 +213,6 @@ class DutyCycle(Metric):
 		rest = super().rest_get()
 		rest['Values'] = self.Values
 		return rest
+
+	def get_open_metric(self, **kwargs):
+		return None

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -130,13 +130,11 @@ class PrometheusTarget(asab.ConfigObject):
 		self.MetricsService = svc
 
 	async def process(self, now, mlist):
-
+		counter_lines = []
 		for metric, values in mlist:
 			if isinstance(metric, asab.metrics.metrics.Counter):
-				counter_lines = []
 				counter_lines.append(metric_to_text(metric.rest_get(), "counter", values, now))
-				self.countertext = '\n'.join(counter_lines)
-				print("proces!")
+		self.countertext = '\n'.join(counter_lines)
 
 	def rest_get(self):
 		gauge_text = gauge_to_openmetrics(self.MetricsService)

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -98,6 +98,28 @@ def to_openmetrics(metrics_service):
 	return text
 
 
+
+import asab
+
+
+class PrometheusTarget(asab.ConfigObject):
+
+	def __init__(self, svc, config_section_name, config=None):
+		super().__init__(config_section_name, config)
+		self.Metrics = {}
+
+
+	async def process(self, now, mlist):
+
+		for metric, values in mlist:
+			if isinstance(metric, asab.metrics.metrics.Counter):
+				pass
+
+
+	def rest_get(self):
+		return self.Metrics
+
+
 # HOW TO FULLFIL OPEMETRICS STANDARD
 
 # ONLY Gauge and Counters are translated into Prometheus. Other Metrics are omitted.

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -65,22 +65,22 @@ def translate_metadata(name, type, unit, help):
 	return metadata
 
 
-def translate_value(name, type, labels_str, value, created=None):
-	if type == "counter":
-		if labels_str:
-			total_line = ("{}{}{} {}".format(name, "_total", labels_str, value))
-			created_line = ("{}{}{} {}".format(name, "_created", labels_str, created))
-		else:
-			total_line = ("{}{} {}".format(name, "_total", value))
-			created_line = ("{}{} {}".format(name, "_created", created))
-		return '\n'.join([total_line, created_line])
+def translate_counter(name, labels_str, value, created):
+	if labels_str:
+		total_line = ("{}{}{} {}".format(name, "_total", labels_str, value))
+		created_line = ("{}{}{} {}".format(name, "_created", labels_str, created))
+	else:
+		total_line = ("{}{} {}".format(name, "_total", value))
+		created_line = ("{}{} {}".format(name, "_created", created))
+	return '\n'.join([total_line, created_line])
 
-	if type == "gauge":
-		if labels_str:
-			line = ("{}{} {}".format(name, labels_str, value))
-		else:
-			line = ("{} {}".format(name, value))
-		return line
+
+def translate_gauge(name, labels_str, value):
+	if labels_str:
+		line = ("{}{} {}".format(name, labels_str, value))
+	else:
+		line = ("{} {}".format(name, value))
+	return line
 
 
 def metric_to_text(metric, type, values=None, created=None):
@@ -93,10 +93,10 @@ def metric_to_text(metric, type, values=None, created=None):
 	help = tags.get("help")
 	labels_str = get_labels(tags)
 	if type == "counter":
-		value_items = values.items()
+		values_items = values.items()
 	if type == "gauge":
-		value_items = metric.get("Values").items()
-	for v_name, value in value_items:
+		values_items = metric.get("Values").items()
+	for v_name, value in values_items:
 		if validate_value(value) is False:
 			L.warning("Invalid OpenMetrics format. Value must be float or integer. {} omitted.".format(m_name))
 			continue
@@ -104,9 +104,9 @@ def metric_to_text(metric, type, values=None, created=None):
 			name = get_full_name(m_name, v_name, unit)
 			metric_lines.append(translate_metadata(name, type, unit, help))
 			if type == "counter":
-				metric_lines.append(translate_value(name, type, labels_str, value, created))
+				metric_lines.append(translate_counter(name, labels_str, value, created))
 			if type == "gauge":
-				metric_lines.append(translate_value(name, type, labels_str, value))
+				metric_lines.append(translate_gauge(name, labels_str, value))
 
 	metric_text = '\n'.join(metric_lines)
 	return metric_text

--- a/asab/metrics/prometheus.py
+++ b/asab/metrics/prometheus.py
@@ -20,7 +20,7 @@ def validate_format(name):
 
 
 def validate_value(value):
-	return isinstance(value, [int, float])
+	return isinstance(value, (int, float))
 
 
 def get_labels(tags):
@@ -40,51 +40,69 @@ def get_labels(tags):
 		return labels_str
 
 
+def get_full_name(m_name, v_name, unit):
+	name = "_".join([m_name, v_name])
+	name = validate_format(name)
+	if unit:
+		name += "_{}".format(unit)
+	return name
+
+
+def translate_metadata(name, type, unit, help):
+	meta_lines = []
+	# If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
+	meta_lines.append("# TYPE {} {}".format(name, type))
+	if unit:
+		meta_lines.append("# UNIT {} {}".format(name, unit))
+	else:
+		L.warning("Invalid OpenMetrics format. Please, add 'unit' in 'Tags'.")
+
+	if help:
+		meta_lines.append("# HELP {} {}".format(name, help))
+	else:
+		L.warning("Invalid OpenMetrics format. Please, add 'help' in 'Tags'.")
+	metadata = '\n'.join(meta_lines)
+	return metadata
+
+
+def translate_value(name, type, labels_str, value):
+	if type == "counter":
+		metricpoint = "_total"
+	if type == "gauge":
+		metricpoint = ""
+	if labels_str:
+		line = ("{}{}{} {}".format(name, metricpoint, labels_str, value))
+	else:
+		line = ("{}{} {}".format(name, metricpoint, value))
+	return line
+
+
 def metric_to_text(metric, type):
 	metric_lines = []
 	m_name = metric.get("Name")
 	tags = metric.get("Tags")
+	unit = tags.get("unit")
+	if unit:
+		unit = validate_format(unit)
+	help = tags.get("help")
 	labels_str = get_labels(tags)
 
 	for v_name, value in metric.get("Values").items():
-		if validate_value is False:
+		if validate_value(value) is False:
 			L.warning("Invalid OpenMetrics format. Value must be float or integer. {} omitted.".format(m_name))
 			continue
 		else:
-			name = "_".join([m_name, v_name])
-			name = validate_format(name)
-			# If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name.
-			if tags.get("unit"):
-				unit = tags.get("unit")
-				unit = validate_format(unit)
-				name += "_{}".format(unit)
-				metric_lines.append("# TYPE {} {}".format(name, type))
-				metric_lines.append("# UNIT {} {}".format(name, unit))
-			else:
-				unit = None
-				metric_lines.append("# TYPE {} {}".format(name, type))
-				L.warning("Invalid OpenMetrics format. Please, add 'unit' in 'Tags'.")
+			name = get_full_name(m_name, v_name, unit)
+			metric_lines.append(translate_metadata(name, type, unit, help))
+			metric_lines.append(translate_value(name, type, labels_str, value))
 
-			if tags.get("help"):
-				metric_lines.append("# HELP {} {}".format(name, tags.get("help")))
-			else:
-				L.warning("Invalid OpenMetrics format. Please, add 'help' in 'Tags'.")
-
-			if type == "counter":
-				metricpoint = "_total"
-			if type == "gauge":
-				metricpoint = ""
-			if labels_str:
-				metric_lines.append("{}{}{} {}".format(name, metricpoint, labels_str, value))
-			else:
-				metric_lines.append("{}{} {}".format(name, metricpoint, value))
 	metric_text = '\n'.join(metric_lines)
 	return metric_text
 
 
 def to_openmetrics(metrics_service):
 	lines = []
-	for mname, metrics in metrics_service.Metrics.items():
+	for metrics in metrics_service.Metrics.values():
 		if isinstance(metrics, asab.metrics.metrics.Counter):
 			counter_text = metric_to_text(metrics.rest_get(), type="counter")
 			lines.append(counter_text)

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -6,7 +6,7 @@ import asab
 
 from .metrics import Metric, Counter, EPSCounter, Gauge, DutyCycle
 from .memstor import MetricsMemstorTarget
-from. prometheus import PrometheusTarget
+
 
 #
 
@@ -46,6 +46,11 @@ class MetricsService(asab.Service):
 			if target_type == 'influxdb':
 				from .influxdb import MetricsInfluxDB
 				target = MetricsInfluxDB(self, 'asab:metrics:{}'.format(target))
+
+			if target_type == "prometheus":
+				from. prometheus import PrometheusTarget
+				target = PrometheusTarget(self, 'asab:metrics:prometheus')
+				self.PrometheusTarget = target
 			else:
 				raise RuntimeError("Unknown target type {}".format(target_type))
 
@@ -54,10 +59,6 @@ class MetricsService(asab.Service):
 		# Memory storage target
 		self.MemstorTarget = MetricsMemstorTarget(self, 'asab:metrics:memory')
 		self.Targets.append(self.MemstorTarget)
-
-		# Prometheus Target
-		self.PrometheusTarget = PrometheusTarget(self, 'asab:metrics:prometheus')
-		self.Targets.append(self.PrometheusTarget)
 
 
 	async def finalize(self, app):

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -34,6 +34,8 @@ class MetricsService(asab.Service):
 			"host": app.HostName,
 		}
 
+		self.PrometheusTarget = None
+
 		app.PubSub.subscribe("Application.tick/60!", self._on_flushing_event)
 
 		for target in asab.Config.get('asab:metrics', 'target').strip().split():
@@ -47,10 +49,11 @@ class MetricsService(asab.Service):
 				from .influxdb import MetricsInfluxDB
 				target = MetricsInfluxDB(self, 'asab:metrics:{}'.format(target))
 
-			if target_type == "prometheus":
+			elif target_type == "prometheus":
 				from. prometheus import PrometheusTarget
 				target = PrometheusTarget(self, 'asab:metrics:prometheus')
 				self.PrometheusTarget = target
+
 			else:
 				raise RuntimeError("Unknown target type {}".format(target_type))
 

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -6,6 +6,7 @@ import asab
 
 from .metrics import Metric, Counter, EPSCounter, Gauge, DutyCycle
 from .memstor import MetricsMemstorTarget
+from. prometheus import PrometheusTarget
 
 #
 
@@ -53,6 +54,10 @@ class MetricsService(asab.Service):
 		# Memory storage target
 		self.MemstorTarget = MetricsMemstorTarget(self, 'asab:metrics:memory')
 		self.Targets.append(self.MemstorTarget)
+
+		# Prometheus Target
+		self.PrometheusTarget = PrometheusTarget(self, 'asab:metrics:prometheus')
+		self.Targets.append(self.PrometheusTarget)
 
 
 	async def finalize(self, app):

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -9,11 +9,13 @@ class MyApplication(asab.Application):
 		# Fake config file
 		asab.Config.read_string("""
 [asab:metrics]
-target=influxdb
+target=influxdb prometheus
 
 [asab:metrics:influxdb]
 url=http://localhost:8086/
 db=mydb
+
+[asab:metrics:prometheus]
 		""")
 
 		from asab.metrics import Module

--- a/test/test_prometheus.py
+++ b/test/test_prometheus.py
@@ -1,12 +1,20 @@
 import unittest
-from asab.metrics.prometheus import metric_to_text, get_labels, validate_format
+from asab.metrics.prometheus import (
+    metric_to_text,
+    get_labels,
+    validate_format,
+    validate_value,
+    get_full_name,
+    translate_metadata,
+    translate_value,
+)
 
 
 class TestPrometheus(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestPrometheus, self).__init__(*args, **kwargs)
 
-    def test_metric_to_text(self):
+    def test_happy_flow(self):
         input_counter = {
             "Name": "mycounter",
             "Tags": {
@@ -30,24 +38,6 @@ mycounter_v2_bytes_total{label="sth",other_label="sth_else"} 5"""
         output = metric_to_text(input_counter, type="counter")
         self.assertEqual(expected_output, output)
 
-        # missing labels and units
-        input_counter2 = {
-            "Name": "_mycounter",
-            "Tags": {
-                "host": "DESKTOP-6J7LEI1",
-                "help": "The most important counter ever.",
-            },
-            "Values": {"v1": 10, "v2": 5},
-        }
-        expected_output2 = """# TYPE mycounter_v1 counter
-# HELP mycounter_v1 The most important counter ever.
-mycounter_v1_total 10
-# TYPE mycounter_v2 counter
-# HELP mycounter_v2 The most important counter ever.
-mycounter_v2_total 5"""
-        output2 = metric_to_text(input_counter2, type="counter")
-        self.assertEqual(expected_output2, output2)
-
     def test_get_labels(self):
         input_tags = {
             "host": "DESKTOP-6J7LEI1",
@@ -60,7 +50,7 @@ mycounter_v2_total 5"""
         output = get_labels(input_tags)
         self.assertEqual(expected_output, output)
 
-        # no labels
+    def test_get_no_labels(self):
         input_tags2 = {
             "host": "DESKTOP-6J7LEI1",
             "unit": "bytes",
@@ -74,3 +64,43 @@ mycounter_v2_total 5"""
         expected_output = "My_metrics"
         output = validate_format(input_name)
         self.assertEqual(expected_output, output)
+
+    def test_validate_value(self):
+        self.assertTrue(validate_value(1))
+        self.assertTrue(validate_value(1.1))
+        self.assertFalse(validate_value("1"))
+
+    def test_get_full_name(self):
+        m_name, v_name, unit = "Metrics", "Value", "Unit"
+        output = get_full_name(m_name, v_name, unit)
+        self.assertEqual("Metrics_Value_Unit", output)
+
+    def test_translate_metadata(self):
+        name, type, unit, help = (
+            "Metrics_Value_Unit",
+            "counter",
+            "Unit",
+            "This is help.",
+        )
+        output = translate_metadata(name, type, unit, help)
+        expected_output = """# TYPE Metrics_Value_Unit counter
+# UNIT Metrics_Value_Unit Unit
+# HELP Metrics_Value_Unit This is help."""
+        self.assertEqual(expected_output, output)
+
+    def test_missing_meta(self):
+        # missing labels and units
+        name, type, unit, help = "Metrics_Value_Unit", "counter", None, None
+        expected_output = "# TYPE Metrics_Value_Unit counter"
+        output = translate_metadata(name, type, unit, help)
+        self.assertEqual(expected_output, output)
+
+    def test_translate_value(self):
+        name, type, labels_str, value = (
+            "Metrics_Value_Unit",
+            "counter",
+            '{labelname:"label"}',
+            5,
+        )
+        output = translate_value(name, type, labels_str, value)
+        self.assertEqual('Metrics_Value_Unit_total{labelname:"label"} 5', output)


### PR DESCRIPTION
Metrics in asab reset every 60 seconds. When Prometheus requests metrics, the Counters values of the last state before the last reset are sent together with the time of reset, which Prometheus accepts as metric point suffixed "_created". A Counter value changes every 60 seconds and during this period it is constant. On the other hand, current values of Gauges are provided whenever Prometheus requests.