### PR TITLE
Fix -w flag behavior

### DIFF
--- a/asab/application.py
+++ b/asab/application.py
@@ -205,7 +205,9 @@ class Application(metaclass=Singleton):
 			Config._default_values['logging:file']['path'] = args.log_file
 
 		if args.web_api:
-			Config._default_values['web'] = {'listen': args.web_api}
+			if 'web' not in Config._default_values:
+				Config._default_values['web'] = {}
+			Config._default_values['web']['listen'] = args.web_api
 
 		return args
 

--- a/asab/application.py
+++ b/asab/application.py
@@ -205,7 +205,7 @@ class Application(metaclass=Singleton):
 			Config._default_values['logging:file']['path'] = args.log_file
 
 		if args.web_api:
-			Config._default_values['web']['listen'] = args.web_api
+			Config._default_values['web'] = {'listen': args.web_api}
 
 		return args
 


### PR DESCRIPTION
Issue: Specifying the `-w` flag causes the app to crash on startup.

Fix: If `-w` is specified, create `web` section in config defaults if it doesn't exist.