### PR TITLE
Add an OBSOLETE logger.

### DIFF
--- a/asab/__init__.py
+++ b/asab/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from .abc.module import Module
 from .abc.service import Service
 from .abc.singleton import Singleton
@@ -11,6 +13,11 @@ from .timer import Timer
 
 from .__version__ import __version__, __build__
 
+# This logger is used to indicate use of the obsolete function
+# Example:
+#    asab.LogObsolete.warning("Use of the obsolete function", struct_data={'eol':'2022-31-12'})
+# See https://github.com/TeskaLabs/asab/issues/240
+LogObsolete = logging.getLogger('OBSOLETE')
 
 __all__ = (
 	'Module',

--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -207,7 +207,7 @@ Example of the use:
 
 Log example:
 
-    21-Jul-2022 14:32:40.983884 WARNING OBSOLETE [eol="2022-31-12"] Use of the obsolete function
+``21-Jul-2022 14:32:40.983884 WARNING OBSOLETE [eol="2022-31-12"] Use of the obsolete function`
 
 
 Reference

--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -186,6 +186,30 @@ Possible URL values:
 The default value is a ``/dev/log`` on Linux or ``/var/run/syslog`` on Mac OSX.
 
 
+Logging of obsolete features
+----------------------------
+
+It proved to be important to inform operators about features that are going to be obsoleted.
+ASAB offers the unified "obsolete" logger.
+This logger can be used to indicate that particular feature is marked as "obsolete" thru logs.
+Such a log message can be then "grepped" from logs in a uniform way.
+
+It is recommended to include `eol` attribute in the `struct_data` of the log with a YYYY-MM-DD date/time of the planned obsoletion of the feature.
+
+Hint: We suggest to automate detection of the obsolete warnings in logs so that the operations are informed well ahead of the actual removal of the feature. The string to seek for in logs is " OBSOLETE ".
+
+Example of the use:
+
+.. code:: python
+
+    asab.LogObsolete.warning("Use of the obsolete function", struct_data={'eol':'2022-31-12'})
+
+
+Log example:
+
+    21-Jul-2022 14:32:40.983884 WARNING OBSOLETE [eol="2022-31-12"] Use of the obsolete function
+
+
 Reference
 ---------
 

--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -189,14 +189,14 @@ The default value is a ``/dev/log`` on Linux or ``/var/run/syslog`` on Mac OSX.
 Logging of obsolete features
 ----------------------------
 
-It proved to be important to inform operators about features that are going to be obsoleted.
+It proved to be essential to inform operators about features that are going to be obsoleted.
 ASAB offers the unified "obsolete" logger.
-This logger can be used to indicate that particular feature is marked as "obsolete" thru logs.
-Such a log message can be then "grepped" from logs in a uniform way.
+This logger can indicate that a particular feature is marked as "obsolete" thru logs.
+Such a log message can then be "grepped" from logs uniformly.
 
-It is recommended to include `eol` attribute in the `struct_data` of the log with a YYYY-MM-DD date/time of the planned obsoletion of the feature.
+It is recommended to include `eol` attribute in the `struct_data` of the log with a `YYYY-MM-DD` date/time of the planned obsoletion of the feature.
 
-Hint: We suggest to automate detection of the obsolete warnings in logs so that the operations are informed well ahead of the actual removal of the feature. The string to seek for in logs is " OBSOLETE ".
+Hint: We suggest automating the detection of obsolete warnings in logs so that the operations are informed well ahead of the actual removal of the feature. The string to seek in logs is " OBSOLETE ".
 
 Example of the use:
 


### PR DESCRIPTION
`asab.LogObsolete.warning("Use of the obsolete function", struct_data={'eol':'2022-31-12'})`

Log example:

```
21-Jul-2022 14:32:40.983884 WARNING OBSOLETE Using obsolete config section [asab:web]. Preferred section name is [web].
```

Closed issue #240