### PR TITLE
EPSCounter fix

### DIFF
--- a/asab/metrics/metrics.py
+++ b/asab/metrics/metrics.py
@@ -112,6 +112,9 @@ class EPSCounter(Counter):
 	def __init__(self, init_values=None):
 		super().__init__(init_values=init_values)
 		self.LastTime = time.time()
+		for v in self.Init.values():
+			assert isinstance(v, (int, float))
+		self.Init = {k: float(v) for k, v in self.Init.items()}
 
 	def flush(self, now):
 

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -31,7 +31,7 @@ class MetricsService(Service):
 		}
 		self.Storage = Storage()
 
-		app.PubSub.subscribe("Application.tick/60!", self._on_flushing_event)
+		app.PubSub.subscribe("Application.tick!", self._on_flushing_event)
 
 		if Config.has_option('asab:metrics', 'target'):
 			for target in Config.get('asab:metrics', 'target').split():

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -31,7 +31,7 @@ class MetricsService(Service):
 		}
 		self.Storage = Storage()
 
-		app.PubSub.subscribe("Application.tick!", self._on_flushing_event)
+		app.PubSub.subscribe("Application.tick/60!", self._on_flushing_event)
 
 		if Config.has_option('asab:metrics', 'target'):
 			for target in Config.get('asab:metrics', 'target').split():


### PR DESCRIPTION
```
07-Sep-2022 09:37:37.365540 WARNING asab.metrics.influxdb Error when sending metrics to Influx: 400
 {"error":"partial write: field type conflict: input field \"[eps.in](http://eps.in/)\" on measurement \"bspump.pipeline.eps\" is type integer, already exists as type float dropped=8"}
```

This is weird to me. 

Values in EPSCounter can never be `int` as there is line 129 dividing value by delta time and 0/`float` = 0.0, even 1/1 = 1.0. So where is the `int` coming from? The only possible way I can see right now is the `return` on line 123. But how... do they have some time machine there? I can't see it as possible. 