### PR TITLE
Add optional API KEY authorization to Elastic Search Storage

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -24,6 +24,7 @@ Config.add_defaults(
 
 			'elasticsearch_username': '',
 			'elasticsearch_password': '',
+			'elasticsearch_api_key': '',
 
 			# make the operation visible to search directly, options: true, false, wait_for
 			# see: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -72,7 +72,7 @@ class StorageService(StorageServiceABC):
 		# Create headers for requests
 		self.Headers = {'Content-Type': 'application/json'}
 		if api_key != '':
-			self.Headers['Authorization'] = "API_KEY {}".format(api_key)
+			self.Headers['Authorization'] = "ApiKey {}".format(api_key)
 
 
 	async def finalize(self, app):

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -72,7 +72,7 @@ class StorageService(StorageServiceABC):
 		# Create headers for requests
 		self.Headers = {'Content-Type': 'application/json'}
 		if api_key != '':
-			self.Headers['Authorization'] = "Authorization: API_KEY {}".format(api_key)
+			self.Headers['Authorization'] = "API_KEY {}".format(api_key)
 
 
 	async def finalize(self, app):


### PR DESCRIPTION
API KEY can be used for authorization when sending requests to Elastic Search.

https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html

```
[asab:storage]
elasticsearch_api_key=MYSUPERSECRETAPIKEY
```

- If both API key and username with password are specified, warning is displayed.