### PR TITLE
Custom exceptions

### DIFF
--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -1,0 +1,23 @@
+class ValidationError(Exception):
+	pass
+
+
+class Conflict(Exception):
+	# TODO: Handle when the value of `key` or `value` is `None`
+	def __init__(self, message=None, *args, key=None, value=None):
+		self.Key = key
+		self.Value = value
+
+		if message is None:
+			if key is not None:
+				if value is not None:
+					message = "in field {}: {}".format(repr(key), repr(value))
+				else:
+					message = "in field {}".format(repr(key))
+			elif value is not None:
+				message = value
+
+		if message is None:
+			super().__init__(*args)
+		else:
+			super().__init__(message, *args)

--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -11,9 +11,9 @@ class Conflict(Exception):
 		if message is None:
 			if key is not None:
 				if value is not None:
-					message = "in field {}: {}".format(repr(key), repr(value))
+					message = "Conflict in field {}: {}".format(repr(key), repr(value))
 				else:
-					message = "in field {}".format(repr(key))
+					message = "Conflict in field {}".format(repr(key))
 			elif value is not None:
 				message = value
 


### PR DESCRIPTION
# `asab.exceptions.ValidationError`
- Request cannot be processed because it has incorrect form
- Service-level equivalent of HTTP Bad request

# `asab.exceptions.Conflict`
- Request cannot be processed because it would result in a state that violates some uniqueness requirement
- The exception has two optional fields: `key` and `value`.
- `raise Conflict(key="username", value="elvis")`
