### PR TITLE
Optional multitenancy in dev mode

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -453,8 +453,12 @@ def _get_id_token_claims(bearer_token: str, auth_server_public_key):
 	except jwcrypto.jws.InvalidJWSSignature:
 		L.warning("Invalid ID token signature.")
 		raise asab.exceptions.NotAuthenticatedError()
+	except ValueError as e:
+		L.error(
+			"Failed to parse JWT ID token ({}). Please check if the Authorization header contains ID token.".format(e))
+		raise aiohttp.web.HTTPBadRequest()
 	except Exception:
-		L.exception("Failed to parse JWT ID token.")
+		L.exception("Failed to parse JWT ID token. Please check if the Authorization header contains ID token.")
 		raise aiohttp.web.HTTPBadRequest()
 
 	try:


### PR DESCRIPTION
When the `dev_mode` is enabled, the `multitenancy` switch is ignored. 
The tenant parameter from query string is extracted if there is one, otherwise it is set to `None`.