### PR TITLE
Documentation: Library

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -26,13 +26,13 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 	FileSystemLibraryProvider to read the files.
 	To read from local git repository, please use FileSystemProvider.
 
-	```
-	[library]
-	providers=git+<URL or deploy token>#<branch name>
+	.. code::
 
-	[library:git]
-	repodir=<optional location of the repository cache>
-	```
+		[library]
+		providers=git+<URL or deploy token>#<branch name>
+
+		[library:git]
+		repodir=<optional location of the repository cache>
 	"""
 	def __init__(self, library, path):
 

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -29,71 +29,74 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 	1) ZooKeeper provider is fully configured from [zookeeper] section
 
-	```
-	[zookeeper]
-	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
-	path=/library
+	.. code::
 
-	[library]
-	providers:
-		zk://
-	```
+		[zookeeper]
+		servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+		path=/library
+
+		[library]
+		providers:
+			zk://
+
 
 
 	2) ZooKeeper provider is configured by `servers` from [zookeeper] section and path from URL
 
-	Path will be `/library'.
+	Path will be `/library`.
 
-	```
-	[zookeeper]
-	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
-	path=/else
+	.. code::
 
-	[library]
-	providers:
-		zk:///library
-	```
+		[zookeeper]
+		servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+		path=/else
+
+		[library]
+		providers:
+			zk:///library
 
 
 	2.1) ZooKeeper provider is configured by `servers` from [zookeeper] section and path from URL
 
-	Path will be `/', this is a special case to 2)
+	Path will be `/`, this is a special case to 2)
 
-	```
-	[zookeeper]
-	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
-	path=/else
+	.. code::
 
-	[library]
-	providers:
-		zk:///
-	```
+		[zookeeper]
+		servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+		path=/else
+
+		[library]
+		providers:
+			zk:///
 
 	3) ZooKeeper provider is fully configured from URL
 
-	```
-	[library]
-	providers:
-		zk://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/library
-	```
+	.. code::
+
+		[library]
+		providers:
+			zk://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/library
+
 
 	4) ZooKeeper provider is configured by `servers` from [zookeeper] section and  joined `path` from [zookeeper] and
 	path from URL
 
-	Path will be `/else/library'
+	Path will be `/else/library`
 
-	```
-	[zookeeper]
-	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
-	path=/else
+	.. code::
 
-	[library]
-	providers:
-		zk://./library
-	```
+		[zookeeper]
+		servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+		path=/else
+
+		[library]
+		providers:
+			zk://./library
+
 
 	If `path` from [zookeeper] section is missing, an application class name will be used
-	Ex. `/BSQueryApp/library'
+	Ex. `/BSQueryApp/library`
 
 	"""
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -25,15 +25,6 @@ L = logging.getLogger(__name__)
 
 class LibraryService(Service):
 	"""
-	ASAB library (aka LibraryService) is an abstration for unified filesystem-like access to resources.
-	In the cluster/cloud microservice architectures, it is imperative that all microservices have access to unified resources.
-	There are technologies such as Apache Zookeeper that provides means for it.
-
-	ASAB library builts on top of this concept and brings that into the ASAB microservice.
-
-	ASAB library is designed to be read-only.
-	It also allows to "stack" various libraries into one view (overlayed) that merges content of each library into one united space.
-
 	Configuration:
 
 	.. code::
@@ -51,19 +42,19 @@ class LibraryService(Service):
 	* `zk://` or `zookeeper://` for ZooKeeper provider
 	* `file://` or local path for FileSystem provider
 	* `azure+https://` for Microsoft Azure Storage provider.
+	* `git+https://` for Git provider.
 
-	The first provider is also responsible for providing `/.disabled.yaml` that controls a visibility of items.
-	If `/.disabled.yaml` is not present, then is considered empty.
+	The first provider is responsible for providing `/.disabled.yaml`.
 
-	A library is created in "not ready" state, each provider then inform library when it is ready (eg. Zookeeper provider needs to connect to Zookeeper servers).
-	Only after all providers are ready, the library itself become ready.
+	A library is created in “not ready” state, each provider then informs the library when it is ready
+	(eg. Zookeeper provider needs to connect to Zookeeper servers). Only after all providers are ready, the library itself becomes ready.
 	The library indicates that by the PubSub event `Library.ready!`.
 	"""
 
 	def __init__(self, app, service_name, paths=None):
 		"""
-		The library service is designed to "exists" in multiple instances,
-		with different `paths` setup.
+		The library service is designed to "exist" in multiple instances,
+		with different `paths` setups.
 		For that reason, you have to provide unique `service_name`
 		and there is no _default_ value for that.
 
@@ -198,7 +189,7 @@ class LibraryService(Service):
 		return None
 
 
-	async def list(self, path="/", tenant=None, recursive=False):
+	async def list(self, path="/", tenant=None, recursive=False) -> list:
 		"""
 		List the directory of the library specified by the path.
 		It returns a list of `LibraryItem` entris.
@@ -335,7 +326,7 @@ class LibraryService(Service):
 		return False
 
 
-	async def export(self, path="/", tenant=None, remove_path=False):
+	async def export(self, path="/", tenant=None, remove_path=False) -> typing.IO:
 		"""
 		It takes a path, and returns a file-like object containing a gzipped tar archive of the library contents of
 		that path
@@ -393,6 +384,7 @@ class LibraryService(Service):
 	async def subscribe(self, paths):
 		"""
 		It subscribes to the changes in the library
+
 		:param paths: A list of absolute paths to subscribe to
 		"""
 		for path in paths:

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -36,13 +36,13 @@ class LibraryService(Service):
 
 	Configuration:
 
-	```
-	[library]
-	providers:
-		provider+1://
-		provider+2://
-		provider+3://
-	```
+	.. code::
+
+		[library]
+		providers:
+			provider+1://
+			provider+2://
+			provider+3://
 
 	The order of providers *IS* important, the priority (or layering) is top-down.
 
@@ -169,12 +169,13 @@ class LibraryService(Service):
 
 		Example of use:
 
-		```
-		itemio = await library.read('/path', 'tenant')
-		if itemio is not None:
-			with itemio:
-				return itemio.read()
-		```
+		.. code::
+
+			itemio = await library.read('/path', 'tenant')
+			if itemio is not None:
+				with itemio:
+					return itemio.read()
+
 
 		:param path: The path to the file, `LibraryItem.name` can be used directly
 		:param tenant: The tenant to apply. If not specified, the global access is assumed
@@ -342,7 +343,6 @@ class LibraryService(Service):
 		:param path: The path to export, defaults to / (optional)
 		:param tenant: The tenant to use for the operation
 		:param remove_path: If True, the path will be removed from the tar file, defaults to False
-		(optional)
 		:return: A file object.
 		"""
 

--- a/doc/asab/library.rst
+++ b/doc/asab/library.rst
@@ -1,33 +1,35 @@
+.. py:currentmodule:: asab.library
+
 .. _library-ref:
+
+
 
 Library
 =======
-
-.. py:currentmodule:: asab.library
 
 The ASAB Library (`asab.library`) is a concept of the shared data content across microservices in the cluster.
 The `asab.library` provides a read-only interface for listing and reading this content.
 The library can also notify the ASAB microservice about changes, eg. for automated update/reload.
 
-There is a companion microservice `asab-library` that can be used for management and editation of the library content.
+There is a companion microservice `asab-library` that can be used for the management and editing of the library content.
 The `asab.library` can however operate without `asab-library` microservice.
 
 
 Library structure
 -----------------
 
-The library content is organized in simplified filesystem manner, with directories and files.
+The library content is organized in a simplified filesystem manner, with directories and files.
 
 Example of the library structure:
 
-.. code:: 
+.. code::
 
  + /folder1/
    - /folder1/item1.yaml
    - /folder1/item2.json
  + /folder2/
    - /folder2/item3.yaml
-   + /folder2folder2.3/
+   + /folder2/folder2.3/
      - /folder2/folder2.3/item4.json
 
 
@@ -36,13 +38,11 @@ Library path rules
 
 * Any path must start with `/`, including the root path (`/`).
 * The folder path must end with `/`.
-* The item path must end with extension (eg. `.json`).
+* The item path must end with an extension (eg. `.json`).
 
 
 Library service
 ---------------
-
-.. autoclass:: LibraryService
 
 
 Example of the use:
@@ -50,12 +50,22 @@ Example of the use:
 .. code:: python
 
     import asab
+    import asab.library
+
+
+    # this substitutes configuration file
+    asab.Config.read_string(
+                """
+    [library]
+    providers=git+https://github.com/TeskaLabs/asab-maestro-library.git
+    """
+            )
+
 
     class MyApplication(asab.Application):
 
         def __init__(self):
             super().__init__()
-
             # Initialize the library service 
             self.LibraryService = asab.library.LibraryService(self, "LibraryService")
             self.PubSub.subscribe("Library.ready!", self.on_library_ready)
@@ -63,7 +73,7 @@ Example of the use:
         async def on_library_ready(self, event_name, library):
             print("# Library\n")
 
-            for item in await self.LibraryService.list("", recursive=True):
+            for item in await self.LibraryService.list("/", recursive=True):
                 print(" *", item)
                 if item.type == 'item':
                     itemio = await self.LibraryService.read(item.name)
@@ -74,18 +84,25 @@ Example of the use:
                     else:
                         print("  - (DISABLED)")
 
+    if __name__ == '__main__':
+        app = MyApplication()
+        app.run()
 
-.. automethod:: LibraryService.read
+For more examples of Library usage, please see `ASAB examples <https://github.com/TeskaLabs/asab/tree/master/examples>`_
 
-.. automethod:: LibraryService.list
 
-.. automethod:: LibraryService.export
+.. autoclass:: LibraryService
+
+    .. automethod:: read
+
+    .. automethod:: list
+
+    .. automethod:: export
 
 
 
 Notification of changes
 -----------------------
-
 
 .. automethod:: LibraryService.subscribe
 
@@ -179,7 +196,7 @@ Reference
 Layers
 ------
 
-The library content can be organized into unlimmited number of layers.
+The library content can be organized into an unlimited number of layers.
 Each layer is represented by a `provider` with a specific configuration.
 
 

--- a/doc/asab/library.rst
+++ b/doc/asab/library.rst
@@ -8,8 +8,13 @@ Library
 =======
 
 The ASAB Library (`asab.library`) is a concept of the shared data content across microservices in the cluster.
+In the cluster/cloud microservice architectures, all microservices must have access to unified resources.
 The `asab.library` provides a read-only interface for listing and reading this content.
-The library can also notify the ASAB microservice about changes, eg. for automated update/reload.
+
+`asab.library` is designed to be read-only.
+It also allows to "stack" various libraries into one view (overlayed) that merges the content of each library into one united space.
+
+The library can also notify the ASAB microservice about changes, e.g. for automated update/reload.
 
 There is a companion microservice `asab-library` that can be used for the management and editing of the library content.
 The `asab.library` can however operate without `asab-library` microservice.
@@ -30,7 +35,7 @@ Example of the library structure:
  + /folder2/
    - /folder2/item3.yaml
    + /folder2/folder2.3/
-     - /folder2/folder2.3/item4.json
+	 - /folder2/folder2.3/item4.json
 
 
 Library path rules
@@ -38,7 +43,20 @@ Library path rules
 
 * Any path must start with `/`, including the root path (`/`).
 * The folder path must end with `/`.
-* The item path must end with an extension (eg. `.json`).
+* The item path must end with an extension (e.g. `.json`).
+
+Layers
+------
+
+The library content can be organized into an unlimited number of layers.
+Each layer is represented by a `provider` with a specific configuration.
+
+The layers of the library are like slices of Swiss cheese layered on top of each other.
+Only if there is a hole in the top layer can you see the layer that shows through underneath.
+It means that files of the upper layer overwrite files with the same path in the lower layers.
+
+The first provider is responsible for providing `/.disabled.yaml` that controls the visibility of items.
+If `/.disabled.yaml` is not present, then is considered empty.
 
 
 Library service
@@ -49,155 +67,49 @@ Example of the use:
 
 .. code:: python
 
-    import asab
-    import asab.library
+	import asab
+	import asab.library
 
 
-    # this substitutes configuration file
-    asab.Config.read_string(
-                """
-    [library]
-    providers=git+https://github.com/TeskaLabs/asab-maestro-library.git
-    """
-            )
+	# this substitutes configuration file
+	asab.Config.read_string(
+				"""
+	[library]
+	providers=git+https://github.com/TeskaLabs/asab-maestro-library.git
+	"""
+			)
 
 
-    class MyApplication(asab.Application):
+	class MyApplication(asab.Application):
 
-        def __init__(self):
-            super().__init__()
-            # Initialize the library service 
-            self.LibraryService = asab.library.LibraryService(self, "LibraryService")
-            self.PubSub.subscribe("Library.ready!", self.on_library_ready)
+		def __init__(self):
+			super().__init__()
+			# Initialize the library service 
+			self.LibraryService = asab.library.LibraryService(self, "LibraryService")
+			self.PubSub.subscribe("Library.ready!", self.on_library_ready)
 
-        async def on_library_ready(self, event_name, library):
-            print("# Library\n")
+		async def on_library_ready(self, event_name, library):
+			print("# Library\n")
 
-            for item in await self.LibraryService.list("/", recursive=True):
-                print(" *", item)
-                if item.type == 'item':
-                    itemio = await self.LibraryService.read(item.name)
-                    if itemio is not None:
-                        with itemio:
-                            content = itemio.read()
-                            print("  - content: {} bytes".format(len(content)))
-                    else:
-                        print("  - (DISABLED)")
+			for item in await self.LibraryService.list("/", recursive=True):
+				print(" *", item)
+				if item.type == 'item':
+					itemio = await self.LibraryService.read(item.name)
+					if itemio is not None:
+						with itemio:
+							content = itemio.read()
+							print("  - content: {} bytes".format(len(content)))
+					else:
+						print("  - (DISABLED)")
 
-    if __name__ == '__main__':
-        app = MyApplication()
-        app.run()
+	if __name__ == '__main__':
+		app = MyApplication()
+		app.run()
+
+The library service may exist in multiple instances, with different `paths` setups.
+For that reason, you have to provide a unique `service_name` and there is no default value for that.
 
 For more examples of Library usage, please see `ASAB examples <https://github.com/TeskaLabs/asab/tree/master/examples>`_
-
-
-.. autoclass:: LibraryService
-
-    .. automethod:: read
-
-    .. automethod:: list
-
-    .. automethod:: export
-
-
-
-Notification of changes
------------------------
-
-.. automethod:: LibraryService.subscribe
-
-
-
-Providers
----------
-
-.. py:currentmodule:: asab.library.providers
-
-The library can be configured to work with following "backends" (aka providers):
-
-
-Filesystem
-^^^^^^^^^^
-
-.. py:currentmodule:: asab.library.providers.filesystem
-
-.. autoclass:: FileSystemLibraryProvider
-    :no-undoc-members:
-
-
-Apache Zookeeper
-^^^^^^^^^^^^^^^^
-
-.. py:currentmodule:: asab.library.providers.zookeeper
-
-.. autoclass:: ZooKeeperLibraryProvider
-    :no-undoc-members:
-
-
-Microsoft Azure Storage
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. py:currentmodule:: asab.library.providers.azurestorage
-
-.. autoclass:: AzureStorageLibraryProvider
-    :no-undoc-members:
-
-
-Git repository
-^^^^^^^^^^^^^^
-
-Connection to git repositories requires `pygit2 <https://www.pygit2.org/>`_ library to be installed.
-
-Example of configuration:
-
-.. code:: ini
-
-    [library]
-    providers: git+https://github.com/john/awesome_project.git
-
-Functionality
-~~~~~~~~~~~~~
-
-The git provider clones the repository into a temporary directory and then uses the File System Provider to read the files from it. The default path for the cloned repository is `/tmp/asab.library.git/` and it can be changed manually:
-
-.. code:: ini
-
-    [library:git]
-    repodir=path/to/repository/cache
-
-
-Deploy tokens in GitLab
-~~~~~~~~~~~~~~~~~~~~~~~
-GitLab uses deploy tokens to enable authentication of deployment tasks, independent of a user account. A `deploy token` is an SSH key that grants access to a single repository. The public part of the key is attached directly to the repository instead of a personal account, and the private part of the key remains on the server. It is the preferred preferred way over changing local SSH settings.
-
-If you want to create a deploy token for your GitLab repository, follow these steps from the `manual <https://docs.gitlab.com/ee/user/project/deploy_tokens/#create-a-deploy-token>`_:
-
-1. Go to **Settings > Repository > Deploy tokens** section in your repository. (Note that you have to possess "Maintainer" or "Owner" role for the repository.)
-2. Expand the "Deploy tokens" section. The list of current Active Deploy Tokens will be displayed. 
-3. Complete the fields and scopes. We recommend to specify custom "username", as you will need it later for the url in configuration.
-4. Record the deploy token's values *before leaving or refreshing the page*! After that, you cannot access it again.
-
-After the deploy token is created, use the URL for repository in the following format:
-
-.. code::
-
-    https://<username>:<deploy_token>@gitlab.example.com/john/awesome_project.git
-
-Reference
-~~~~~~~~~
-
-.. py:currentmodule:: asab.library.providers.git
-
-.. autoclass:: GitLibraryProvider
-    :no-undoc-members:
-
-
-
-Layers
-------
-
-The library content can be organized into an unlimited number of layers.
-Each layer is represented by a `provider` with a specific configuration.
 
 
 Library configuration
@@ -208,16 +120,226 @@ Example:
 
 .. code:: ini
 
-    [library]
-    providers:
-        provider+1://...
-        provider+2://...
-        provider+3://...
+	[library]
+	providers:
+		provider+1://...
+		provider+2://...
+		provider+3://...
+
 
 
 PubSub messages
 ---------------
+Read more about :ref:`PubSub<pubsub_page>` in ASAB.
 
 .. option:: Library.ready!
 
+A library is created in a “not ready” state.
+Only after all providers are ready, the library itself becomes ready.
+The library indicates that by the PubSub event `Library.ready!`.
+
+.. option:: Library.not_ready!
+
+The readiness of the library (connection to external technologies) can be lost. You can also subscribe to `Library.not_ready!` event.
+
 .. option:: Library.change!
+
+You can get `Notification on Changes`_ in the library. Specify a path or paths that you would like to "listen to". Then subscribe to `Library.change!` PubSub event.
+Available for Git and FileSystem providers for now.
+
+
+
+Notification on changes
+-----------------------
+
+.. automethod:: LibraryService.subscribe
+
+
+
+Providers
+---------
+
+The library can be configured to work with the following "backends" (aka providers):
+
+
+Filesystem
+^^^^^^^^^^
+
+The most basic provider that reads data from the local filesystem.
+The notification on changes functionality is available only for Linux systems, as it implements `inotify <https://en.wikipedia.org/wiki/Inotify>`_
+
+Configuration examples:
+
+.. code:: ini
+
+	[library]
+	providers: /home/user/directory
+
+
+.. code:: ini
+
+	[library]
+	providers: ./this_directory
+
+
+.. code:: ini
+
+	[library]
+	providers: file:///home/user/directory
+
+
+
+Apache Zookeeper
+^^^^^^^^^^^^^^^^
+
+ZooKeeper as a consensus technology is vital for microservices in the cluster.
+
+There are several configuration strategies:
+
+1) Configuration from [zookeeper] section.
+
+.. code:: ini
+
+	[zookeeper]
+	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+	path=/library
+
+	[library]
+	providers:
+		zk://
+
+
+
+2) Specify a path of a ZooKeeper node where only library lives.
+
+	The library path will be `/library`.
+
+.. code:: ini
+
+	[zookeeper]
+	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+	path=/else
+
+	[library]
+	providers:
+		zk:///library
+
+
+	The library path will be `/`.
+
+.. code:: ini
+
+	[zookeeper]
+	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+	path=/else
+
+	[library]
+	providers:
+		zk:///
+
+3) Configuration from the URL in the [library] section.
+
+.. code:: ini
+
+	[library]
+	providers:
+		zk://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/library
+
+
+4) Configuration from [zookeeper] section and joined `path` from [zookeeper] and [library] sections.
+
+	The resulting path will be `/else/library`.
+
+.. code:: ini
+
+	[zookeeper]
+	servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
+	path=/else
+
+	[library]
+	providers:
+		zk://./library
+
+
+If a `path` from the [zookeeper] section is missing, an application class name will be used
+E.g. `/BSQueryApp/library`
+
+
+Microsoft Azure Storage
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Reads from the Microsoft Azure Storage container.
+
+Configuration:
+
+.. code:: ini
+
+	[library]
+	providers: azure+https://ACCOUNT-NAME.blob.core.windows.net/BLOB-CONTAINER
+
+
+If Container Public Access Level is not set to "Public access",
+then "Access Policy" must be created with "Read" and "List" permissions
+and "Shared Access Signature" (SAS) query string must be added to a URL in a configuration:
+
+.. code:: ini
+
+	[library]
+	providers: azure+https://ACCOUNT-NAME.blob.core.windows.net/BLOB-CONTAINER?sv=2020-10-02&si=XXXX&sr=c&sig=XXXXXXXXXXXXXX
+
+
+
+Git repository
+^^^^^^^^^^^^^^
+
+Connection to git repositories requires `pygit2 <https://www.pygit2.org/>`_ library to be installed.
+
+Configuration:
+
+.. code:: ini
+
+	[library]
+	providers: git+https://github.com/john/awesome_project.git
+
+
+Deploy tokens in GitLab
+~~~~~~~~~~~~~~~~~~~~~~~
+GitLab uses deploy tokens to enable authentication of deployment tasks, independent of a user account.
+Authentication through deploy tokens is the only supported option for now.
+
+If you want to create a deploy token for your GitLab repository, follow these steps from the `manual <https://docs.gitlab.com/ee/user/project/deploy_tokens/#create-a-deploy-token>`_:
+
+1. Go to **Settings > Repository > Deploy tokens** section in your repository. (Note that you have to possess a "Maintainer" or "Owner" role for the repository.)
+2. Expand the "Deploy tokens" section. The list of current Active Deploy Tokens will be displayed. 
+3. Complete the fields and scopes. We recommend a custom "username", as you will need it later for the URL in the configuration.
+4. Record the deploy token's values *before leaving or refreshing the page*! After that, you cannot access it again.
+
+After the deploy token is created, use the URL for the repository in the following format:
+
+.. code:: ini
+
+	[library]
+	providers: git+https://<username>:<deploy_token>@gitlab.example.com/john/awesome_project.git
+
+
+Where does the repository clone?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The git provider clones the repository into a temporary directory. The default path for the cloned repository is `/tmp/asab.library.git/` and it can be changed manually:
+
+.. code:: ini
+
+	[library:git]
+	repodir=path/to/repository/cache
+
+
+Reference
+^^^^^^^^^
+.. autoclass:: LibraryService
+
+	.. automethod:: read
+
+	.. automethod:: list
+
+	.. automethod:: export
+

--- a/doc/asab/pubsub.rst
+++ b/doc/asab/pubsub.rst
@@ -1,3 +1,5 @@
+.. _pubsub_page:
+
 Publish-Subscribe
 =================
 

--- a/doc/asab/web/auth.rst
+++ b/doc/asab/web/auth.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: asab.web.auth
+
+Authorization 
+=============
+
+.. autofunction:: require
+.. autofunction:: noauth
+
+.. autoclass:: AuthService
+
+    .. automethod:: install

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,11 +16,12 @@
 
    asab/web/index
    asab/web/restapidocs
-   asab/web/authn
+   asab/web/auth
    asab/web/cors
    asab/metrics
    asab/storage
    asab/alert
+   asab/library
 
 .. toctree::
    :maxdepth: 2
@@ -34,7 +35,6 @@
    asab/module
    asab/various
    asab/zookeeper
-   asab/library
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
- I thought there is no asab-library configuration but it was not rendered
- I didn't find how to make the docs of GitProvider automatically, because of sys.exit() in there - sphinx is afraid to exit itself.. so this one must be manual
- there is sphinx 1.8.6 running on our readthedocs. Sphinx on reathedocs must be updated or tested aginst sphinx 1.8.6 locally. Many things work with 7.x (latest version), but not in the production.
- do not ignore red warnings when building the documentation - sphinx is trying to help you. 