### PR TITLE
Add an application-level restart

### DIFF
--- a/asab/application.py
+++ b/asab/application.py
@@ -348,7 +348,7 @@ class Application(metaclass=Singleton):
 			if hasattr(self.Loop, "shutdown_asyncgens"):
 				self.Loop.run_until_complete(self.Loop.shutdown_asyncgens())
 			self.Loop.close()
-		
+
 		finally:
 			if self.ExitCode == "!RESTART!":
 				os.execv(sys.executable, [os.path.basename(sys.executable)] + sys.argv)


### PR DESCRIPTION
Add a method `app.restart()` that schedules a **hard restart** of the whole application.

This function works by using `os.execv()`, which replaces the current process with a new one (without creating a new process ID). Arguments and environment variables will be retained.

https://en.wikipedia.org/wiki/Exec_(system_call)
 
**IMPORTANT:** Please note that this will work on Unix-based systems only, as it uses a feature specific to Unix.
 
**A piece of advice:** Be careful while using this function, make sure you have some control over when and how this function is being called to avoid any unexpected process restarts. It is not common to use these types of function calls in Python applications.