### PR TITLE
in_docker selfawareness with cgroup v2

### DIFF
--- a/asab/docker/__init__.py
+++ b/asab/docker/__init__.py
@@ -24,12 +24,22 @@ Config.add_defaults(
 
 
 def running_in_docker():
-	in_docker = os.path.exists('/.dockerenv') or os.path.isfile('/proc/self/cgroup')
-	if in_docker:
+	# if os.path.exists('/.dockerenv'):
+	# 	# when is this true??
+	# 	return True
+
+	if os.path.isfile('/proc/self/cgroup'):
 		with open('/proc/self/cgroup', "r") as f:
-			if not any('docker' in line for line in f.readlines()):
-				in_docker = False
-	return in_docker
+			if any('docker' in line for line in f.readlines()):
+				return True
+
+	# since Ubuntu 22.04 linux kernel uses cgroups v2 which do not operate with /proc/self/cgroup file
+	if os.path.isfile('/proc/self/mountinfo'):
+		with open('/proc/self/mountinfo', "r") as f:
+			if any('docker' in line for line in f.readlines()):
+				return True
+
+	return False
 
 
 class Module(Module):

--- a/asab/docker/__init__.py
+++ b/asab/docker/__init__.py
@@ -24,19 +24,16 @@ Config.add_defaults(
 
 
 def running_in_docker():
-	# if os.path.exists('/.dockerenv'):
-	# 	# when is this true??
-	# 	return True
 
-	if os.path.isfile('/proc/self/cgroup'):
+	if os.path.exists('/.dockerenv') and os.path.isfile('/proc/self/cgroup'):
 		with open('/proc/self/cgroup', "r") as f:
 			if any('docker' in line for line in f.readlines()):
 				return True
 
 	# since Ubuntu 22.04 linux kernel uses cgroups v2 which do not operate with /proc/self/cgroup file
-	if os.path.isfile('/proc/self/mountinfo'):
+	if os.path.exists('/.dockerenv') and os.path.isfile('/proc/self/mountinfo'):
 		with open('/proc/self/mountinfo', "r") as f:
-			if any('docker' in line for line in f.readlines()):
+			if any('docker/container' in line for line in f.readlines()):
 				return True
 
 	return False

--- a/asab/docker/service.py
+++ b/asab/docker/service.py
@@ -58,8 +58,9 @@ def get_docker_container_id():
 	if os.path.isfile('/proc/self/cgroup'):
 		with open('/proc/self/cgroup', "r") as f:
 			cgroup = f.read()
-			container_id = cgroup.split("/docker/")[1].split("\n")[0]
-			return container_id
+			if any('docker' in line for line in cgroup):
+				container_id = cgroup.split("/docker/")[1].split("\n")[0]
+				return container_id
 
 	# since Ubuntu 22.04 linux kernel uses cgroups v2 which do not operate with /proc/self/cgroup file
 	if os.path.isfile('/proc/self/mountinfo'):

--- a/asab/docker/service.py
+++ b/asab/docker/service.py
@@ -42,11 +42,13 @@ class DockerService(Service):
 			return
 
 		docker_info = call_docker_api(container_id)
+		L.warning("docker_info: {}".format(docker_info))
 		container_name = docker_info.get("Name")
 
 		if docker_info or container_name is None:
 			L.warning("Docker API does not provide container name. Using container ID as hostname.")
 			self.ContainerName = container_id
+			self.ServerName = self.App.Hostname
 			return
 
 		self.ContainerName = container_name.lstrip("/")
@@ -112,6 +114,7 @@ def get_api_address_from_config():
 			configsection = "asab:docker"
 			L.warning("Using obsolete config section [asab:docker]. Preferred section name is [docker]")
 
+	L.warning("docker socket: {}".format(Config.get(configsection, "socket")))
 	return Config.get(configsection, "socket")
 
 

--- a/asab/docker/service.py
+++ b/asab/docker/service.py
@@ -45,10 +45,10 @@ class DockerService(Service):
 		L.warning("docker_info: {}".format(docker_info))
 		container_name = docker_info.get("Name")
 
-		if docker_info or container_name is None:
+		if container_name is None:
 			L.warning("Docker API does not provide container name. Using container ID as hostname.")
 			self.ContainerName = container_id
-			self.ServerName = self.App.Hostname
+			self.ServerName = self.App.HostName
 			return
 
 		self.ContainerName = container_name.lstrip("/")

--- a/asab/docker/service.py
+++ b/asab/docker/service.py
@@ -27,7 +27,7 @@ class DockerService(Service):
 	def load_hostname(self):
 		hostname = platform.node()
 		if self.ContainerName is not None:
-			hostname = "{}".format(self.ContainerName)
+			hostname = self.ContainerName
 		else:
 			L.warning("Failed to obtain docker container name from Docker API.")
 		return hostname
@@ -42,15 +42,14 @@ class DockerService(Service):
 			return
 
 		docker_info = call_docker_api(container_id)
-		L.warning("docker_info: {}".format(docker_info))
-		container_name = docker_info.get("Name")
 
-		if container_name is None:
+		if docker_info is None:
 			L.warning("Docker API does not provide container name. Using container ID as hostname.")
 			self.ContainerName = container_id
 			self.ServerName = self.App.HostName
 			return
 
+		container_name = docker_info.get("Name")
 		self.ContainerName = container_name.lstrip("/")
 		self.ServerName = docker_info.get("Config").get("Hostname")
 
@@ -114,7 +113,6 @@ def get_api_address_from_config():
 			configsection = "asab:docker"
 			L.warning("Using obsolete config section [asab:docker]. Preferred section name is [docker]")
 
-	L.warning("docker socket: {}".format(Config.get(configsection, "socket")))
 	return Config.get(configsection, "socket")
 
 

--- a/asab/docker/service.py
+++ b/asab/docker/service.py
@@ -1,6 +1,7 @@
 import socket
 import platform
 import logging
+import os
 
 import http.client
 import json
@@ -35,58 +36,83 @@ class DockerService(Service):
 		return self.ServerName
 
 	def get_docker_info(self):
-		configsection = "docker"
-		if configsection not in Config.sections():
-			# Remove after Jun 2023
-			if "asab:docker" in Config.sections():
-				configsection = "asab:docker"
-				L.warning("Using obsolete config section [asab:docker]. Preferred section name is [docker]")
+		container_id = get_docker_container_id()
+		if container_id is None:
+			L.warning("Failed to obtain docker container ID from cgroup.")
+			return
 
-		remote_api = Config.get(configsection, "socket")
-		if len(remote_api) > 0:
-			# In docker, hostname defaults to container ID
-			# It is necessary to use container name for better readability of the metrics
-			try:
+		docker_info = call_docker_api(container_id)
+		container_name = docker_info.get("Name")
 
-				if remote_api.startswith("https://"):
-					conn = http.client.HTTPSConnection(remote_api.replace("https://", ""))
-				elif remote_api.startswith("http://"):
-					conn = http.client.HTTPConnection(remote_api.replace("http://", ""))
-				else:
-					conn = HTTPUnixConnection(remote_api)
+		if docker_info or container_name is None:
+			L.warning("Docker API does not provide container name. Using container ID as hostname.")
+			self.ContainerName = container_id
+			return
 
-				# TODO: Make more elegant
-				with open("/proc/self/cgroup", "r") as cgroup_file:
-					cgroup = cgroup_file.read()
-				conn.request("GET", "http://localhost/containers/{}/json".format(
-					cgroup.split("/docker/")[1].split("\n")[0]
-				))
+		self.ContainerName = container_name.lstrip("/")
+		self.ServerName = docker_info.get("Config").get("Hostname")
 
-				docker_info_request = conn.getresponse()
-				if docker_info_request.status != 200:
-					L.warning(
-						"Docker API call at '{}' failed.".format(remote_api),
-						struct_data={'status': docker_info_request.status}
-					)
-					return
 
-			except Exception as e:
-				L.warning("Connection to Docker API could not be established: '{}'.".format(e))
-				return
+def get_docker_container_id():
+	if os.path.isfile('/proc/self/cgroup'):
+		with open('/proc/self/cgroup', "r") as f:
+			cgroup = f.read()
+			container_id = cgroup.split("/docker/")[1].split("\n")[0]
+			return container_id
 
-			docker_info_data = docker_info_request.read()
-			docker_info = json.loads(docker_info_data.decode("utf-8"))
-			container_name = docker_info.get("Name")
-			if container_name is None:
-				L.warning("Docker API does not provide container name. Using container ID as hostname.")
-				return
+	# since Ubuntu 22.04 linux kernel uses cgroups v2 which do not operate with /proc/self/cgroup file
+	if os.path.isfile('/proc/self/mountinfo'):
+		with open('/proc/self/mountinfo', "r") as f:
+			for line in f.readlines():
+				if '/docker/containers/' in line:
+					container_id = line.split('/docker/containers/')[-1]
+					container_id = container_id.split('/')[0]
+					return container_id
 
-			# Store the container name in tags as host
-			if container_name.startswith("/"):
-				self.ContainerName = container_name[1:]
 
-			# ServerName is also good to know
-			self.ServerName = docker_info.get("Config").get("Hostname")
+def call_docker_api(container_id):
+	remote_api = get_api_address_from_config()
+	if len(remote_api) == 0:
+		return
+	if remote_api.startswith("https://"):
+		conn = http.client.HTTPSConnection(remote_api.replace("https://", ""))
+	elif remote_api.startswith("http://"):
+		conn = http.client.HTTPConnection(remote_api.replace("http://", ""))
+	else:
+		conn = HTTPUnixConnection(remote_api)
+
+	try:
+		conn.request("GET", "http://localhost/containers/{}/json".format(container_id))
+
+		docker_info = conn.getresponse()
+		if docker_info.status != 200:
+			L.warning(
+				"Docker API call at '{}' failed.".format(remote_api),
+				struct_data={'status': docker_info.status}
+			)
+			return
+
+	except Exception as e:
+		L.warning("Connection to Docker API could not be established: '{}'.".format(e))
+		return
+
+	docker_info_data = docker_info.read()
+	docker_info = json.loads(docker_info_data.decode("utf-8"))
+
+	return docker_info
+
+
+
+
+def get_api_address_from_config():
+	configsection = "docker"
+	if configsection not in Config.sections():
+		# Remove after Jun 2023
+		if "asab:docker" in Config.sections():
+			configsection = "asab:docker"
+			L.warning("Using obsolete config section [asab:docker]. Preferred section name is [docker]")
+
+	return Config.get(configsection, "socket")
 
 
 


### PR DESCRIPTION
- With Ubuntu 22.04, **cgroup v2** is being used instead of cgroup v1. 
- cgroup v2 does not use `/proc/self/cgroup` file to store info about the group
- instead it is possible to find "docker/container/<container_id>" piece of information in `/proc/self/mountinfo`
- Unfortunately, this information somehow propagated from my governator docker container outside the container into the same file on my computer. (Don't know what that means.) 
- Thus, distinguishing whether the process is running in docker or not is dependent on `/.dockerenv` file. However, as some clever guy on [StackOverflow](https://superuser.com/questions/1021834/what-are-dockerenv-and-dockerinit) noted, this file is empty, and God knows why it is still there and when it disappears.
- **Needs to be tested across multiple environments before merge.**
- ...and I can't wait to discard this functionality from asab for good. It is getting more evil than ever.
