### PR TITLE
Zookeeper integration refactored.

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -162,16 +162,16 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		"""
 		if zkcontainer != self.ZookeeperContainer:
 			return
-		
+
 		L.info("is connected.", struct_data={'path': self.FullPath})
 
 		def on_version_changed(version, event):
 			self.App.Loop.call_soon_threadsafe(self._check_version_counter, version)
-		
+
 		def install_watcher():
 			return kazoo.recipe.watchers.DataWatch(self.Zookeeper.Client, self.VersionNodePath, on_version_changed)
 
-		self.VersionWatch =await self.Zookeeper.ProactorService.execute(install_watcher)
+		self.VersionWatch = await self.Zookeeper.ProactorService.execute(install_watcher)
 
 		await self._set_ready()
 

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -1,6 +1,8 @@
 import json
 import asyncio
 import logging
+import urllib.parse
+import configparser
 
 import kazoo.exceptions
 import kazoo.recipe.watchers
@@ -21,36 +23,126 @@ class ZooKeeperContainer(ConfigObject):
 	ConfigDefaults = {
 		# Server list to which ZooKeeper Client tries connecting.
 		# Specify a comma (,) separated server list.
-		# A server is defined as address:port format.
+		# A server is defined as `address:port` format.
 		# Example:
 		# "servers": "zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181"
-		#
-		# WARNING: If the value is not provided (empty string), Zookeeper container refuses to start
+		# If servers are empty, default from [zookeeper]/servers will be taken
+		# If [zookeeper]/servers value is not provided, ZOOKEEPER_SERVERS environment variable is used
 		"servers": "",
 
-		# The default is an application class name
+		# If not provided, "/asab" path will be used
 		"path": "",
 	}
 
 
 	def __init__(self, zksvc, config_section_name, config=None, z_path=None):
 		"""
-		Alternative 1: Obtain Zookeeper container with `config_section_name` configuration section
-		Alternative 2: Obtain Zookeeper container with call z_path (URL)
-		Example:
-		zk_cnt = ZooKeeperContainer(app, config_section_name='', z_path=z_path)
+		Zookeeper cofiguration:
+
+		* Source 1: Obtain Zookeeper configuration from the configuration section specified by `config_section_name` argument
+
+		* Source 2: Obtain Zookeeper configuration from `z_path` argument, which is Zookeeper URL (see below)
+
+		* Source 3: `ZOOKEEPER_SERVERS` environment variable
+
+
+		The `z_path` argument has precedence over config but the implementation will look
+		at configuration if `z_path` URL is missing completely or partially.
+
+		Supported types of z_path` URLs:
+
+		1. Absolute URL
+			Example: zookeeper://zookeeper:12181/etc/configs/file1
+
+			There is no fallback to the configuration.
+
+
+
+		2. Relative URL with full path
+			Example: zookeeper:///etc/configs/file1
+			
+			In this case the relative url is expanded as follows:
+			zookeeper://{zookeeper_server}/etc/configs/file1
+			
+			Where {zookeeper_server} is substituted with the server entry of the [zookeeper] configuration file section.
+
+
+
+		3. Relative URL with relative path
+		
+			Example: zookeeper:./etc/configs/file1
+				In this case, the relative URL is expanded as follows:
+				
+				zookeper://{zookeeper_server}/{zookeeper_path}/etc/configs/file1
+				Where {zookeeper_server} is substituted with the "server" entry of the [zookeeper] configuration file section and
+				{zookeeper_path} is substituted with the "path" entry of the [zookeeper] configuration file section.
+
+		Sample config file:
+		[zookeeper]
+		server=server1:port1,server2:port2,server3:port3
+		path=myfolder
+
 		"""
 		super().__init__(config_section_name=config_section_name, config=config)
-
 		self.App = zksvc.App
-		self.ConfigSectionName = config_section_name
-		self.ZooKeeper = KazooWrapper(zksvc.App, self.Config, z_path)
-		self.ZooKeeperPath = self.ZooKeeper.Path
+
+		# Parse URL from z_path
+		if z_path is not None:
+			url_pieces = urllib.parse.urlparse(z_path)
+			url_netloc = url_pieces.netloc
+			url_path = url_pieces.path
+		else:
+			url_netloc = ""
+			url_path = ""
+
+		# If there is no location, use the value of 'servers' from the configuration
+		if url_netloc == "":
+			url_netloc = self.Config.get("servers", "")
+		
+		if url_netloc == "":
+			from ..config import Config
+			try:
+				url_netloc = Config.get("zookeeper", "servers")
+			except (configparser.NoOptionError, configparser.NoSectionError):
+				pass
+		
+		if url_netloc == "":
+			url_netloc = os.environ.get("ZOOKEEPER_SERVERS", "")
+
+		if url_netloc == "":
+			# if server entry is missing exit
+			L.critical("Cannot connect to Zookeeper, the configuration of the server address is not available.")
+			raise SystemExit("Exit due to a critical configuration error.")
+
+		assert url_netloc is not None
+
+		# If path has not been provided, use the value of 'path' from the configuration
+		if url_path == "":
+			url_path = self.Config.get("path", "")
+
+		if url_path == "":
+			from ..config import Config
+			try:
+				url_path = Config.get("zookeeper", "path")
+			except (configparser.NoOptionError, configparser.NoSectionError):
+				pass
+
+		if url_path == "":
+			url_path = 'asab'
+
+		# Remove all heading '/' from path
+		while url_path.startswith('/'):
+			url_path = url_path[1:]
+
+		self.ZooKeeper = KazooWrapper(zksvc, url_netloc)
+		self.Path = url_path
+		
 		self.Advertisments = dict()
 		self.DataWatchers = set()
-		self.App.PubSub.subscribe("Application.tick/300!", self._do_advertise)
+		self.App.PubSub.subscribe("Application.tick/300!", self._readvertise)
 
-		zksvc._register_container(self)
+		zksvc.Containers.append(self)
+		zksvc.ProactorService.schedule(self._start, self.App)
 
 
 	def _start(self, app):
@@ -66,11 +158,10 @@ class ZooKeeperContainer(ConfigObject):
 			)
 			return
 
-		self.ZooKeeper.Client.ensure_path(self.ZooKeeper.Path)
+		self.ZooKeeper.Client.ensure_path(self.Path)
 
 		def in_main_thread():
 			self.App.PubSub.publish("ZooKeeperContainer.started!", self)
-
 		self.App.Loop.call_soon_threadsafe(in_main_thread)
 
 
@@ -85,21 +176,25 @@ class ZooKeeperContainer(ConfigObject):
 		return self.ZooKeeper.Client.connected
 
 
+	# Advertisement into Zookeeper
+
 	def advertise(self, data, path):
-		adv = self.Advertisments.get(self.ZooKeeper.Path + path)
+		adv = self.Advertisments.get(self.Path + path)
 		if adv is None:
-			adv = ZooKeeperAdvertisement(self.ZooKeeper.Path + path)
-			self.Advertisments[self.ZooKeeper.Path + path] = adv
-		adv.set_data(data)
-		self.App.TaskService.schedule(adv._do_advertise(self))
+			adv = ZooKeeperAdvertisement(self.Path + path)
+			self.Advertisments[self.Path + path] = adv
+		self.App.TaskService.schedule(adv._set_data(self, data))
 
 
-	async def _do_advertise(self, *args):
+	async def _readvertise(self, *args):
 		for adv in self.Advertisments.values():
-			await adv._do_advertise(self)
+			await adv._readvertise(self)
+
+
+	# Reading
 
 	async def get_children(self):
-		return await self.ZooKeeper.get_children(self.ZooKeeper.Path)
+		return await self.ZooKeeper.get_children(self.Path)
 
 	async def get_data(self, child, encoding="utf-8"):
 		raw_data = await self.get_raw_data(child)
@@ -108,7 +203,10 @@ class ZooKeeperContainer(ConfigObject):
 		return json.loads(raw_data.decode(encoding))
 
 	async def get_raw_data(self, child):
-		return await self.ZooKeeper.get_data("{}/{}".format(self.ZooKeeper.Path, child))
+		return await self.ZooKeeper.get_data("{}/{}".format(self.Path, child))
+
+
+	# Watcher
 
 	def _on_watcher_trigger(self, data, stat):
 		def on_watcher_trigger():
@@ -124,32 +222,50 @@ class ZooKeeperContainer(ConfigObject):
 class ZooKeeperAdvertisement(object):
 
 	def __init__(self, path):
-		self.Path = path
 		self.Data = None
-		self.Node = None
+		
+		self.Path = path
+		self.RealPath = None
+		
 		self.Lock = asyncio.Lock()
 
 
-	def set_data(self, data):
-		if isinstance(data, dict):
-			self.Data = json.dumps(data).encode("utf-8")
-		elif isinstance(data, str):
-			self.Data = data.encode("utf-8")
-		else:
-			self.Data = data
+	async def _set_data(self, zoocontainer, data):
+		async with self.Lock:
+			if isinstance(data, dict):
+				self.Data = json.dumps(data).encode("utf-8")
+			elif isinstance(data, str):
+				self.Data = data.encode("utf-8")
+			else:
+				self.Data = data
+
+			def write_to_zk():
+				if self.RealPath is None:
+					self.RealPath = zoocontainer.ZooKeeper.Client.create(self.Path, self.Data, sequence=True, ephemeral=True, makepath=True)
+				else:
+					try:
+						zoocontainer.ZooKeeper.Client.set(self.RealPath, self.Data)
+					except kazoo.exceptions.NoNodeError:
+						self.RealPath = zoocontainer.ZooKeeper.Client.create(self.Path, self.Data, sequence=True, ephemeral=True, makepath=True)
+
+			await zoocontainer.ZooKeeper.ProactorService.execute(write_to_zk)
 
 
-	async def _do_advertise(self, zoocontainer):
+	async def _readvertise(self, zoocontainer):
 		if self.Data is None:
 			return
 
-		async with self.Lock:
-			if self.Node is not None and await zoocontainer.ZooKeeper.exists(self.Node):
-				await zoocontainer.ZooKeeper.set_data(self.Node, self.Data)
-				return
+		if self.RealPath is None:
+			return
 
-			try:
-				self.Node = await zoocontainer.ZooKeeper.create(self.Path, self.Data, sequential=True, ephemeral=True)
-			except kazoo.exceptions.NoNodeError:
-				await zoocontainer.ZooKeeper.ensure_path(self.Path.rstrip(self.Path.split("/")[-1]))
-				self.Node = await zoocontainer.ZooKeeper.create(self.Path, self.Data, sequential=True, ephemeral=True)
+		async with self.Lock:
+
+			def check_at_zk():
+				if zoocontainer.ZooKeeper.Client.exists(self.RealPath):
+					return
+
+				# If the advertisement node is not present in the Zookeeper, force the recreation
+				self.RealPath = zoocontainer.ZooKeeper.Client.create(self.Path, self.Data, sequence=True, ephemeral=True)
+
+			await zoocontainer.ZooKeeper.ProactorService.execute(check_at_zk)
+

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -1,3 +1,4 @@
+import os
 import json
 import asyncio
 import logging
@@ -60,19 +61,19 @@ class ZooKeeperContainer(ConfigObject):
 
 		2. Relative URL with full path
 			Example: zookeeper:///etc/configs/file1
-			
+
 			In this case the relative url is expanded as follows:
 			zookeeper://{zookeeper_server}/etc/configs/file1
-			
+
 			Where {zookeeper_server} is substituted with the server entry of the [zookeeper] configuration file section.
 
 
 
 		3. Relative URL with relative path
-		
+
 			Example: zookeeper:./etc/configs/file1
 				In this case, the relative URL is expanded as follows:
-				
+
 				zookeper://{zookeeper_server}/{zookeeper_path}/etc/configs/file1
 				Where {zookeeper_server} is substituted with the "server" entry of the [zookeeper] configuration file section and
 				{zookeeper_path} is substituted with the "path" entry of the [zookeeper] configuration file section.
@@ -98,14 +99,14 @@ class ZooKeeperContainer(ConfigObject):
 		# If there is no location, use the value of 'servers' from the configuration
 		if url_netloc == "":
 			url_netloc = self.Config.get("servers", "")
-		
+
 		if url_netloc == "":
 			from ..config import Config
 			try:
 				url_netloc = Config.get("zookeeper", "servers")
 			except (configparser.NoOptionError, configparser.NoSectionError):
 				pass
-		
+
 		if url_netloc == "":
 			url_netloc = os.environ.get("ZOOKEEPER_SERVERS", "")
 
@@ -136,7 +137,7 @@ class ZooKeeperContainer(ConfigObject):
 
 		self.ZooKeeper = KazooWrapper(zksvc, url_netloc)
 		self.Path = url_path
-		
+
 		self.Advertisments = dict()
 		self.DataWatchers = set()
 		self.App.PubSub.subscribe("Application.tick/300!", self._readvertise)
@@ -223,10 +224,10 @@ class ZooKeeperAdvertisement(object):
 
 	def __init__(self, path):
 		self.Data = None
-		
+
 		self.Path = path
 		self.RealPath = None
-		
+
 		self.Lock = asyncio.Lock()
 
 
@@ -268,4 +269,3 @@ class ZooKeeperAdvertisement(object):
 				self.RealPath = zoocontainer.ZooKeeper.Client.create(self.Path, self.Data, sequence=True, ephemeral=True)
 
 			await zoocontainer.ZooKeeper.ProactorService.execute(check_at_zk)
-

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -150,7 +150,7 @@ class ZooKeeperContainer(ConfigObject):
 
 	# Reading
 
-	async def get_children(self, path = ""):
+	async def get_children(self, path=""):
 		return await self.ZooKeeper.get_children("{}/{}".format(self.Path, path))
 
 	async def get_data(self, path, encoding="utf-8"):

--- a/asab/zookeeper/service.py
+++ b/asab/zookeeper/service.py
@@ -16,8 +16,14 @@ class ZooKeeperService(Service):
 
 	def __init__(self, app, service_name):
 		super().__init__(app, service_name)
-		self.App = app
+
+		# Make sure that the proactor service exists
+		from ..proactor import Module
+		app.add_module(Module)
+		self.ProactorService = app.get_service("asab.ProactorService")
+
 		self.Containers = []
+
 
 
 	async def finalize(self, app):
@@ -51,11 +57,6 @@ class ZooKeeperService(Service):
 
 		container = ZooKeeperContainer(self, config_section_name=config_section)
 		return container
-
-
-	def _register_container(self, container):
-		self.Containers.append(container)
-		container.ZooKeeper.ProactorService.schedule(container._start, self.App)
 
 
 	async def advertise(self, data, path, encoding="utf-8", container=None):

--- a/asab/zookeeper/wrapper.py
+++ b/asab/zookeeper/wrapper.py
@@ -1,5 +1,4 @@
 import logging
-import urllib.parse
 
 import kazoo.client
 import kazoo.exceptions
@@ -12,74 +11,11 @@ L = logging.getLogger(__name__.rsplit(".", 1)[0])  # We want just "asab.zookeepe
 
 
 class KazooWrapper(object):
-	"""
-	This function builds ZooKeeper clients from Configs and URLs
 
-	Supported types of URLs:
 
-	1. Absolute URL.
-	Example: zookeeper://zookeeper:12181/etc/configs/file1
-
-	2. Relative URL with full path
-		Example: zookeeper:///etc/configs/file1
-		In this case the relative url is expanded as follows:
-		zookeeper://{default_server}/etc/configs/file1
-		Where {default_server} is substituted with the server entry of the [zookeeper] configuration file section.
-
-	3. Relative URL with relative path
-	Example: zookeeper:./etc/configs/file1
-		In this case, the relative URL is expanded as follows:
-		zookeper://{default_server}/{default_path}/etc/configs/file1
-		Where {default_server} is substituted with the "server" entry of the [zookeeper] configuration file section and
-		{default_path} is substituted with the "path" entry of the [zookeeper] configuration file section.
-
-	Sample config file:
-	[asab.zookeeper]
-	server=server1:port1,server2:port2,server3:port3
-	path=myfolder
-	"""
-
-	def __init__(self, app, config, z_url):
-
-		# Make sure that the proactor service exists
-		from ..proactor import Module
-		app.add_module(Module)
-		self.ProactorService = app.get_service("asab.ProactorService")
-
-		# Parse URL
-		if z_url is not None:
-			url_pieces = urllib.parse.urlparse(z_url)
-			url_netloc = url_pieces.netloc
-			url_path = url_pieces.path
-		else:
-			url_netloc = ''
-			url_path = ''
-
-		# If there is no location, use the value of 'servers' from the configuration
-		if url_netloc == '':
-			url_netloc = config.get("servers")
-			if url_netloc == '' or url_netloc is None:
-				# if server entry is missing exit
-				L.critical("Cannot connect to Zookeeper, the configuration value of 'servers' not provided: '{}'".format(config))
-				raise SystemExit("Exit due to a critical configuration error.")
-
-		# If path has not been provided, use the value of 'path' from the configuration
-		if url_path == '':
-			url_path = config.get("path")
-
-		# If path still has not been found (not in configuration), derive the path from the application class name
-		if url_path == '' or url_path is None:
-			url_path = app.__class__.__name__
-
-		# Remove all heading '/' from path
-		while url_path.startswith('/'):
-			url_path = url_path[1:]
-
-		self.Path = url_path.rstrip('/')
-		self.Hosts = url_netloc
-
-		# Create and return the client and the url-path
-		self.Client = kazoo.client.KazooClient(hosts=self.Hosts)
+	def __init__(self, zksvc, hosts):
+		self.ProactorService = zksvc.ProactorService
+		self.Client = kazoo.client.KazooClient(hosts=hosts)
 
 
 	# connection start/close calls
@@ -150,9 +86,20 @@ class KazooWrapper(object):
 			return None
 		return ret
 
-	# create ephemeral node
-	async def create(self, path, value, sequential, ephemeral):
+	async def create(self, path, value, sequence=False, ephemeral=False, makepath=False):
 
-		ret = await self.ProactorService.execute(
-			self.Client.create, path, value, None, ephemeral, sequential, False)
-		return ret
+		def do():
+			return self.Client.create(path, value=value, ephemeral=ephemeral, sequence=sequence, makepath=makepath)
+
+		return await self.ProactorService.execute(do)
+
+
+	# create a new node or update the existing one
+	async def upsert(self, path, value):
+		def do():
+			try:
+				return self.Client.create(path, value=value)
+			except kazoo.exceptions.NodeExistsError:
+				return self.Client.set(path, data)
+
+		return await self.ProactorService.execute(do)

--- a/asab/zookeeper/wrapper.py
+++ b/asab/zookeeper/wrapper.py
@@ -100,6 +100,6 @@ class KazooWrapper(object):
 			try:
 				return self.Client.create(path, value=value)
 			except kazoo.exceptions.NodeExistsError:
-				return self.Client.set(path, data)
+				return self.Client.set(path, value)
 
 		return await self.ProactorService.execute(do)

--- a/doc/asab/zookeeper.rst
+++ b/doc/asab/zookeeper.rst
@@ -1,0 +1,154 @@
+.. _zookeeper-ref:
+
+Zookeeper
+=========
+
+.. py:currentmodule:: asab.zookeeper
+
+The `asab.zookeeper` is a `Apache Zookeeper <https://zookeeper.apache.org>`_ asynchronous client based on `Kazoo <https://github.com/python-zk/kazoo>`_ library.
+
+Apache ZooKeeper is a distributed coordination service that provides a hierarchical key-value data store, called a znode tree, to store and manage configuration, coordination, and synchronization data. The znode tree is similar to a file system tree, where each znode is like a file or a directory.
+
+Apache ZooKeeper can be used to design microservices in a stateless manner by managing and coordinating the state information between microservices. In this design, each microservice does not store any state information, but instead relies on ZooKeeper for state management.
+
+
+Zookeeper container
+-------------------
+
+A Zookeeper container represents a connectivity to Apache Zookeeper server(s).
+The application can operate multiple instances of Zookeeper container.
+
+
+This code illustrates the typical way how to create Zookeeper container:
+
+.. code:: python
+
+    import asab.zookeeper
+
+    class MyApplication(asab.Application):
+
+        def __init__(self):
+            ...
+
+            # Load the ASAB Zookeeper module
+            self.add_module(asab.zookeeper.Module)
+
+            # Initialize ZooKeeper Service
+            self.ZooKeeperService = self.get_service("asab.ZooKeeperService")
+
+            # Create the Zookeeper container
+            self.ZooKeeperContainer = asab.zookeeper.ZooKeeperContainer(self.ZooKeeperService)
+
+            # Subscribe to Zookeeper container ready event
+            self.PubSub.subscribe("ZooKeeperContainer.started!", self._on_zk_ready)
+
+
+        async def _on_zk_ready(self, event_name, zookeeper):
+            if zookeeper != self.ZooKeeperContainer:
+                return
+
+            print("Connected to Zookeeper!")
+
+
+
+.. autoclass:: ZooKeeperContainer
+
+Specifications are obtained from:
+
+1. `z_path` argument, which is Zookeeper URL (see below)
+2. the configuration section specified by `config_section_name` argument
+3. `ZOOKEEPER_SERVERS` environment variable
+
+The `z_path` argument has precedence over config but the implementation will look
+at configuration if `z_path` URL is missing completely or partially.
+Also, if configuration section doesn't provide information about servers, `ZOOKEEPER_SERVERS` environment variable is used.
+
+
+Example of configuration section
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: ini
+
+    [zookeeper]
+    servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+    path=myfolder
+
+
+Example of `ZOOKEEPER_SERVER` environment variable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: ini
+
+    ZOOKEEPER_SERVERS=zookeeper-1:2181,zookeeper-2:2181
+
+
+Supported types of `z_path` URLs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Absolute URL
+    
+    `zookeeper://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/etc/configs/file1`
+
+
+    The URL contains all information for a connectivity.
+
+
+2. URL without servers with absolute path
+    
+    `zookeepers:///etc/configs/file1`
+
+    In this case the relative url is expanded as follows:
+    `zookeeper://{zookeeper_servers}/etc/configs/file1`
+
+    Where `{zookeeper_servers}` is substituted with the `servers` entry of the [zookeeper] configuration file section.
+
+
+3. URL without servers with relative path
+
+    `zookeeper:./etc/configs/file1`
+    
+    In this case, the relative URL is expanded as follows:
+    `zookeper://{zookeeper_servers}/{zookeeper_path}/etc/configs/file1`
+
+    Where {zookeeper_servers} is substituted with the `servers` entry of the [zookeeper] configuration file section and
+    {zookeeper_path} is substituted with the "path" entry of the [zookeeper] configuration file section.
+
+
+
+.. automethod:: ZooKeeperContainer.is_connected
+
+
+Reading from Zookeeeper
+-----------------------
+
+.. automethod:: ZooKeeperContainer.get_children
+
+.. automethod:: ZooKeeperContainer.get_data
+
+.. automethod:: ZooKeeperContainer.get_raw_data
+
+
+Advertisement into Zookeeper
+----------------------------
+
+.. automethod:: ZooKeeperContainer.advertise
+
+
+Kazoo
+-----
+
+Kazoo is the synchronous Python library for Apache Zookeeper.
+
+It can be used directly for a more complicated tasks.
+Kazoo `client` is accessible at `ZooKeeperContainer.ZooKeeper.Client`.
+Synchronous methods of Kazoo client must be executed using `ProactorService`.
+
+Here is the example:
+
+.. code:: python
+
+     def write_to_zk():
+        self.ZooKeeperContainer.ZooKeeper.Client.create(path, data, sequence=True, ephemeral=True, makepath=True)
+
+    await self.ZooKeeperContainer.ZooKeeper.ProactorService.execute(write_to_zk)
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,4 @@
 .. ASAB documentation master file, created by
-sphinx-quickstart on Sat Mar  3 23:48:03 2018.
-You can adapt this file completely to your liking, but it should at least
-contain the root `toctree` directive.
 
 .. include:: asab/index.rst
 
@@ -35,6 +32,7 @@ contain the root `toctree` directive.
    asab/service
    asab/module
    asab/various
+   asab/zookeeper
    asab/library
 
 .. toctree::


### PR DESCRIPTION
# Summary

- Refactorization of the way how Kazoo (Zookeeper client) is integrated with ASAB
- Clarification of the approach to the configuration
- Introduction of `ZOOKEEPER_SERVERS` environment variable
- Refactoring of the approach to advertisement, mainly to reduce number of versions created in Zookeeper
- Documentation


# BREAKING CHANGES

- Code that directly interacts with the Kazoo wrapper / client will need to be updated.
- `sequential` argument of `create()` method has been renamed to`sequence` (aligned with Kazoo)
- Watcher is removed (use Kazoo directly)

