### PR TITLE
Fix/generate id when not specified in `InMemory` storage

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -363,9 +363,7 @@ class ElasicSearchUpsertor(UpsertorABC):
 			self.ModSet['_c'] = now  # Set the creation timestamp
 
 
-	@classmethod
-	def generate_id(cls):
-		raise NotImplementedError("generate_id")
+
 
 
 	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -368,8 +368,6 @@ class ElasicSearchUpsertor(UpsertorABC):
 		raise NotImplementedError("generate_id")
 
 
-
-
 	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
 		# TODO: Implement webhook call
 		if self.ObjId is None:

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -363,6 +363,10 @@ class ElasicSearchUpsertor(UpsertorABC):
 			self.ModSet['_c'] = now  # Set the creation timestamp
 
 
+	@classmethod
+	def generate_id(cls):
+		raise NotImplementedError("generate_id")
+
 
 
 

--- a/asab/storage/inmemory.py
+++ b/asab/storage/inmemory.py
@@ -6,6 +6,11 @@ from .exceptions import DuplicateError
 
 class InMemoryUpsertor(UpsertorABC):
 
+	def __init__(self, storage, collection, obj_id, version=None):
+		super().__init__(storage, collection, obj_id, version)
+		if self.ObjId is None:
+			# generate a random unique binary ID
+			self.ObjId = self.generate_id()
 
 	async def execute(self, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
 		# TODO: Implement webhook call

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -19,16 +19,12 @@ L = logging.getLogger(__name__)
 class UpsertorABC(abc.ABC):
 
 	def __init__(self, storage, collection, obj_id, version=None):
-		'''
-		'''
 
 		self.Storage = storage
 		self.Collection = collection
 		self.ObjId = obj_id
 
-		if self.ObjId is None:
-			# generate a random unique binary id
-			self.ObjId = self.__class__.generate_id()
+
 
 		self.Version = version
 

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -26,6 +26,10 @@ class UpsertorABC(abc.ABC):
 		self.Collection = collection
 		self.ObjId = obj_id
 
+		if self.ObjId is None:
+			# generate a random unique binary id
+			self.ObjId = self.__class__.generate_id()
+
 		self.Version = version
 
 		now = datetime.datetime.now(datetime.timezone.utc)
@@ -53,9 +57,14 @@ class UpsertorABC(abc.ABC):
 
 	@classmethod
 	def generate_id(cls):
+		"""
+		Generate a unique ID string using a combination of a random UUID and a SHA-256 hash.
+
+		:return: A string representation of the generated ID.
+		"""
 		m = hashlib.sha256()
 		m.update(uuid.uuid4().bytes)
-		return m.digest()
+		return m.hexdigest()
 
 
 	def set(self, objField, value, encrypt=False, encrypt_iv=None):

--- a/asab/storage/upsertor.py
+++ b/asab/storage/upsertor.py
@@ -24,8 +24,6 @@ class UpsertorABC(abc.ABC):
 		self.Collection = collection
 		self.ObjId = obj_id
 
-
-
 		self.Version = version
 
 		now = datetime.datetime.now(datetime.timezone.utc)
@@ -52,7 +50,7 @@ class UpsertorABC(abc.ABC):
 
 
 	@classmethod
-	def generate_id(cls):
+	def generate_id(cls) -> bytes:
 		"""
 		Generate a unique ID string using a combination of a random UUID and a SHA-256 hash.
 
@@ -60,7 +58,7 @@ class UpsertorABC(abc.ABC):
 		"""
 		m = hashlib.sha256()
 		m.update(uuid.uuid4().bytes)
-		return m.hexdigest()
+		return m.digest()
 
 
 	def set(self, objField, value, encrypt=False, encrypt_iv=None):


### PR DESCRIPTION
In `InMemoryUpsertor` , IDs were not automatically generated which caused getters and setters not working.

