### PR TITLE
Configurable openapi server path

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -54,10 +54,10 @@ class DocWebHandler(object):
 				"version": "1.0.0",
 			},
 			"servers": [
-				{"url": "/", "description": "Here"}
+				# Get base API path relatively from openapi endpoint
+				{"url": "../../", "description": "Here"}
 			],
 
-			# Base path relative to openapi endpoint
 			"paths": {},
 			# Authorization
 			# TODO: Authorization must not be always of OAuth type

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -54,7 +54,7 @@ class DocWebHandler(object):
 				"version": "1.0.0",
 			},
 			"servers": [
-				# Get base API path relatively from openapi endpoint
+				# Get base API path relatively from /asab/v1/openapi endpoint
 				{"url": "../../", "description": "Here"}
 			],
 


### PR DESCRIPTION
The base bath `/` does not work when the API is running on a subpath (e.g. `https://example.com/sub/path/my-api`). We need to derive the base path relatively from the openapi endpoint `<URL>/asab/v1/openapi` by going two steps up (`../../`).

- [ ] revisit approach to auth - developer mode for auth: asab will inject mock id token to every request
- [ ] configurable server path