### PR TITLE
WIP: Placing timestamp of last flush to watch table

### DIFF
--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -29,7 +29,7 @@ class MetricsService(Service):
 		self.Tags = {
 			"host": app.HostName,
 		}
-		self.Storage = Storage()
+		self.Storage = Storage(app)
 
 		app.PubSub.subscribe("Application.tick/60!", self._on_flushing_event)
 
@@ -85,6 +85,7 @@ class MetricsService(Service):
 			return
 
 		now = self._flush_metrics()
+		self.Storage.LastFlush = now
 
 		pending = set()
 		for target in self.Targets:

--- a/asab/metrics/storage.py
+++ b/asab/metrics/storage.py
@@ -9,8 +9,9 @@ L = logging.getLogger(__name__)
 
 class Storage(object):
 
-	def __init__(self):
+	def __init__(self, app):
 		self.Metrics = []
+		self.LastFlush = app.time()
 
 
 	def add(self, metric_name: str, tags: dict, reset: bool, help: str, unit: str):


### PR DESCRIPTION
I had to find a way to provide info about last flush (update of the metrics values) to the user. I could place the timestamp into every metric record. And probably I should do that. However, it requires change in every metric class and rework of unittests. Which brought me to rather easy solution of keeping this information in Storage object, which is common for all the metrics. 

... and Elena will place it into the `watch_metrics` table :slightly_smiling_face: 