### PR TITLE
Feature: now colors are disabled when running in container

### DIFF
--- a/asab/log.py
+++ b/asab/log.py
@@ -170,12 +170,24 @@ class Logging(object):
 
 	def _configure_console_logging(self):
 		self.ConsoleHandler = logging.StreamHandler(stream=sys.stderr)
-		self.ConsoleHandler.setFormatter(StructuredDataFormatter(
-			fmt=Config["logging:console"]["format"],
-			datefmt=Config["logging:console"]["datefmt"],
-			sd_id=Config["logging"]["sd_id"],
-			use_color=True
-		))
+
+		# Disable colors when running in container
+		from .docker import running_in_container
+		if running_in_container():
+			self.ConsoleHandler.setFormatter(StructuredDataFormatter(
+				fmt=Config["logging:console"]["format"],
+				datefmt=Config["logging:console"]["datefmt"],
+				sd_id=Config["logging"]["sd_id"],
+				use_color=False
+			))
+		else:
+			self.ConsoleHandler.setFormatter(StructuredDataFormatter(
+				fmt=Config["logging:console"]["format"],
+				datefmt=Config["logging:console"]["datefmt"],
+				sd_id=Config["logging"]["sd_id"],
+				use_color=True
+			))
+
 		self.ConsoleHandler.setLevel(logging.DEBUG)
 		self.RootLogger.addHandler(self.ConsoleHandler)
 


### PR DESCRIPTION
Trying to fix an [issue: Colors in logging should be disabled when running in the docker/podman](https://github.com/TeskaLabs/asab/issues/335).
