### PR TITLE
Storage: Accept multiple webhook URIs

### DIFF
--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -205,6 +205,6 @@ class MongoDBUpsertor(UpsertorABC):
 				upsertor_data["unset"] = {k: v for k, v in self.ModUnset.items() if not k.startswith("__")}
 			webhook_data["upsertor"] = upsertor_data
 
-			await self._webhook(webhook_data)
+			await self.webhook(webhook_data)
 
 		return self.ObjId

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -181,7 +181,7 @@ class MongoDBUpsertor(UpsertorABC):
 		# 			pass
 		# 	obj[k] = o
 
-		if self.Storage.WebhookURI is not None:
+		if self.Storage.WebhookURIs is not None:
 			webhook_data = {
 				"collection": self.Collection,
 			}

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -1,8 +1,9 @@
 import abc
 import secrets
 import hashlib
-
+import logging
 import asab
+import re
 
 try:
 	import cryptography.hazmat.primitives.ciphers
@@ -10,6 +11,12 @@ try:
 	import cryptography.hazmat.primitives.ciphers.modes
 except ModuleNotFoundError:
 	cryptography = None
+
+#
+
+L = logging.getLogger(__name__)
+
+#
 
 
 ENCRYPTED_PREFIX = b"$aes-cbc$"
@@ -19,7 +26,9 @@ class StorageServiceABC(asab.Service):
 
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
-		self.WebhookURI = asab.Config.get("asab:storage:changestream", "webhook_uri", fallback="") or None
+		self.WebhookURIs = asab.Config.get("asab:storage:changestream", "webhook_uris", fallback="") or None
+		if self.WebhookURIs is not None:
+			self.WebhookURIs = [uri for uri in re.split(r"\s+", self.WebhookURIs) if len(uri) > 0]
 		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "webhook_auth", fallback="") or None
 
 		# Specify a non-empty AES key to enable AES encryption of selected fields

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -29,6 +29,10 @@ class StorageServiceABC(asab.Service):
 		self.WebhookURIs = asab.Config.get("asab:storage:changestream", "webhook_uri", fallback="") or None
 		if self.WebhookURIs is not None:
 			self.WebhookURIs = [uri for uri in re.split(r"\s+", self.WebhookURIs) if len(uri) > 0]
+			try:
+				self.ProactorService = app.get_service("asab.ProactorService")
+			except KeyError as e:
+				raise Exception("Storage webhooks require ProactorService") from e
 		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "webhook_auth", fallback="") or None
 
 		# Specify a non-empty AES key to enable AES encryption of selected fields

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -26,7 +26,7 @@ class StorageServiceABC(asab.Service):
 
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
-		self.WebhookURIs = asab.Config.get("asab:storage:changestream", "webhook_uris", fallback="") or None
+		self.WebhookURIs = asab.Config.get("asab:storage:changestream", "webhook_uri", fallback="") or None
 		if self.WebhookURIs is not None:
 			self.WebhookURIs = [uri for uri in re.split(r"\s+", self.WebhookURIs) if len(uri) > 0]
 		self.WebhookAuth = asab.Config.get("asab:storage:changestream", "webhook_auth", fallback="") or None

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -4,7 +4,6 @@ import uuid
 import hashlib
 import datetime
 import logging
-import aiohttp
 import asab.web.rest.json
 import requests
 import typing

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -156,7 +156,9 @@ class UpsertorABC(abc.ABC):
 					) as response:
 						if response.status // 100 != 2:
 							text = await response.text()
-							L.error("Webhook endpoint responded with {}:\n{}".format(response.status, text))
+							L.error(
+								"Webhook endpoint responded with {}:\n{}".format(response.status, text),
+								struct_data={"uri": webhook_uri})
 							continue
 						self.WebhookResponseData[webhook_uri] = await response.json()
 			except json.decoder.JSONDecodeError as e:

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -43,7 +43,7 @@ class UpsertorABC(abc.ABC):
 		self.ModPush = {}
 		self.ModPull = {}
 
-		self.WebhookResponseData = None
+		self.WebhookResponseData = {}
 
 
 	def get_id_name(self):
@@ -117,14 +117,14 @@ class UpsertorABC(abc.ABC):
 			```python
 			upsertor = storage_service.upsertor("users")
 			upsertor.set("name", "Raccoon")
-			await upsertor.execute(custom_data={"action": "user_creation"})
+			await upsertor.execute(custom_data={"event_type": "create_user"})
 			```
 
 			will trigger a webhook whose payload may look like this:
 			```json
 			{
 				"collection": "users",
-				"custom": {"action": "user_creation"},
+				"custom": {"event_type": "create_user"},
 				"upsertor": {
 					"id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
 					"id_field_name": "_id",
@@ -144,21 +144,22 @@ class UpsertorABC(abc.ABC):
 
 
 	async def _webhook(self, data: dict):
-		assert self.Storage.WebhookURI is not None
+		assert self.Storage.WebhookURIs is not None
 		json_dump = asab.web.rest.json.JSONDumper(pretty=False)(data)
-		try:
-			async with aiohttp.ClientSession(auth=self.Storage.WebhookAuth) as session:
-				async with session.put(
-					self.Storage.WebhookURI,
-					data=json_dump,
-					headers={"Content-Type": "application/json"}
-				) as response:
-					if response.status // 100 != 2:
-						text = await response.text()
-						L.error("Webhook endpoint responded with {}:\n{}".format(response.status, text))
-						return
-					self.WebhookResponseData = await response.json()
-		except json.decoder.JSONDecodeError as e:
-			L.error("Failed to decode JSON response from webhook: {}".format(str(e)))
-		except Exception as e:
-			L.error("Webhook call failed with {}: {}".format(type(e).__name__, str(e)))
+		for webhook_uri in self.Storage.WebhookURIs:
+			try:
+				async with aiohttp.ClientSession(auth=self.Storage.WebhookAuth) as session:
+					async with session.put(
+						webhook_uri,
+						data=json_dump,
+						headers={"Content-Type": "application/json"}
+					) as response:
+						if response.status // 100 != 2:
+							text = await response.text()
+							L.error("Webhook endpoint responded with {}:\n{}".format(response.status, text))
+							continue
+						self.WebhookResponseData[webhook_uri] = await response.json()
+			except json.decoder.JSONDecodeError as e:
+				L.error("Failed to decode JSON response from webhook: {}".format(str(e)))
+			except Exception as e:
+				L.error("Webhook call failed with {}: {}".format(type(e).__name__, str(e)))

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -156,7 +156,7 @@ class UpsertorABC(abc.ABC):
 		try:
 			with requests.Session() as session:
 				if self.Storage.WebhookAuth:
-					session.auth = ("Basic", self.Storage.WebhookAuth)
+					session.headers["Authorization"] = self.Storage.WebhookAuth
 				with session.put(
 					uri,
 					data=data,


### PR DESCRIPTION
Closes #328 

- Option `webhook_uri` now accepts a list of whitespace-separated target URIs.
- `Upsertor.WebhookResponseData` is now a dict with webhook URIs as keys and the respective JSON responses as values.