### PR TITLE
Fix issue with proactor using event loop.

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -205,10 +205,10 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		if self.Version is None:
 			# Initial grab of the version
-			self.Version = int(version)
+			self.Version = version
 			return
 
-		if self.Version == int(version):
+		if self.Version == version:
 			# The version has not changed
 			return
 

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -190,7 +190,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			return
 
 		version = await self.Zookeeper.get_data(self.VersionNodePath)
-		await self.Zookeeper.ProactorService.execute(self._check_version_counter, version)
+		self._check_version_counter(version)
 
 
 	def _check_version_counter(self, version):


### PR DESCRIPTION
```
05-May-2023 06:31:58.716583 ERROR root Task exception was never retrieved
{'future': <Task finished coro=<ZooKeeperLibraryProvider._get_version_counter() done, defined at /usr/local/lib/python3.7/site-packages/asab/library/providers/zookeeper.py:188> exception=RuntimeError("There is no current event loop in thread 'AsabProactorThread_265'.")>}
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/asab/library/providers/zookeeper.py", line 193, in _get_version_counter
    await self.Zookeeper.ProactorService.execute(self._check_version_counter, version)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.7/site-packages/asab/library/providers/zookeeper.py", line 216, in _check_version_counter
    self.App.PubSub.publish("Library.change!", self, "TODO")
  File "/usr/local/lib/python3.7/site-packages/asab/pubsub.py", line 130, in publish
    callback(message_type, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/asab/pubsub.py", line 89, in _deliver_async
    asyncio.ensure_future(callback(message_type, *args, **kwargs))
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 607, in ensure_future
    loop = events.get_event_loop()
  File "/usr/local/lib/python3.7/asyncio/events.py", line 644, in get_event_loop
    % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'AsabProactorThread_265'.
```

Tested