### PR TITLE
Corrected logic of watch_metrics endpoint

### DIFF
--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -1,6 +1,5 @@
 import aiohttp.web
 import copy
-import re
 import fnmatch
 
 from .openmetric import metric_to_openmetric

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -64,24 +64,24 @@ class MetricWebHandler(object):
 		* watch curl localhost:8080/asab/v1/watch_metrics -> all metrics
 
 		Strict filters (inclusion and exclusion):
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=web_requests -> web_requests metric only
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=-web_requests -> all metrics w/o web_requests metric
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=web_requests -> web_requests metric only
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=-web_requests -> all metrics w/o web_requests metric
 
-		Includes:
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=web* -> metrics that start with "web"
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=*web -> metrics that end with "web"
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=*web* -> metrics that contain "web"
+		Includes only:
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=web* -> metrics that start with "web"
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=*web -> metrics that end with "web"
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=*web* -> metrics that contain "web"
 
 		Excludes:
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=-web* -> metrics that start with "web"
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=-*web -> metrics that end with "web"
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=-*web* -> metrics that contain "web"
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=-web* -> metrics that start with "web"
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=-*web -> metrics that end with "web"
+		* watch curl localhost:8080/asab/v1/watch_metrics?filter=-*web* -> metrics that contain "web"
 
 		---
 		tags: ['asab.metrics']
 		"""
 
-		filter = request.query.get("f")
+		filter = request.query.get("filter")
 		tags = request.query.get("tags")
 		tags = True if tags is not None and tags.lower() == 'true' else False
 		text = watch_table(self.MetricsService.Storage.Metrics, filter, tags)

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -70,9 +70,6 @@ class MetricWebHandler(object):
 		"""
 
 		filter = request.query.get("name")
-		print(filter)
-		# web_metrics_flag = request.query.get("web_requests_metrics")
-		# web_metrics_flag = True if web_metrics_flag is not None and web_metrics_flag.lower() == 'true' else False
 		tags = request.query.get("tags")
 		tags = True if tags is not None and tags.lower() == 'true' else False
 		text = watch_table(self.MetricsService.Storage.Metrics, filter, tags)
@@ -130,9 +127,7 @@ def watch_table(metric_records: list, filter, tags):
 					if "*" not in filter and not name == filter:
 						continue
 				if re.fullmatch("\-\w*", filter_root):
-					print("negative filter")
 					if "*" in filter and name.startswith(filter_root[1:]):
-						print("there is a star!")
 						continue
 					if "*" not in filter and name == filter[1:]:
 						continue

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -127,17 +127,15 @@ def watch_table(metric_records: list, filter, tags):
 			name = metric_record.get("name")
 
 			if filter is not None:
-				filter_root = [item for item in re.split("\*", filter) if len(item) > 0 and item != "-"][0].replace("-", "")
+				filter_parsed = [item for item in re.split("\*", filter) if len(item) > 0 and item != "-"]
+				filter_root = filter_parsed[0].replace("-", "")
 				if re.fullmatch("\-\D*", filter):
-					if "*" in filter and filter_root in name:
-						continue
-					if "*" not in filter and name == filter_root:
+					if filter_for_exclusion(filter, filter_root, name):
 						continue
 				elif re.fullmatch("\D*", filter):
-					if "*" in filter and not filter_root in name:
+					if filter_for_inclusion(filter, filter_root, name):
 						continue
-					if "*" not in filter and not name == filter_root:
-						continue
+
 
 			if metric_record.get("type") in ["Histogram", "HistogramWithDynamicTags"]:
 				for upperboud, values in field.get("values").get("buckets").items():
@@ -153,6 +151,14 @@ def watch_table(metric_records: list, filter, tags):
 
 	text = "\n".join(lines)
 	return text
+
+
+def filter_for_exclusion(filter, filter_root, name):
+		return ("*" in filter and filter_root in name) or ("*" not in filter and name == filter_root)
+
+
+def filter_for_inclusion(filter, filter_root, name):
+		return ("*" in filter and not filter_root in name) or ("*" not in filter and not name == filter_root)
 
 
 def build_line(name, value_name, value, m_name_len, v_name_len, tags, upperbound=None, t_string=None, t_name_len=None):

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -62,7 +62,7 @@ class MetricWebHandler(object):
 
 		Example commands:
 		* watch curl localhost:8080/asab/v1/watch_metrics -> full list
-		* watch curl localhost:8080/asab/v1/watch_metrics?name=web_requests -> web_requests only
+		* watch curl localhost:8080/asab/v1/watch_metrics?name=web_requests* -> web_requests only
 		* watch curl localhost:8080/asab/v1/watch_metrics?name=-web_requests* -> full list w/o web requests
 
 		---
@@ -114,12 +114,28 @@ def watch_table(metric_records: list, filter, tags):
 			if field.get("values") is None:
 				continue
 			name = metric_record.get("name")
-			if filter is not None and re.fullmatch("\w*", filter):
-				if not name.startswith(filter):
-					continue
-			if filter is not None and re.fullmatch("\-\w*", filter):
-				if name.startswith(filter[1:]):
-					continue
+
+			# if filter is not None and re.fullmatch("\w*", filter):
+			# 	if not name.startswith(filter):
+			# 		continue
+			# if filter is not None and re.fullmatch("\-\w*", filter):
+			# 	if name.startswith(filter[1:]):
+			# 		continue
+
+			if filter is not None:
+				filter_root = filter.partition("*")[0]
+				if re.fullmatch("\w*", filter_root):
+					if "*" in filter and not name.startswith(filter_root):
+						continue
+					if "*" not in filter and not name == filter:
+						continue
+				if re.fullmatch("\-\w*", filter_root):
+					print("negative filter")
+					if "*" in filter and name.startswith(filter_root[1:]):
+						print("there is a star!")
+						continue
+					if "*" not in filter and name == filter[1:]:
+						continue
 
 			if metric_record.get("type") in ["Histogram", "HistogramWithDynamicTags"]:
 				for upperboud, values in field.get("values").get("buckets").items():

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -62,15 +62,15 @@ class MetricWebHandler(object):
 
 		Example commands:
 		* watch curl localhost:8080/asab/v1/watch_metrics -> all metrics
-		
+
 		Strict filters (inclusion and exclusion):
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=web_requests -> web_requests metric only 
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=-web_requests -> all metrics w/o web_requests
+		* watch curl localhost:8080/asab/v1/watch_metrics?f=web_requests -> web_requests metric only
+		* watch curl localhost:8080/asab/v1/watch_metrics?f=-web_requests -> all metrics w/o web_requests metric
 
 		Includes:
 		* watch curl localhost:8080/asab/v1/watch_metrics?f=web* -> metrics that start with "web"
 		* watch curl localhost:8080/asab/v1/watch_metrics?f=*web -> metrics that end with "web"
-		* watch curl localhost:8080/asab/v1/watch_metrics?f=*web_requests* -> metrics that contain "web"
+		* watch curl localhost:8080/asab/v1/watch_metrics?f=*web* -> metrics that contain "web"
 
 		Excludes:
 		* watch curl localhost:8080/asab/v1/watch_metrics?f=-web* -> metrics that start with "web"
@@ -126,7 +126,7 @@ def watch_table(metric_records: list, filter, tags):
 
 			if filter is not None:
 				if filter.startswith("-"):
-					if fnmatch.fnmatch(name, filter.replace('-','')):
+					if fnmatch.fnmatch(name, filter[1:]):
 						continue
 				else:
 					if not fnmatch.fnmatch(name, filter):


### PR DESCRIPTION
1) Corrected a typo in the Examples section (wrong endpoint name, reversed);
2) Complete metrics table (including web_requests metrics) is shown only if they have been explicitly asked for (the relevant parameter web_requests_metrics is True).
3) Corrected the logic behind tags parameter (returned tags for any string in the request, including False).