### PR TITLE
Storage webhook

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -371,7 +371,8 @@ class ElasicSearchUpsertor(UpsertorABC):
 		raise NotImplementedError("generate_id")
 
 
-	async def execute(self):
+	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+		# TODO: Implement webhook call
 		if self.ObjId is None:
 			return await self._insert_noobjid()
 		else:

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -372,7 +372,7 @@ class ElasicSearchUpsertor(UpsertorABC):
 		raise NotImplementedError("generate_id")
 
 
-	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None):
 		# TODO: Implement webhook call
 		if self.ObjId is None:
 			return await self._insert_noobjid()

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -4,6 +4,7 @@ import aiohttp
 import logging
 import datetime
 import urllib.parse
+import typing
 
 from .service import StorageServiceABC
 from .upsertor import UpsertorABC

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -372,7 +372,7 @@ class ElasicSearchUpsertor(UpsertorABC):
 		raise NotImplementedError("generate_id")
 
 
-	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
 		# TODO: Implement webhook call
 		if self.ObjId is None:
 			return await self._insert_noobjid()

--- a/asab/storage/inmemory.py
+++ b/asab/storage/inmemory.py
@@ -6,7 +6,8 @@ from .exceptions import DuplicateError
 class InMemoryUpsertor(UpsertorABC):
 
 
-	async def execute(self):
+	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+		# TODO: Implement webhook call
 		id_name = self.get_id_name()
 
 		# Get the object

--- a/asab/storage/inmemory.py
+++ b/asab/storage/inmemory.py
@@ -7,7 +7,7 @@ from .exceptions import DuplicateError
 class InMemoryUpsertor(UpsertorABC):
 
 
-	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None):
 		# TODO: Implement webhook call
 		id_name = self.get_id_name()
 

--- a/asab/storage/inmemory.py
+++ b/asab/storage/inmemory.py
@@ -1,3 +1,4 @@
+import typing
 from .service import StorageServiceABC
 from .upsertor import UpsertorABC
 from .exceptions import DuplicateError

--- a/asab/storage/inmemory.py
+++ b/asab/storage/inmemory.py
@@ -7,7 +7,7 @@ from .exceptions import DuplicateError
 class InMemoryUpsertor(UpsertorABC):
 
 
-	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
 		# TODO: Implement webhook call
 		id_name = self.get_id_name()
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -113,7 +113,7 @@ class MongoDBUpsertor(UpsertorABC):
 		return bson.objectid.ObjectId()
 
 
-	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
 		id_name = self.get_id_name()
 		addobj = {}
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -1,5 +1,5 @@
 import datetime
-
+import typing
 import motor.motor_asyncio
 import pymongo
 import bson

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -185,6 +185,9 @@ class MongoDBUpsertor(UpsertorABC):
 				data["push"] = self.ModPush.items()
 			if len(self.ModUnset) > 0:
 				data["unset"] = self.ModUnset
-			await self._webhook(data)
+			await self._webhook({
+				"collection": self.Collection,
+				"data": data
+			})
 
 		return self.ObjId

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -172,4 +172,19 @@ class MongoDBUpsertor(UpsertorABC):
 		# 			pass
 		# 	obj[k] = o
 
+		if self.Storage.WebhookURI is not None:
+			data = {
+				id_name: self.ObjId,
+				"_v": int(self.Version),
+			}
+			if len(self.ModSet) > 0:
+				data["set"] = self.ModSet
+			if len(self.ModInc) > 0:
+				data["inc"] = self.ModInc
+			if len(self.ModPush) > 0:
+				data["push"] = self.ModPush.items()
+			if len(self.ModUnset) > 0:
+				data["unset"] = self.ModUnset
+			await self._webhook(data)
+
 		return self.ObjId

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -113,7 +113,7 @@ class MongoDBUpsertor(UpsertorABC):
 		return bson.objectid.ObjectId()
 
 
-	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None):
 		id_name = self.get_id_name()
 		addobj = {}
 
@@ -177,8 +177,8 @@ class MongoDBUpsertor(UpsertorABC):
 				"collection": self.Collection,
 			}
 
-			if webhook_user_data is not None:
-				webhook_data["user_data"] = webhook_user_data
+			if custom_data is not None:
+				webhook_data["custom"] = custom_data
 
 			# Add upsetor data; do not include fields that start with "__"
 			upsertor_data = {
@@ -194,7 +194,7 @@ class MongoDBUpsertor(UpsertorABC):
 				upsertor_data["push"] = {k: v for k, v in self.ModPush.items() if not k.startswith("__")}
 			if len(self.ModUnset) > 0:
 				upsertor_data["unset"] = {k: v for k, v in self.ModUnset.items() if not k.startswith("__")}
-			webhook_data["upsertor_data"] = upsertor_data
+			webhook_data["upsertor"] = upsertor_data
 
 			await self._webhook(webhook_data)
 

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -6,6 +6,8 @@ class StorageServiceABC(asab.Service):
 
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
+		self.WebhookURI = asab.Config.get("asab:storage:changestream", "uri", fallback=None)
+		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "auth", fallback=None)
 
 
 	@abc.abstractmethod

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -6,8 +6,8 @@ class StorageServiceABC(asab.Service):
 
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
-		self.WebhookURI = asab.Config.get("asab:storage:changestream", "webhook_uri", fallback=None)
-		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "webhook_auth", fallback=None)
+		self.WebhookURI = asab.Config.get("asab:storage:changestream", "webhook_uri", fallback="") or None
+		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "webhook_auth", fallback="") or None
 
 
 	@abc.abstractmethod

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -6,8 +6,8 @@ class StorageServiceABC(asab.Service):
 
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
-		self.WebhookURI = asab.Config.get("asab:storage:changestream", "uri", fallback=None)
-		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "auth", fallback=None)
+		self.WebhookURI = asab.Config.get("asab:storage:changestream", "webhook_uri", fallback=None)
+		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "webhook_auth", fallback=None)
 
 
 	@abc.abstractmethod

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -104,7 +104,7 @@ class UpsertorABC(abc.ABC):
 
 
 	@abc.abstractmethod
-	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
 		"""
 		Commit upsertor data to the storage
 

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -104,7 +104,7 @@ class UpsertorABC(abc.ABC):
 
 
 	@abc.abstractmethod
-	async def execute(self, webhook_user_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None):
 		"""
 		Commit upsertor data to the storage
 

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import aiohttp
 import asab.web.rest.json
+import typing
 
 #
 
@@ -103,7 +104,12 @@ class UpsertorABC(abc.ABC):
 
 
 	@abc.abstractmethod
-	async def execute(self):
+	async def execute(self, webhook_user_data: typing.Optional[dict]=None):
+		"""
+		Commit upsertor data to the storage
+
+		:webhook_data: Additional data to include in webhook payload
+		"""
 		pass
 
 

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -106,9 +106,37 @@ class UpsertorABC(abc.ABC):
 	@abc.abstractmethod
 	async def execute(self, custom_data: typing.Optional[dict] = None):
 		"""
-		Commit upsertor data to the storage
+		Commit upsertor data to the storage. Afterwards, send a webhook request with upsertion details.
 
-		:webhook_data: Additional data to include in webhook payload
+		:custom_data: Custom execution data. Included in webhook payload.
+
+		Example:
+			The following upsertion
+			```python
+			upsertor = storage_service.upsertor("users")
+			upsertor.set("name", "Raccoon")
+			await upsertor.execute(custom_data={"action": "user_creation"})
+			```
+
+			will trigger a webhook whose payload may look like this:
+			```json
+			{
+				"collection": "users",
+				"custom": {"action": "user_creation"},
+				"upsertor": {
+					"id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
+					"id_field_name": "_id",
+					"_v": 0,
+					"inc": {"_v": 1},
+					"set": {
+						"_c": "2022-07-11T16:06:04.380445+00:00",
+						"_id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
+						"_m": "2022-07-11T16:06:04.380445+00:00",
+						"name": "Raccoon"
+					}
+				}
+			}
+			```
 		"""
 		pass
 

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -119,7 +119,7 @@ class UpsertorABC(abc.ABC):
 				) as response:
 					if response.status // 100 != 2:
 						text = await response.text()
-						L.error("Webhook endpoint responded with {}:\n{}".format(response.status, text[:1000]))
+						L.error("Webhook endpoint responded with {}:\n{}".format(response.status, text))
 						return
 					self.WebhookResponseData = await response.json()
 		except json.decoder.JSONDecodeError as e:


### PR DESCRIPTION
Create a webhook that is triggered by any `asab.storage.Upsertor.execute()` call and makes a **PUT request** to a pre-configured URL.
The webhook payload is a JSON containing the upsertor data (excluding sensitive `__`-prefixed fields).

To set the webhook up, provide a non-empty `webhook_uri` in the config:
```ini
[asab:storage:changestream]
webhook_uri=http://localhost:8080/webhook
```