### PR TITLE
Verbose dev mode info when the app starts

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -99,13 +99,19 @@ class AuthService(asab.Service):
 
 		self.DevModeEnabled = asab.Config.getboolean("auth", "dev_mode")
 		if self.DevModeEnabled:
-			self.DevUserInfo = DEV_USERINFO_DEFAULT
 			dev_user_info_path = asab.Config.get("auth", "dev_user_info_path")
 			if os.path.isfile(dev_user_info_path):
 				# Update userinfo with custom values
 				# Unset fields with null values
 				with open(dev_user_info_path, "rb") as fp:
 					self.DevUserInfo = json.load(fp)
+			else:
+				self.DevUserInfo = DEV_USERINFO_DEFAULT
+			# Validate user info
+			resources = self.DevUserInfo.get("resources", {})
+			if not isinstance(resources, dict) or not all(
+				map(lambda kv: isinstance(kv[0], str) and isinstance(kv[1], list), resources.items())):
+				raise ValueError("User info 'resources' must be an object with string keys and array values.")
 			L.warning(
 				"AuthService is running in DEV MODE. All web requests will be authorized with mock user info, which "
 				"currently grants access to the following tenants: {}. To customize dev mode authorization (add or "

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -99,26 +99,27 @@ class AuthService(asab.Service):
 
 		self.DevModeEnabled = asab.Config.getboolean("auth", "dev_mode")
 		if self.DevModeEnabled:
+			# Load custom user info
 			dev_user_info_path = asab.Config.get("auth", "dev_user_info_path")
 			if os.path.isfile(dev_user_info_path):
-				# Update userinfo with custom values
-				# Unset fields with null values
 				with open(dev_user_info_path, "rb") as fp:
 					self.DevUserInfo = json.load(fp)
 			else:
 				self.DevUserInfo = DEV_USERINFO_DEFAULT
+
 			# Validate user info
 			resources = self.DevUserInfo.get("resources", {})
 			if not isinstance(resources, dict) or not all(
-				map(lambda kv: isinstance(kv[0], str) and isinstance(kv[1], list), resources.items())):
+				map(lambda kv: isinstance(kv[0], str) and isinstance(kv[1], list), resources.items())
+			):
 				raise ValueError("User info 'resources' must be an object with string keys and array values.")
+
 			L.warning(
 				"AuthService is running in DEV MODE. All web requests will be authorized with mock user info, which "
 				"currently grants access to the following tenants: {}. To customize dev mode authorization (add or "
 				"remove tenants and resources, change username etc.), provide your own user info in {!r}.".format(
 					list(t for t in self.DevUserInfo.get("resources", {}).keys() if t != "*"),
-					dev_user_info_path)
-			)
+					dev_user_info_path))
 		else:
 			if len(self.PublicKeysUrl) == 0:
 				raise ValueError("No 'public_keys_url' provided in [auth] config section.")

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -15,7 +15,7 @@ asab.Config["auth"]["multitenancy"] = "yes"
 # The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
 # You can provide custom user info by specifying `dev_user_info_path` pointing to your JSON file.
 asab.Config["auth"]["dev_mode"] = "yes"
-asab.Config["auth"]["dev_user_info_path"] = ""
+asab.Config["auth"]["dev_user_info_path"] = "./dev-userinfo.json"
 
 # URL of the authorization server's JWK public keys, used for ID token verification.
 # This option is ignored in dev mode.
@@ -36,9 +36,10 @@ class MyApplication(asab.Application):
 		self.WebService = self.get_service("asab.WebService")
 		self.WebContainer = asab.web.WebContainer(self.WebService, "web")
 
+		self.WebContainer.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
+
 		# Initialize authorization
 		self.AuthService = asab.web.auth.AuthService(self)
-		self.WebContainer.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
 		self.AuthService.install(self.WebContainer)
 
 		# Add routes


### PR DESCRIPTION
When dev mode is enabled, a message of the following type is logged on startup:
```
01-Jun-2023 17:06:37.298255 WARNING asab.web.auth.service AuthService is running in DEV MODE. 
All web requests will be authorized with mock user info, which currently grants access to the following 
tenants: ['test-tenant', 'default']. To customize dev mode authorization (add or remove tenants and resources, 
change username etc.), provide your own user info in '/conf/dev-userinfo.json'.

```

Also added the tenant `default` to the default mock userinfo, since it is also used in asab webui dev mode.