### PR TITLE
Trying to advertise "web" into zookeeper

### DIFF
--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -45,8 +45,7 @@ class ApiService(asab.Service):
 		else:
 			self.Manifest = None
 
-
-
+		self.App.PubSub.subscribe("WebContainer.started!", self.advertise)
 
 
 	def attention_required(self, att: dict, att_id=None):
@@ -135,10 +134,6 @@ class ApiService(asab.Service):
 
 		# get zookeeper-service
 		self.ZkContainer = zoocontainer
-		self.ZkContainer.advertise(
-			data=self._build_zookeeper_adv_data(),
-			path="/run/{}.".format(self.App.__class__.__name__),
-		)
 
 
 	def _build_zookeeper_adv_data(self):
@@ -159,3 +154,9 @@ class ApiService(asab.Service):
 		if self.WebContainer is not None:
 			adv_data['web'] = self.WebContainer.Addresses
 		return adv_data
+
+	def advertise(self, message_type, webcontainer):
+		self.ZkContainer.advertise(
+			data=self._build_zookeeper_adv_data(),
+			path="/run/{}.".format(self.App.__class__.__name__),
+		)

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
 		'aiohttp>=3.6.2',
 		'fastjsonschema>=2.14.4',
 		'aiozk>=0.25.0',
+		'kazoo>=2.8.0',
 	],
 	cmdclass={
 		'build_py': custom_build_py,


### PR DESCRIPTION
The `web` item is always empty in zookeeper when microservices advertise about themselves. That's because API Service, which makes this advertisement, is synchronous and advertises in application init time. However, this `web` information originates in WebContainer during async initialize() which happens **after** the advertisement. 
I just made the ApiService wait for WebContainer to initialize... Not very elegant, but working...