### PR TITLE
WIP: Fix GitProvider

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -134,16 +134,11 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 
 	def pull(self):
-		'''
-		Emulates `git pull` command.
-		'''
-		commit_id = self.fetch()
-		self.GitRepository.merge(commit_id)
 
-	async def list(self, path: str) -> list:
-		# Keep in mind this magical update before every `list` when implementing the GitProvider
-		await self.ProactorService.execute(self.pull)
-		return await super().list(path)
+		commit_id = self.fetch()
+
+		self.GitRepository.head.set_target(commit_id)
+		self.GitRepository.reset(commit_id, pygit2.GIT_RESET_HARD)
 
 
 def get_git_credentials(url):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -135,10 +135,14 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 	def pull(self):
 
-		commit_id = self.fetch()
+		new_commit_id = self.fetch()
 
-		self.GitRepository.head.set_target(commit_id)
-		self.GitRepository.reset(commit_id, pygit2.GIT_RESET_HARD)
+		if new_commit_id == self.GitRepository.head.target:
+			return
+
+		self.GitRepository.head.set_target(new_commit_id)
+		self.GitRepository.reset(new_commit_id, pygit2.GIT_RESET_HARD)
+		self.App.PubSub.publish("GitProviderUpdated!", self)
 
 
 def get_git_credentials(url):


### PR DESCRIPTION
- Merge was a stupid idea.
- I'm not sure whether passing the reference and removing changes from work_dir by reset hard is a good choice, but much better. And Přemek-proof. 
- Pulling before the listing is stupid because the library service does recursive listing.
- Where is the "spot" in the library service to integrate the update indication? 
- Fetching once in a minute is... There will always be one-minute lag when updating the repository. And there is no way how to invoke the changes - how to make the provider fetch now and not in a minute.
- `pull` is not really "pull" now. 