### PR TITLE
Update docs: logging with custom level configuration

### DIFF
--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -60,6 +60,16 @@ ASAB uses Python logging levels with the addition of ``LOG_NOTICE`` level.
 | ``NOTSET``     | 0             |                              |
 +----------------+---------------+------------------------------+
 
+Example of a custom level configuration:
+
+.. code:: ini
+    levels=
+        myApp.module1 DEBUG
+        myApp.module2 WARNING
+        customLogger ERROR
+
+The logger name and the corresponding logging level are separated by a space, each logger is on a separate line.
+
 
 Verbose mode
 ------------

--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -64,6 +64,7 @@ ASAB uses Python logging levels with the addition of ``LOG_NOTICE`` level.
 Example of a custom level configuration:
 
 .. code:: ini
+    [logging]
     levels=
         myApp.module1 DEBUG
         myApp.module2 WARNING

--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -64,6 +64,7 @@ ASAB uses Python logging levels with the addition of ``LOG_NOTICE`` level.
 Example of a custom level configuration:
 
 .. code:: ini
+    
     [logging]
     levels=
         myApp.module1 DEBUG

--- a/doc/asab/log.rst
+++ b/doc/asab/log.rst
@@ -60,6 +60,7 @@ ASAB uses Python logging levels with the addition of ``LOG_NOTICE`` level.
 | ``NOTSET``     | 0             |                              |
 +----------------+---------------+------------------------------+
 
+
 Example of a custom level configuration:
 
 .. code:: ini


### PR DESCRIPTION
An example of how you can set custom logger levels added to ASAB documentation.