### PR TITLE
Optionally run housekeeping at startup

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -99,7 +99,8 @@ class ConfigParser(configparser.ConfigParser):
 
 		"housekeeping": {
 			"at": "03:00",
-			"limit": "05:00"
+			"limit": "05:00",
+			"run_at_startup": "no",
 		}
 
 	}


### PR DESCRIPTION
Optionally trigger `Application.housekeeping!` at application startup. Disabled by default.

To enable, set `run_at_startup` to `yes`:

```ini
[housekeeping]
run_at_startup=yes
```

Or run the app with `--startup-housekeeping` command line argument.