### PR TITLE
WebSocket Factory refactoring

### DIFF
--- a/asab/web/websocket.py
+++ b/asab/web/websocket.py
@@ -110,10 +110,10 @@ class WebSocketFactory(object):
 		L.log(LOG_NOTICE, "Websocket connection accepted")
 
 		wsid = await self.register(ws, request)
-		await self.on_connect(ws)
 
 		try:
 			self.WebSockets[wsid] = ws
+			await self.on_connect(ws, wsid)
 
 			async for msg in ws:
 				if msg.type == aiohttp.WSMsgType.ERROR:
@@ -142,7 +142,7 @@ class WebSocketFactory(object):
 		return self.Counter
 
 
-	async def on_connect(self, ws):
+	async def on_connect(self, websocket, wsid):
 		'''
 		Override this method to implement action on websocket connection
 		'''

--- a/asab/web/websocket.py
+++ b/asab/web/websocket.py
@@ -109,7 +109,8 @@ class WebSocketFactory(object):
 
 		L.log(LOG_NOTICE, "Websocket connection accepted")
 
-		wsid = await self.on_connect(ws, request)
+		wsid = await self.register(ws, request)
+		await self.on_connect(ws)
 
 		try:
 			self.WebSockets[wsid] = ws
@@ -131,7 +132,7 @@ class WebSocketFactory(object):
 		return ws
 
 
-	async def on_connect(self, ws, request):
+	async def register(self, ws, request):
 		'''
 		Must return the unique identifier of the websocket `wsid`.
 		The default implementation is the unique counter.
@@ -139,6 +140,13 @@ class WebSocketFactory(object):
 		'''
 		self.Counter += 1
 		return self.Counter
+
+
+	async def on_connect(self, ws):
+		'''
+		Override this method to implement action on websocket connection
+		'''
+		pass
 
 
 	async def on_message(self, websocket, message, wsid):


### PR DESCRIPTION
I wanted to make some action when websocket connects, but overriding the `on_connect` method, I accidentally removed websocket "registration" - getting wsid. It was stupid and I could fix it in my implementation but maybe this could prevent someone else doing the same mistake.