### PR TITLE
Improving Swagger docs

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -9,6 +9,7 @@ import yaml
 
 L = logging.getLogger(__name__)
 
+
 ##
 
 
@@ -44,7 +45,6 @@ class DocWebHandler(object):
 		else:
 			description = ""
 
-
 		specs = {
 			"openapi": "3.0.1",
 			"info": {
@@ -56,12 +56,14 @@ class DocWebHandler(object):
 				},
 				"version": "1.0.0"
 			},
-			"servers": [
-				{"url": "../../"}  # Base path relative to openapi endpoint
-			],
+			"servers": [],  # Base path relative to openapi endpoint
 			"paths": {
 			},
 		}
+
+		# Add servers to specs
+		for server in self.WebContainer.Addresses:
+			specs["servers"].append({"url": "{} ({}:{})".format(self.App.ServerName, server[0], server[1])})
 
 		if adddict is not None:
 			specs.update(adddict)
@@ -153,6 +155,7 @@ class DocWebHandler(object):
 
 		return specs
 
+
 	# This is the web request handler
 	async def doc(self, request):
 		'''
@@ -196,6 +199,7 @@ window.onload = () => {{
 		)
 
 		return aiohttp.web.Response(text=page, content_type="text/html")
+
 
 	async def openapi(self, request):
 		'''

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -70,7 +70,7 @@ class DocWebHandler(object):
 				"securitySchemes": {
 					"oAuthSample": {
 						"type": "oauth2",
-						"description": "This API uses OAuth 2, this window allows [links](https://teskalabs.com)",
+						"description": "",
 						"flows": {
 							"authorizationCode": {
 								"authorizationUrl": self.AuthorizationUrl,  # "http://localhost/seacat/api/openidconnect/authorize"

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -26,6 +26,7 @@ class DocWebHandler(object):
 
 		self.AuthorizationUrl = asab.Config.get(config_section_name, "authorizationUrl")
 		self.TokenUrl = asab.Config.get(config_section_name, "tokenUrl")
+		self.Scopes = asab.Config.get(config_section_name, "scopes").split(",")
 
 
 	def build_swagger_specs(self):
@@ -76,9 +77,7 @@ class DocWebHandler(object):
 								"authorizationUrl": self.AuthorizationUrl,  # "http://localhost/seacat/api/openidconnect/authorize"
 								"tokenUrl": self.TokenUrl,  # "http://localhost/seacat/api/openidconnect/token"
 								"scopes": {
-									"write_stuff": "modify stuff :D",
-									"read_stuff": "read stuff :DD",
-									"openid": "openid",
+									"openid": "Required Scope for OpenIDConnect!",
 								}
 							}
 						}
@@ -86,6 +85,9 @@ class DocWebHandler(object):
 				},
 			},
 		}
+
+		for scope in self.Scopes:
+			specs["components"]["securitySchemes"]["oAuthSample"]["flows"]["authorizationCode"]["scopes"].update({scope: "{} scope.".format(scope.strip().capitalize())})
 
 		# Show what server/docker container you are on, and it's IP
 		specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}</strong>".format(

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -56,10 +56,10 @@ class DocWebHandler(object):
 				},
 				"version": "1.0.0"
 			},
-			"servers": [],  # Base path relative to openapi endpoint
-			"paths": {
-			},
-			# This is how you modify how autherization works
+			"servers": [{"url": "../../"}],  # Base path relative to openapi endpoint
+			"paths": {},
+
+			# Authorization
 			"components": {
 				"securitySchemes": {
 					"oAuthSample": {
@@ -82,7 +82,7 @@ class DocWebHandler(object):
 		for server in self.WebContainer.Addresses:
 			specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}:{}</strong>".format(
 				self.App.ServerName, server[0], server[1]) + "<p>{}</p>".format(description))
-			specs["servers"].append({"url": "http://{}:{}".format(server[0], server[1])})
+		# specs["servers"].append({"url": "http://{}:{}".format(server[0], server[1])})
 
 		if adddict is not None:
 			specs.update(adddict)

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -134,6 +134,7 @@ class DocWebHandler(object):
 			description += '\n\nHandler: `{}`'.format(handler_name)
 
 			methoddict = {
+				'summary': description.split("\n")[0],
 				'description': description,
 				'tags': ['general'],
 				'responses': {

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -2,6 +2,7 @@ import re
 import logging
 import inspect
 
+import asab
 import aiohttp
 import aiohttp.web
 import yaml
@@ -16,12 +17,15 @@ L = logging.getLogger(__name__)
 
 class DocWebHandler(object):
 
-	def __init__(self, app, web_container):
+	def __init__(self, app, web_container, config_section_name='asab:doc'):
 		self.App = app
 		self.WebContainer = web_container
 		self.WebContainer.WebApp.router.add_get('/doc', self.doc)
 		self.WebContainer.WebApp.router.add_get('/oauth2-redirect.html', self.oauth2_redirect)
 		self.WebContainer.WebApp.router.add_get('/asab/v1/openapi', self.openapi)
+
+		self.AuthorizationUrl = asab.Config.get(config_section_name, "authorizationUrl")
+		self.TokenUrl = asab.Config.get(config_section_name, "tokenUrl")
 
 
 	def build_swagger_specs(self):
@@ -69,8 +73,8 @@ class DocWebHandler(object):
 						"description": "This API uses OAuth 2, this window allows [links](https://teskalabs.com)",
 						"flows": {
 							"authorizationCode": {
-								"authorizationUrl": "https://auth.test.loc/seacat/api/openidconnect/authorize",
-								"tokenUrl": "https://auth.test.loc/seacat/api/openidconnect/token",
+								"authorizationUrl": self.AuthorizationUrl,  # "http://localhost/seacat/api/openidconnect/authorize"
+								"tokenUrl": self.TokenUrl,  # "http://localhost/seacat/api/openidconnect/token"
 								"scopes": {
 									"write_stuff": "modify stuff :D",
 									"read_stuff": "read stuff :DD",

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -83,6 +83,7 @@ class DocWebHandler(object):
 			},
 		}
 
+		# Show what server/docker container you are on, and it's IP
 		for server in self.WebContainer.Addresses:
 			specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}:{}</strong>".format(
 				self.App.ServerName, server[0], server[1]) + "<p>{}</p>".format(description))

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -104,15 +104,23 @@ class DocWebHandler(object):
 				path = route_info["path"]
 
 			elif "formatter" in route_info:
-				# TODO: Extract URL parameters from formatter string
+				# Extract URL parameters from formatter string
 				path = route_info["formatter"]
 
-				for m in re.findall(r'\{.*\}', path):
-					parameters.append({
-						'in': 'path',
-						'name': m[1:-1],
-						'required': True,
-					})
+				for params in re.findall(r'\{.*\}', path):
+					if "/" in params:
+						for parameter in params.split("/"):
+							parameters.append({
+								'in': 'path',
+								'name': parameter[1:-1],
+								'required': True,
+							})
+					else:
+						parameters.append({
+							'in': 'path',
+							'name': params[1:-1],
+							'required': True,
+						})
 
 			else:
 				L.warning("Cannot obtain path info from route", struct_data=route_info)

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -27,6 +27,7 @@ class DocWebHandler(object):
 		self.AuthorizationUrl = asab.Config.get(config_section_name, "authorizationUrl")
 		self.TokenUrl = asab.Config.get(config_section_name, "tokenUrl")
 		self.Scopes = asab.Config.get(config_section_name, "scopes").split(",")
+		self.Version = asab.Config.get(config_section_name, "version")
 
 
 	def build_swagger_specs(self):
@@ -89,8 +90,11 @@ class DocWebHandler(object):
 		for scope in self.Scopes:
 			specs["components"]["securitySchemes"]["oAuthSample"]["flows"]["authorizationCode"]["scopes"].update({scope: "{} scope.".format(scope.strip().capitalize())})
 
+		if self.Version:
+			specs["info"]["version"] = self.Version
+
 		# Show what server/docker container you are on, and it's IP
-		specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}</strong>".format(
+		specs["info"]["description"] = ("Running on: <strong>{}</strong> on: <strong>{}</strong>".format(
 			self.App.ServerName, self.WebContainer.Addresses) + "<p>{}</p>".format(description))
 		# specs["servers"].append({"url": "http://{}:{}".format(server[0], server[1])})
 

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -56,10 +56,33 @@ class DocWebHandler(object):
 				},
 				"version": "1.0.0"
 			},
-			"servers": [{"url": "../../"}],  # Base path relative to openapi endpoint
+			"servers": [],  # Base path relative to openapi endpoint
 			"paths": {
 			},
+			# This is how you modify how autherization works
+			"components": {
+				"securitySchemes": {
+					"oAuthSample": {
+						"type": "oauth2",
+						"description": "This API uses OAuth 2, this window allows [links](https://teskalabs.com)",
+						"flows": {
+							"implicit": {
+								"authorizationUrl": "",
+								"scopes": {
+									"write_stuff": "modify stuff :D",
+									"read_stuff": "read stuff :DD",
+								}
+							}
+						}
+					}
+				},
+			},
 		}
+
+		for server in self.WebContainer.Addresses:
+			specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}:{}</strong>".format(
+				self.App.ServerName, server[0], server[1]) + "<p>{}</p>".format(description))
+			specs["servers"].append({"url": "http://{}:{}".format(server[0], server[1])})
 
 		if adddict is not None:
 			specs.update(adddict)

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -24,7 +24,7 @@ class DocWebHandler(object):
 
 	def build_swagger_specs(self):
 		"""
-		Takes a docstring of a class and a docstring of mmethods and merges them
+		Takes a docstring of a class and a docstring of methods and merges them
 		into a Swagger specification.
 		"""
 

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -17,7 +17,7 @@ L = logging.getLogger(__name__)
 
 class DocWebHandler(object):
 
-	def __init__(self, app, web_container, config_section_name='asab:doc'):
+	def __init__(self, api_service, app, web_container, config_section_name='asab:doc'):
 		self.App = app
 		self.WebContainer = web_container
 		self.WebContainer.WebApp.router.add_get('/doc', self.doc)
@@ -27,7 +27,7 @@ class DocWebHandler(object):
 		self.AuthorizationUrl = asab.Config.get(config_section_name, "authorizationUrl")
 		self.TokenUrl = asab.Config.get(config_section_name, "tokenUrl")
 		self.Scopes = asab.Config.get(config_section_name, "scopes").split(",")
-		self.Version = asab.Config.get(config_section_name, "version")
+		self.Manifest = api_service.Manifest
 
 
 	def build_swagger_specs(self):
@@ -87,11 +87,13 @@ class DocWebHandler(object):
 			},
 		}
 
+		# Gets all the scopes from config and puts them into scopes
 		for scope in self.Scopes:
 			specs["components"]["securitySchemes"]["oAuthSample"]["flows"]["authorizationCode"]["scopes"].update({scope: "{} scope.".format(scope.strip().capitalize())})
 
-		if self.Version:
-			specs["info"]["version"] = self.Version
+		# Version from MANIFEST.json
+		if self.Manifest:
+			specs["info"]["version"] = self.Manifest["version"]
 
 		# Show what server/docker container you are on, and it's IP
 		specs["info"]["description"] = ("Running on: <strong>{}</strong> on: <strong>{}</strong>".format(

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -70,7 +70,7 @@ class DocWebHandler(object):
 			# Authorization
 			"components": {
 				"securitySchemes": {
-					"oAuthSample": {
+					"oAuth": {
 						"type": "oauth2",
 						"description": "",
 						"flows": {
@@ -89,7 +89,7 @@ class DocWebHandler(object):
 
 		# Gets all the scopes from config and puts them into scopes
 		for scope in self.Scopes:
-			specs["components"]["securitySchemes"]["oAuthSample"]["flows"]["authorizationCode"]["scopes"].update({scope: "{} scope.".format(scope.strip().capitalize())})
+			specs["components"]["securitySchemes"]["oAuth"]["flows"]["authorizationCode"]["scopes"].update({scope: "{} scope.".format(scope.strip().capitalize())})
 
 		# Version from MANIFEST.json
 		if self.Manifest:

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -69,6 +69,7 @@ class DocWebHandler(object):
 		for route in self.WebContainer.WebApp.router.routes():
 			if route.method == 'HEAD':
 				# Skip HEAD methods
+				# TODO: once/if there is graphql, its method name is probably `*`
 				continue
 
 			parameters = []
@@ -97,8 +98,21 @@ class DocWebHandler(object):
 				specs['paths'][path] = pathobj = {}
 
 			if inspect.ismethod(route.handler):
-				handler_name = "{}.{}()".format(route.handler.__self__.__class__.__name__, route.handler.__name__)
-				docstr = route.handler.__doc__
+				if route.handler.__name__ == "validator":
+					json_schema = route.handler.__getattribute__("json_schema")
+					docstr = route.handler.__getattribute__("func").__doc__
+					parameters.append({
+						'in': 'body',
+						'name': 'body',
+						'required': True,
+						'schema': json_schema
+					})
+					handler_name = "{}.{}()".format(route.handler.__self__.__class__.__name__, route.handler.__getattribute__("func").__name__)
+
+				else:
+					handler_name = "{}.{}()".format(route.handler.__self__.__class__.__name__, route.handler.__name__)
+					docstr = route.handler.__doc__
+
 			else:
 				handler_name = str(route.handler)
 				docstr = route.handler.__doc__

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -3,6 +3,7 @@ import logging
 import inspect
 
 import aiohttp
+import aiohttp.web
 import yaml
 
 ##
@@ -19,6 +20,7 @@ class DocWebHandler(object):
 		self.App = app
 		self.WebContainer = web_container
 		self.WebContainer.WebApp.router.add_get('/doc', self.doc)
+		self.WebContainer.WebApp.router.add_get('/oauth2-redirect.html', self.oauth2_redirect)
 		self.WebContainer.WebApp.router.add_get('/asab/v1/openapi', self.openapi)
 
 
@@ -66,11 +68,13 @@ class DocWebHandler(object):
 						"type": "oauth2",
 						"description": "This API uses OAuth 2, this window allows [links](https://teskalabs.com)",
 						"flows": {
-							"implicit": {
-								"authorizationUrl": "",
+							"authorizationCode": {
+								"authorizationUrl": "https://auth.test.loc/seacat/api/openidconnect/authorize",
+								"tokenUrl": "https://auth.test.loc/seacat/api/openidconnect/token",
 								"scopes": {
 									"write_stuff": "modify stuff :D",
 									"read_stuff": "read stuff :DD",
+									"openid": "openid",
 								}
 							}
 						}
@@ -218,6 +222,94 @@ window.onload = () => {{
 			openapi_url="./asab/v1/openapi",
 		)
 
+		return aiohttp.web.Response(text=page, content_type="text/html")
+
+
+	def oauth2_redirect(self, request):
+		"""
+		Required for the authorization to work.
+		---
+		tags: ['asab.doc']
+		"""
+		page = """<!doctype html>
+<html lang="en-US">
+<head>
+	<title>Swagger UI: OAuth2 Redirect</title>
+</head>
+<body>
+<script>
+	'use strict';
+	function run () {
+		var oauth2 = window.opener.swaggerUIRedirectOauth2;
+		var sentState = oauth2.state;
+		var redirectUrl = oauth2.redirectUrl;
+		var isValid, qp, arr;
+
+		if (/code|token|error/.test(window.location.hash)) {
+			qp = window.location.hash.substring(1);
+		} else {
+			qp = location.search.substring(1);
+		}
+
+		arr = qp.split("&");
+		arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+		qp = qp ? JSON.parse('{' + arr.join() + '}',
+				function (key, value) {
+					return key === "" ? value : decodeURIComponent(value);
+				}
+		) : {};
+
+		isValid = qp.state === sentState;
+
+		if ((
+			oauth2.auth.schema.get("flow") === "accessCode" ||
+			oauth2.auth.schema.get("flow") === "authorizationCode" ||
+			oauth2.auth.schema.get("flow") === "authorization_code"
+		) && !oauth2.auth.code) {
+			if (!isValid) {
+				oauth2.errCb({
+					authId: oauth2.auth.name,
+					source: "auth",
+					level: "warning",
+					message: "Authorization may be unsafe, passed state was changed in server. The passed state wasn't returned from auth server."
+				});
+			}
+
+			if (qp.code) {
+				delete oauth2.state;
+				oauth2.auth.code = qp.code;
+				oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+			} else {
+				let oauthErrorMsg;
+				if (qp.error) {
+					oauthErrorMsg = "["+qp.error+"]: " +
+						(qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+						(qp.error_uri ? "More info: "+qp.error_uri : "");
+				}
+
+				oauth2.errCb({
+					authId: oauth2.auth.name,
+					source: "auth",
+					level: "error",
+					message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server."
+				});
+			}
+		} else {
+			oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+		}
+		window.close();
+	}
+
+	if (document.readyState !== 'loading') {
+		run();
+	} else {
+		document.addEventListener('DOMContentLoaded', function () {
+			run();
+		});
+	}
+</script>
+</body>
+</html>"""
 		return aiohttp.web.Response(text=page, content_type="text/html")
 
 

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -156,7 +156,7 @@ class DocWebHandler(object):
 	# This is the web request handler
 	async def doc(self, request):
 		'''
-		Acces the API documentation using a browser.
+		Access the API documentation using a browser.
 		---
 		tags: ['asab.doc']
 		'''

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -98,6 +98,7 @@ class DocWebHandler(object):
 				continue
 
 			parameters = []
+			methoddict = {}
 
 			route_info = route.get_info()
 			if "path" in route_info:
@@ -134,12 +135,14 @@ class DocWebHandler(object):
 				if route.handler.__name__ == "validator":
 					json_schema = route.handler.__getattribute__("json_schema")
 					docstr = route.handler.__getattribute__("func").__doc__
-					parameters.append({
-						'in': 'body',
-						'name': 'body',
-						'required': True,
-						'schema': json_schema
-					})
+
+					methoddict["requestBody"] = {
+						"content": {
+							"application/json": {
+								"schema": json_schema
+							}
+						},
+					}
 					handler_name = "{}.{}()".format(route.handler.__self__.__class__.__name__, route.handler.__getattribute__("func").__name__)
 
 				else:
@@ -168,14 +171,14 @@ class DocWebHandler(object):
 
 			description += '\n\nHandler: `{}`'.format(handler_name)
 
-			methoddict = {
+			methoddict.update({
 				'summary': description.split("\n")[0],
 				'description': description,
 				'tags': ['general'],
 				'responses': {
 					'200': {'description': 'Success'}
-				}
-			}
+				},
+			})
 
 			if len(parameters) > 0:
 				methoddict['parameters'] = parameters

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -52,7 +52,7 @@ class DocWebHandler(object):
 				"description": description,
 				"contact": {
 					"name": "ASAB microservice",
-					"url": "http://www.github.com/teskalabs/asab",
+					"url": "https://www.github.com/teskalabs/asab",
 				},
 				"version": "1.0.0"
 			},

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -88,9 +88,8 @@ class DocWebHandler(object):
 		}
 
 		# Show what server/docker container you are on, and it's IP
-		for server in self.WebContainer.Addresses:
-			specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}:{}</strong>".format(
-				self.App.ServerName, server[0], server[1]) + "<p>{}</p>".format(description))
+		specs["info"]["description"] = ("Current Server: <strong>{}</strong> on: <strong>{}</strong>".format(
+			self.App.ServerName, self.WebContainer.Addresses) + "<p>{}</p>".format(description))
 		# specs["servers"].append({"url": "http://{}:{}".format(server[0], server[1])})
 
 		if adddict is not None:

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -39,7 +39,7 @@ class DocWebHandler(object):
 				try:
 					adddict = yaml.load(docstr[i:], Loader=yaml.SafeLoader)
 				except yaml.YAMLError as e:
-						L.error("Failed to parse '{}' doc string {}".format(self.App.__class__.__name__, e))
+					L.error("Failed to parse '{}' doc string {}".format(self.App.__class__.__name__, e))
 			else:
 				description = docstr
 		else:
@@ -56,14 +56,10 @@ class DocWebHandler(object):
 				},
 				"version": "1.0.0"
 			},
-			"servers": [],  # Base path relative to openapi endpoint
+			"servers": [{"url": "../../"}],  # Base path relative to openapi endpoint
 			"paths": {
 			},
 		}
-
-		# Add servers to specs
-		for server in self.WebContainer.Addresses:
-			specs["servers"].append({"url": "{} ({}:{})".format(self.App.ServerName, server[0], server[1])})
 
 		if adddict is not None:
 			specs.update(adddict)

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -4,7 +4,6 @@ import json
 import datetime
 import logging
 
-
 from .. import Service, Config
 from ..docker import running_in_docker
 from .web_handler import APIWebHandler
@@ -14,6 +13,7 @@ from .doc import DocWebHandler
 ##
 
 L = logging.getLogger(__name__)
+
 
 ##
 
@@ -64,7 +64,6 @@ class ApiService(Service):
 			self.ChangeLog = path
 		else:
 			self.ChangeLog = None
-
 
 		self.App.PubSub.subscribe("WebContainer.started!", self._on_webcontainer_start)
 		self.App.PubSub.subscribe("ZooKeeperContainer.started!", self._on_zkcontainer_start)
@@ -130,7 +129,7 @@ class ApiService(Service):
 
 		self.WebHandler = APIWebHandler(self, self.WebContainer.WebApp, self.APILogHandler)
 
-		self.DocWebHandler = DocWebHandler(self.App, self.WebContainer)
+		self.DocWebHandler = DocWebHandler(self, self.App, self.WebContainer)
 
 		# If asab.MetricsService is available, initialize its web handler
 		metrics_svc = self.App.get_service("asab.MetricsService")
@@ -198,6 +197,7 @@ class ApiService(Service):
 	def _on_webcontainer_start(self, message_type, container):
 		if container == self.WebContainer:
 			self._do_zookeeper_adv_data()
+
 
 	def _on_zkcontainer_start(self, message_type, container):
 		if container == self.ZkContainer:

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -257,7 +257,7 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 
 		form_content_types = frozenset(['', 'application/x-www-form-urlencoded', 'multipart/form-data'])
 
-		async def validator(json_schema, *args, **kwargs):
+		async def validator(*args, **kwargs):
 			# Initializing fastjsonschema.compile method and generating
 			# the validation function for validating JSON schema
 			request = args[-1]

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -257,7 +257,7 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 
 		form_content_types = frozenset(['', 'application/x-www-form-urlencoded', 'multipart/form-data'])
 
-		async def validator(*args, **kwargs):
+		async def validator(json_schema, *args, **kwargs):
 			# Initializing fastjsonschema.compile method and generating
 			# the validation function for validating JSON schema
 			request = args[-1]
@@ -282,6 +282,10 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 				raise e
 
 			return await func(*args, **kwargs)
+
+		# This is here for Swagger documentation
+		setattr(validator, 'json_schema', json_schema)
+		setattr(validator, 'func', func)
 
 		return validator
 

--- a/doc/asab/web/restapidocs.rst
+++ b/doc/asab/web/restapidocs.rst
@@ -1,0 +1,69 @@
+REST API Docs
+==============
+
+ASAB's API service generates a `Swagger documentation <https://swagger.io/specification>`_ which automatically shows all
+of your endpoints. However you will need to follow some steps to add summaries, tags and more
+
+Before you start, make sure that you have a `REST API webserver <https://asab.readthedocs.io/en/latest/tutorial/web/chapter1.html>`_.
+
+If you want Authorization in Swagger, you will need a OpenIDConnect endpoint.
+
+In your microservice
+-----------
+
+First you need to initialize the API Service:
+
+.. code-block:: python
+
+    # Initialize API service
+    self.ApiService = asab.api.ApiService(self)
+
+    # Introduce Web to API Service
+    self.ApiService.initialize_web()
+
+If you want Authorization to work you will need to initialize the Authz service as well:
+
+.. code-block:: python
+
+    self.AuthzService = asab.web.authz.AuthzService(self)
+    self.AuthzService.OAuth2Url = "http://localhost:8081/openidconnect"
+    self.WebContainer.WebApp.middlewares.append(asab.web.authz.authz_middleware_factory(self, self.AuthzService))
+
+After initializing the API Service a **/doc** endpoint will become available. You will notice
+that some or none of your endpoints have summaries, tags or descriptions.
+
+That's because you need to add a docstring to the endpoint function:
+
+.. code-block:: python
+
+    async def endpoint(self, request):
+        """
+        Summary looks like this and takes the first line from docstring.
+
+        Description of what this endpoint does.
+
+        ---
+        tags: [asab.mymicroservice]
+        """
+
+The first line of the docstring gets shown as a summary next to the endpoint in Swagger.
+There are also extra parameters you can set like tags, which work like categories.
+
+Authorization in Swagger
+-----------
+TODO..
+
+Authorization requires having a OpenIDConnect endpoint (like SeaCat).
+
+Configuration
+-----------
+TODO..
+
+You need to put this in config etc. supports adding scopes etc.
+
+.. code-block:: ini
+
+    [asab:doc]
+    authorizationUrl=http://localhost/seacat/api/openidconnect/authorize
+    tokenUrl=http://localhost/seacat/api/openidconnect/token
+    scopes=read,write

--- a/doc/asab/web/restapidocs.rst
+++ b/doc/asab/web/restapidocs.rst
@@ -2,9 +2,9 @@ REST API Docs
 ==============
 
 ASAB's API service generates a `Swagger documentation <https://swagger.io/specification>`_ which automatically shows all
-of your endpoints. However you will need to follow some steps to add summaries, tags and more
+of your endpoints. However you will need to follow some steps to add summaries, tags and more.
 
-Before you start, make sure that you have a `REST API webserver <https://asab.readthedocs.io/en/latest/tutorial/web/chapter1.html>`_.
+Before you start, make sure that you have a `REST API microservice <https://asab.readthedocs.io/en/latest/tutorial/web/chapter2.html>`_.
 
 If you want Authorization in Swagger, you will need a OpenIDConnect endpoint.
 
@@ -21,18 +21,10 @@ First you need to initialize the API Service:
     # Introduce Web to API Service
     self.ApiService.initialize_web()
 
-If you want Authorization to work you will need to initialize the Authz service as well:
-
-.. code-block:: python
-
-    self.AuthzService = asab.web.authz.AuthzService(self)
-    self.AuthzService.OAuth2Url = "http://localhost:8081/openidconnect"
-    self.WebContainer.WebApp.middlewares.append(asab.web.authz.authz_middleware_factory(self, self.AuthzService))
-
 After initializing the API Service a **/doc** endpoint will become available. You will notice
 that some or none of your endpoints have summaries, tags or descriptions.
 
-That's because you need to add a docstring to the endpoint function:
+That's because you need to add a docstring to your endpoint method:
 
 .. code-block:: python
 
@@ -49,21 +41,67 @@ That's because you need to add a docstring to the endpoint function:
 The first line of the docstring gets shown as a summary next to the endpoint in Swagger.
 There are also extra parameters you can set like tags, which work like categories.
 
+The description of the microservice also needs a docstring for it to show up:
+
+.. code-block:: python
+
+    class TutorialApp(asab.Application):
+        """
+        TutorialApp is the best microservice in the world!
+
+        <marquee>The description supports HTML tags</marquee>
+        """
+
 Authorization in Swagger
 -----------
-TODO..
+Authorization requires having an OpenIDConnect endpoint with an Authorization and Token endpoint (like SeaCat).
 
-Authorization requires having a OpenIDConnect endpoint (like SeaCat).
+First initialize the Authz service in your microservice:
+
+.. code-block:: python
+
+    self.AuthzService = asab.web.authz.AuthzService(self)
+    self.AuthzService.OAuth2Url = "http://localhost:8081/openidconnect"
+    self.WebContainer.WebApp.middlewares.append(asab.web.authz.authz_middleware_factory(self, self.AuthzService))
+
+Setting the OAuth2Url is important, otherwise authorization will not work.
+
+You need to add an Authz header above at the endpoint method:
+
+.. code-block:: python
+
+    @asab.web.authz.required("resource:topsecret")
+    async def top_secret_endpoint(self, request):
+
+Then add the Authorization and Token endpoints into your `config <#configuration>`_.
+
+After setting up Authorization, a green `Authorize` button will appear. Authorizing will add a bearer token to every
+request you do inside Swagger. You will get unauthorized if you refresh the page.
+
+If it does not add a bearer token, or it does not authorize you at all, retrace your steps and try again.
 
 Configuration
 -----------
-TODO..
+Some parts of Swagger can be changed with this configuration.
 
-You need to put this in config etc. supports adding scopes etc.
+For authorization you will need to add a `authorizationUrl` and `tokenUrl`:
 
 .. code-block:: ini
 
     [asab:doc]
-    authorizationUrl=http://localhost/seacat/api/openidconnect/authorize
-    tokenUrl=http://localhost/seacat/api/openidconnect/token
+    authorizationUrl=http://localhost:8080/openidconnect/authorize
+    tokenUrl=http://localhost:8080/openidconnect/token
+
+If you have an endpoint that requires a scope, you can add it with the configuration file:
+
+.. code-block:: ini
+
+    [asab:doc]
     scopes=read,write
+
+You can change the version tag that shows next to the name of your microservice:
+
+.. code-block:: ini
+
+    [asab:doc]
+    version=1.0.0

--- a/doc/asab/web/restapidocs.rst
+++ b/doc/asab/web/restapidocs.rst
@@ -2,11 +2,9 @@ REST API Docs
 ==============
 
 ASAB's API service generates a `Swagger documentation <https://swagger.io/specification>`_ which automatically shows all
-of your endpoints. However you will need to follow some steps to add summaries, tags and more.
+of your endpoints and you can add summaries, descriptions, tags and more.
 
-Before you start, make sure that you have a `REST API microservice <https://asab.readthedocs.io/en/latest/tutorial/web/chapter2.html>`_.
-
-If you want Authorization in Swagger, you will need a OpenIDConnect endpoint.
+If you want Authorization in Swagger docs, you will need an OpenIDConnect endpoint.
 
 In your microservice
 -----------
@@ -38,10 +36,7 @@ That's because you need to add a docstring to your endpoint method:
         tags: [asab.mymicroservice]
         """
 
-The first line of the docstring gets shown as a summary next to the endpoint in Swagger.
-There are also extra parameters you can set like tags, which work like categories.
-
-The description of the microservice also needs a docstring for it to show up:
+Also by adding a docstring to your ASAB Application, a description will be automatically added to the top of the Swagger docs:
 
 .. code-block:: python
 
@@ -54,35 +49,32 @@ The description of the microservice also needs a docstring for it to show up:
 
 Authorization in Swagger
 -----------
-Authorization requires having an OpenIDConnect endpoint with an Authorization and Token endpoint (like SeaCat).
+Authorization requires making an OpenIDConnect endpoint with an Authorization and Token endpoint (like with using `SeaCat Auth <https://github.com/TeskaLabs/seacat-auth>`_).
 
-First initialize the Authz service in your microservice:
+After your endpoint has authorization, `here's an example <https://github.com/TeskaLabs/asab/blob/master/examples/web-authz-userinfo.py>`_,
+add the Authorization and Token endpoints into your `config <#configuration>`_.
 
-.. code-block:: python
-
-    self.AuthzService = asab.web.authz.AuthzService(self)
-    self.AuthzService.OAuth2Url = "http://localhost:8081/openidconnect"
-    self.WebContainer.WebApp.middlewares.append(asab.web.authz.authz_middleware_factory(self, self.AuthzService))
-
-Setting the OAuth2Url is important, otherwise authorization will not work.
-
-You need to add an Authz header above at the endpoint method:
+For the authorization bearer token to be added to the request, a scope is needed to be put into the security parameter in a docstring.
+It does not matter what it is called or if it exists, but it's needed to be there. But "`- oAuth:`" always needs to be there.
 
 .. code-block:: python
 
     @asab.web.authz.required("resource:topsecret")
     async def top_secret_endpoint(self, request):
+        """
+        Top secret!
 
-Then add the Authorization and Token endpoints into your `config <#configuration>`_.
+        ---
+        tags: [asab.coolestmicroservice]
+        security:
+            - oAuth:
+                - read
+        """
 
-After setting up Authorization, a green `Authorize` button will appear. Authorizing will add a bearer token to every
-request you do inside Swagger. You will get unauthorized if you refresh the page.
-
-If it does not add a bearer token, or it does not authorize you at all, retrace your steps and try again.
+After setting up Authorization, a green `Authorize` button should appear in the Swagger docs.
 
 Configuration
 -----------
-Some parts of Swagger can be changed with this configuration.
 
 For authorization you will need to add a `authorizationUrl` and `tokenUrl`:
 
@@ -98,10 +90,3 @@ If you have an endpoint that requires a scope, you can add it with the configura
 
     [asab:doc]
     scopes=read,write
-
-You can change the version tag that shows next to the name of your microservice:
-
-.. code-block:: ini
-
-    [asab:doc]
-    version=1.0.0

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 .. ASAB documentation master file, created by
-   sphinx-quickstart on Sat Mar  3 23:48:03 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+sphinx-quickstart on Sat Mar  3 23:48:03 2018.
+You can adapt this file completely to your liking, but it should at least
+contain the root `toctree` directive.
 
 .. include:: asab/index.rst
 
@@ -18,6 +18,7 @@
    :caption: Services
 
    asab/web/index
+   asab/web/restapidocs
    asab/web/authn
    asab/web/cors
    asab/mom/index


### PR DESCRIPTION
I did some voodoo, so there's a `json_schema` passed to swagger from the `json_schema_handler` decorator. Especially helpful in POST requests. 

I had troubles to write valid yaml into docstring when using tabs as indentation - because yaml did not read tabs and flake8 doesn't allow me to use spaces in the docstring instead.

swagger example: https://editor.swagger.io/

@ateska 
I guess that `Servers` and `Authorize` features should be added?
And anything more is up to @antoninvondrovic freestyle?

And some refactoring extracting some more functions instead of all the if/else might be needed. :) 