### PR TITLE
Feature/Optional argument `event_type` added into `Upsertor.execute()` method

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -368,7 +368,7 @@ class ElasicSearchUpsertor(UpsertorABC):
 		raise NotImplementedError("generate_id")
 
 
-	async def execute(self, custom_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
 		# TODO: Implement webhook call
 		if self.ObjId is None:
 			return await self._insert_noobjid()

--- a/asab/storage/inmemory.py
+++ b/asab/storage/inmemory.py
@@ -7,7 +7,7 @@ from .exceptions import DuplicateError
 class InMemoryUpsertor(UpsertorABC):
 
 
-	async def execute(self, custom_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
 		# TODO: Implement webhook call
 		id_name = self.get_id_name()
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -190,7 +190,7 @@ class MongoDBUpsertor(UpsertorABC):
 				webhook_data["custom"] = custom_data
 
 			if event_type is not None:
-				webhook_data["custom"]["event_type"] = event_type
+				webhook_data["event_type"] = event_type
 
 			# Add upsetor data; do not include fields that start with "__"
 			upsertor_data = {

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -122,7 +122,7 @@ class MongoDBUpsertor(UpsertorABC):
 		return bson.objectid.ObjectId()
 
 
-	async def execute(self, custom_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
 		id_name = self.get_id_name()
 		addobj = {}
 
@@ -188,6 +188,9 @@ class MongoDBUpsertor(UpsertorABC):
 
 			if custom_data is not None:
 				webhook_data["custom"] = custom_data
+
+			if event_type is not None:
+				webhook_data["custom"]["event_type"] = event_type
 
 			# Add upsetor data; do not include fields that start with "__"
 			upsertor_data = {

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -112,7 +112,7 @@ class UpsertorABC(abc.ABC):
 		Commit upsertor data to the storage. Afterwards, send a webhook request with upsertion details.
 
 		:custom_data: Custom execution data. Included in webhook payload.
-		
+
 		---
 		Example:
 		---

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -107,40 +107,48 @@ class UpsertorABC(abc.ABC):
 
 
 	@abc.abstractmethod
-	async def execute(self, custom_data: typing.Optional[dict] = None):
+	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
 		"""
 		Commit upsertor data to the storage. Afterwards, send a webhook request with upsertion details.
 
 		:custom_data: Custom execution data. Included in webhook payload.
-
+		
+		---
 		Example:
-			The following upsertion
-			```python
-			upsertor = storage_service.upsertor("users")
-			upsertor.set("name", "Raccoon")
-			await upsertor.execute(custom_data={"event_type": "create_user"})
-			```
+		---
 
-			will trigger a webhook whose payload may look like this:
-			```json
-			{
-				"collection": "users",
-				"custom": {"event_type": "create_user"},
-				"upsertor": {
-					"id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
-					"id_field_name": "_id",
-					"_v": 0,
-					"inc": {"_v": 1},
-					"set": {
-						"_c": "2022-07-11T16:06:04.380445+00:00",
-						"_id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
-						"_m": "2022-07-11T16:06:04.380445+00:00",
-						"name": "Raccoon"
-					}
+		The following upsertion
+
+		```python
+		upsertor = storage_service.upsertor("users")
+		upsertor.set("name", "Raccoon")
+		await upsertor.execute(custom_data={"custom_key": "custom_value"}, event_type = "create_user")
+		```
+
+		will trigger a webhook whose payload may look like this:
+		```json
+		{
+			"collection": "users",
+			"custom": {
+				"custom_key": "custom_value",
+				"event_type": "create_user"
+				},
+			"upsertor": {
+				"id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
+				"id_field_name": "_id",
+				"_v": 0,
+				"inc": {"_v": 1},
+				"set": {
+					"_c": "2022-07-11T16:06:04.380445+00:00",
+					"_id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",
+					"_m": "2022-07-11T16:06:04.380445+00:00",
+					"name": "Raccoon"
 				}
 			}
-			```
+		}
+		```
 		"""
+
 		pass
 
 

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -113,6 +113,8 @@ class UpsertorABC(abc.ABC):
 
 		:custom_data: Custom execution data. Included in webhook payload.
 
+		:event_type: Event type included in webhook payload.
+
 		---
 		Example:
 		---
@@ -129,9 +131,9 @@ class UpsertorABC(abc.ABC):
 		```json
 		{
 			"collection": "users",
+			"event_type": "create_user",
 			"custom": {
-				"custom_key": "custom_value",
-				"event_type": "create_user"
+				"custom_key": "custom_value"
 				},
 			"upsertor": {
 				"id": "2O-h3ulpO-ZwDrkSbQlYB3pYS0JJxCJj3nr6uQAu8aU",


### PR DESCRIPTION
(https://github.com/TeskaLabs/asab/issues/370).

Now the user can call `.upsertor()` method with an optional argument `event_type`, which is `str` or `None` and it adds
```python
{"event_type": event_type}}
```
into webhook.