### PR TITLE
Defect: Zookeeper sometimes has forward slash at the end of path.

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -259,6 +259,9 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		else:
 			node_path = self.BasePath
 
+		# Zookeeper path should not have forward slash at the end of path
+		node_path = node_path.rstrip("/")
+
 		assert '//' not in node_path
 		assert node_path[0] == '/'
 		assert len(node_path) == 1 or node_path[-1:] != '/'

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -264,6 +264,5 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		assert '//' not in node_path
 		assert node_path[0] == '/'
-		assert len(node_path) == 1 or node_path[-1:] != '/'
 
 		return node_path

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -237,7 +237,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				continue
 
 			items.append(LibraryItem(
-				name=(path + node) if path == '/' else (path + '/' + node),
+				name=(path + node) if path == '/' else (path + node),
 				type="item" if '.' in node else "dir",  # We detect files in zookeeper by presence of the dot in the filename,
 				providers=[self],
 			))

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -237,7 +237,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				continue
 
 			items.append(LibraryItem(
-				name=(path + node) if path == '/' else (path + node),
+				name=(path + node) if path == '/' else (path.rstrip("/") + "/" + node),
 				type="item" if '.' in node else "dir",  # We detect files in zookeeper by presence of the dot in the filename,
 				providers=[self],
 			))


### PR DESCRIPTION
Important Note: If you are using asab.library, please be aware that breaking changes have been made. This means that your current code may not work as intended.
When specifying paths within asab.library, please follow these rules:

- All paths must start with a forward slash (/), even the root path.
- Folder paths must end with a forward slash (/).
- Item paths must end with an extension (e.g. .json).

To retrieve a list of items using the API, use the following syntax:
`GET /library/list/Dashboards/`
Alternatively, you can use the following code:
`await self.LibraryService.list("/Parsers/nginx-access-log/")`