### PR TITLE
Reload auth public keys when needed

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -347,7 +347,7 @@ class AuthService(asab.Service):
 		Check access to requested tenant and add tenant resources to the request
 		"""
 		# Check if tenant access is authorized
-		if tenant not in request._Tenants and not request.has_superuser_access():
+		if tenant not in request._Tenants:
 			L.warning("Tenant not authorized.", struct_data={"tenant": tenant, "sub": request._UserInfo.get("sub")})
 			raise asab.exceptions.AccessDeniedError()
 

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -196,12 +196,10 @@ class AuthService(asab.Service):
 		Check if public keys have been fetched from the authorization server and fetch them if not yet.
 		"""
 		now = datetime.datetime.now(datetime.timezone.utc)
-		print(self.AuthServerLastSuccessfulCheck)
 		if self.AuthServerLastSuccessfulCheck is not None \
 			and now < self.AuthServerLastSuccessfulCheck + self.AuthServerCheckCooldown:
 			# Public keys have been fetched recently
 			return
-		print("checking server")
 
 		async with aiohttp.ClientSession() as session:
 			try:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -153,7 +153,7 @@ class AuthService(asab.Service):
 		return True
 
 
-	def get_userinfo_from_id_token(self, bearer_token):
+	async def get_userinfo_from_id_token(self, bearer_token):
 		"""
 		Parse the bearer ID token and extract user info.
 		"""
@@ -305,7 +305,7 @@ class AuthService(asab.Service):
 			else:
 				# Extract user info from the request Authorization header
 				bearer_token = _get_bearer_token(request)
-				user_info = self.get_userinfo_from_id_token(bearer_token)
+				user_info = await self.get_userinfo_from_id_token(bearer_token)
 
 			# Add userinfo, tenants and global resources to the request
 			request._UserInfo = user_info


### PR DESCRIPTION
- Instead of a periodic pull, try to reload auth server public keys anytime they are outdated or not ready at the time of request authentication.
- **`BREAKING`** Superuser can only access tenants that are authorized in the current session.
- Removed the `tenant_url` config option, which is no longer necessary.