### PR TITLE
Add an explicit exception handling to PubSub synchronous message delivery

### DIFF
--- a/asab/pubsub.py
+++ b/asab/pubsub.py
@@ -126,7 +126,10 @@ class PubSub(object):
 
 		else:
 			for callback in self._callback_iter(message_type):
-				callback(message_type, *args, **kwargs)
+				try:
+					callback(message_type, *args, **kwargs)
+				except Exception:
+					L.exception("Error in a PubSub callback", struct_data={'message_type': message_type})
 
 
 	def publish_threadsafe(self, message_type, *args, **kwargs):


### PR DESCRIPTION
Missing exception handling for PubSub resulted in a very strange and non-deterministic propagation of an exception from the PubSub handler to a caller.