### PR TITLE
Draft: Documentation: Git Provider in ASAB Library

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -47,7 +47,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		split_path = path.split("#", 1)
 		if len(split_path) > 1:
 			self.Branch = split_path[-1]
-			self.URL = split_path[0][4:]
+			self.URL = split_path[0][4:]  # omit 'git+' part
 		else:
 			self.Branch = None
 			self.URL = path[4:]

--- a/doc/asab/library.rst
+++ b/doc/asab/library.rst
@@ -166,6 +166,9 @@ After the deploy token is created, use the URL for repository in the following f
 
     https://<username>:<deploy_token>@gitlab.example.com/john/awesome_project.git
 
+Reference
+~~~~~~~~~
+
 .. py:currentmodule:: asab.library.providers.git
 
 .. autoclass:: GitLibraryProvider

--- a/doc/asab/library.rst
+++ b/doc/asab/library.rst
@@ -129,6 +129,43 @@ Microsoft Azure Storage
 Git repository
 ^^^^^^^^^^^^^^
 
+Connection to git repositories requires `pygit2 <https://www.pygit2.org/>`_ library to be installed.
+
+Example of configuration:
+
+.. code:: ini
+
+    [library]
+    providers: git+https://github.com/john/awesome_project.git
+
+Functionality
+~~~~~~~~~~~~~
+
+The git provider clones the repository into a temporary directory and then uses the File System Provider to read the files from it. The default path for the cloned repository is `/tmp/asab.library.git/` and it can be changed manually:
+
+.. code:: ini
+
+    [library:git]
+    repodir=path/to/repository/cache
+
+
+Deploy tokens in GitLab
+~~~~~~~~~~~~~~~~~~~~~~~
+GitLab uses deploy tokens to enable authentication of deployment tasks, independent of a user account. A `deploy token` is an SSH key that grants access to a single repository. The public part of the key is attached directly to the repository instead of a personal account, and the private part of the key remains on the server. It is the preferred preferred way over changing local SSH settings.
+
+If you want to create a deploy token for your GitLab repository, follow these steps from the `manual <https://docs.gitlab.com/ee/user/project/deploy_tokens/#create-a-deploy-token>`_:
+
+1. Go to **Settings > Repository > Deploy tokens** section in your repository. (Note that you have to possess "Maintainer" or "Owner" role for the repository.)
+2. Expand the "Deploy tokens" section. The list of current Active Deploy Tokens will be displayed. 
+3. Complete the fields and scopes. We recommend to specify custom "username", as you will need it later for the url in configuration.
+4. Record the deploy token's values *before leaving or refreshing the page*! After that, you cannot access it again.
+
+After the deploy token is created, use the URL for repository in the following format:
+
+.. code::
+
+    https://<username>:<deploy_token>@gitlab.example.com/john/awesome_project.git
+
 .. py:currentmodule:: asab.library.providers.git
 
 .. autoclass:: GitLibraryProvider

--- a/examples/library-git-provider.py
+++ b/examples/library-git-provider.py
@@ -9,11 +9,14 @@ class MyApplication(asab.Application):
 		super().__init__()
 
 		# Specify the location of the library
+		# The branch can be optionally specified in the URL fragment (after '#')
+		# If the branch does not exist, KeyError is raised with the message: "reference 'refs/remotes/origin/...' not found"
 		asab.Config["library"]["providers"] = "git+https://github.com/TeskaLabs/asab.git"
 
-		self.LibraryService = asab.library.LibraryService(self, "LibraryService")
+		self.LibraryService = asab.library.LibraryService(self, "LibraryService", )
 
-		self.Path = "/examples/data/"  # path to directory must start and end with "/"
+		# Specify the directory path. It must start and end with "/"!
+		self.Path = "/examples/data/"
 
 		# Continue only if the library is ready
 		self.PubSub.subscribe("Library.ready!", self.on_library_ready)
@@ -23,12 +26,12 @@ class MyApplication(asab.Application):
 		items = await self.LibraryService.list(self.Path, recursive=True)
 
 		print("=" * 10)
-		print("# Testing git provider with ASAB Library\n")
+		print("# Testing Git provider with ASAB Library\n")
 		print("The repository is cloned to a temporary directory: {}".format(self.LibraryService.Libraries[0].RepoPath))
 		print("=" * 10)
 
 		if len(items) == 0:
-			print("There are no items in directory {}!".format())
+			print("There are no items in directory {}!".format(self.Path))
 		else:
 			print("Items:")
 

--- a/examples/library-git-provider.py
+++ b/examples/library-git-provider.py
@@ -27,8 +27,12 @@ class MyApplication(asab.Application):
 
 		print("=" * 10)
 		print("# Testing Git provider with ASAB Library\n")
-		print("The repository is cloned to a temporary directory: {}".format(self.LibraryService.Libraries[0].RepoPath))
-		print("=" * 10)
+		print("The repository is cloned to a temporary directory: {}\n".format(self.LibraryService.Libraries[0].RepoPath))
+
+		if self.LibraryService.Libraries[0].Branch is not None:
+			print("On branch: {}\n".format(self.LibraryService.Libraries[0].Branch))
+		else:
+			print("On branch: master/main\n")
 
 		if len(items) == 0:
 			print("There are no items in directory {}!".format(self.Path))

--- a/examples/library-git-provider.py
+++ b/examples/library-git-provider.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import asab
+import asab.library
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__()
+
+		# Specify the location of the library
+		asab.Config["library"]["providers"] = "git+https://github.com/TeskaLabs/asab.git"
+
+		self.LibraryService = asab.library.LibraryService(self, "LibraryService")
+
+		self.Path = "/examples/data/"  # path to directory must start and end with "/"
+
+		# Continue only if the library is ready
+		self.PubSub.subscribe("Library.ready!", self.on_library_ready)
+
+
+	async def on_library_ready(self, event_name, library):
+		items = await self.LibraryService.list(self.Path, recursive=True)
+
+		print("=" * 10)
+		print("# Testing git provider with ASAB Library\n")
+		print("The repository is cloned to a temporary directory: {}".format(self.LibraryService.Libraries[0].RepoPath))
+		print("=" * 10)
+
+		if len(items) == 0:
+			print("There are no items in directory {}!".format())
+		else:
+			print("Items:")
+
+		for item in items:
+			print("*", item.name)
+			if item.type == 'item':
+				itemio = await self.LibraryService.read(item.name)
+				if itemio is not None:
+					with itemio:
+						content = itemio.read()
+						print("  - content: {} bytes".format(len(content)))
+				else:
+					print("  - N/A")  # Item is likely disabled
+		print("\n", "=" * 10, sep="")
+		self.stop()
+
+
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()

--- a/examples/library-git-provider.py
+++ b/examples/library-git-provider.py
@@ -13,11 +13,13 @@ class MyApplication(asab.Application):
 		# If the branch does not exist, KeyError is raised with the message: "reference 'refs/remotes/origin/...' not found"
 		asab.Config["library"]["providers"] = "git+https://github.com/TeskaLabs/asab.git"
 
+		# NOTE: If cloning from GitLab, use Deploy Tokens and specify the provider in format:
+		# git+https://<username>:<deploy_token>@gitlab.com/john/awesome_project.git
+
 		# The repository will be cloned to a temporary directory. You can optionally specify the path like this:
 		# asab.Config["library:git"]["repodir"] = "/tmp/asab.provider.git/awesome_project"
 
-
-		self.LibraryService = asab.library.LibraryService(self, "LibraryService", )
+		self.LibraryService = asab.library.LibraryService(self, "LibraryService")
 
 		# Specify the directory path. It must start and end with "/"!
 		self.Path = "/examples/data/"

--- a/examples/library-git-provider.py
+++ b/examples/library-git-provider.py
@@ -13,6 +13,10 @@ class MyApplication(asab.Application):
 		# If the branch does not exist, KeyError is raised with the message: "reference 'refs/remotes/origin/...' not found"
 		asab.Config["library"]["providers"] = "git+https://github.com/TeskaLabs/asab.git"
 
+		# The repository will be cloned to a temporary directory. You can optionally specify the path like this:
+		# asab.Config["library:git"]["repodir"] = "/tmp/asab.provider.git/awesome_project"
+
+
 		self.LibraryService = asab.library.LibraryService(self, "LibraryService", )
 
 		# Specify the directory path. It must start and end with "/"!
@@ -23,6 +27,7 @@ class MyApplication(asab.Application):
 
 
 	async def on_library_ready(self, event_name, library):
+
 		items = await self.LibraryService.list(self.Path, recursive=True)
 
 		print("=" * 10)

--- a/examples/library-subscribe.py
+++ b/examples/library-subscribe.py
@@ -9,12 +9,8 @@ class MyApplication(asab.Application):
 
 	def __init__(self):
 		super().__init__()
-		asab.Config.read_string(
-			"""
-[library]
-providers=git+https://github.com/TeskaLabs/asab.git
-"""
-		)
+		asab.Config["library"]["providers"] = "git+https://github.com/TeskaLabs/asab.git"
+
 		self.LibraryService = asab.library.LibraryService(
 			self,
 			"LibraryService",
@@ -24,6 +20,8 @@ providers=git+https://github.com/TeskaLabs/asab.git
 		self.PubSub.subscribe("Library.ready!", self.on_library_ready)
 		self.PubSub.subscribe("Library.change!", self.on_library_change)
 
+		# NOTE: Git Provider periodically pulls changes once per minute
+
 
 	async def on_library_ready(self, event_name, library=None):
 		items = await self.LibraryService.list("", recursive=True)
@@ -32,7 +30,8 @@ providers=git+https://github.com/TeskaLabs/asab.git
 			print(" *", item)
 		print("\n===")
 
-		self.LibraryService.subscribe(["/asab"])
+		# Add subscription for changes in paths
+		await self.LibraryService.subscribe(["/asab"])
 
 	def on_library_change(self, msg, provider, path):
 		print("\N{rabbit} New changes in the library found by provider: '{}'".format(provider))


### PR DESCRIPTION
- An example of how to use git provider created.
- A small section about git provider added together with manual on Deploy Tokens on GitLab.

![Screenshot 2023-06-12 at 14-47-39 Library — ASAB documentation](https://github.com/TeskaLabs/asab/assets/68327081/a8f99e4f-bccd-4333-b90b-15df27ab7218)
