### PR TITLE
return True when resources are ok

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -182,6 +182,7 @@ class AuthService(asab.Service):
 		for resource in required_resources:
 			if resource not in authorized_resources:
 				return False
+		return True
 
 
 	async def _fetch_public_keys_if_needed(self, *args, **kwargs):


### PR DESCRIPTION
We could not proceed with implementing resources in bs-query. This helped, but I am a bit scared of touching this thing, so please, do check this twice. 

Also, I am a bit not happy about growing configuration needs. 

from my config:
```
[auth]
#dev_mode=yes
multitenancy=yes
public_keys_url=http://localhost:8181/openidconnect/public_keys
tenant_url=http://localhost:8181/tenant
```

is tenant_url really needed there?