### PR TITLE
Add API Key authorization option for ElasticSearch

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -12,6 +12,7 @@ from .upsertor import UpsertorABC
 from ..config import Config
 from ..tls import SSLContextBuilder
 
+import ssl
 
 #
 
@@ -78,7 +79,7 @@ class StorageService(StorageServiceABC):
 		if api_key != '':
 			self.Headers['Authorization'] = "ApiKey {}".format(api_key)
 
-		self.SSLContextBuilder = SSLContextBuilder(self)
+		self.SSLContextBuilder = SSLContextBuilder(config_section_name)
 
 
 	async def finalize(self, app):
@@ -113,7 +114,7 @@ class StorageService(StorageServiceABC):
 		for url in self.ServerUrls:
 
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -167,7 +168,7 @@ class StorageService(StorageServiceABC):
 			try:
 
 				if url.startswith('https://'):
-					ssl_context = self.SSLContextBuilder.build()
+					ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
 
@@ -227,7 +228,7 @@ class StorageService(StorageServiceABC):
 					request_url = "{}{}".format(url, index)
 
 				if url.startswith('https://'):
-					ssl_context = self.SSLContextBuilder.build()
+					ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
 					
@@ -274,7 +275,7 @@ class StorageService(StorageServiceABC):
 			request_url = "{}{}/_mapping".format(url, index)
 
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -305,7 +306,7 @@ class StorageService(StorageServiceABC):
 			request_url = "{}_template/{}?format=json".format(url, template_name)
 
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -339,7 +340,7 @@ class StorageService(StorageServiceABC):
 			L.warning("Posting index template into url: {}".format(request_url))
 
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -372,7 +373,7 @@ class StorageService(StorageServiceABC):
 					request_url = "{}/_reindex".format(url)
 
 				if url.startswith('https://'):
-					ssl_context = self.SSLContextBuilder.build()
+					ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
 
@@ -427,7 +428,7 @@ class StorageService(StorageServiceABC):
 			for url in self.ServerUrls:
 
 				if url.startswith('https://'):
-					ssl_context = self.SSLContextBuilder.build()
+					ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
 
@@ -512,7 +513,7 @@ class StorageService(StorageServiceABC):
 		for url in self.ServerUrls:
 
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -546,7 +547,7 @@ class StorageService(StorageServiceABC):
 			try:
 				count_url = "{}{}/_count".format(url, index)
 				if url.startswith('https://'):
-					ssl_context = self.SSLContextBuilder.build()
+					ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
 
@@ -568,7 +569,7 @@ class StorageService(StorageServiceABC):
 		"""
 		for url in self.ServerUrls:
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -596,7 +597,7 @@ class StorageService(StorageServiceABC):
 		# TODO: There is an option here to specify settings (e.g. shard number, replica number etc) and mappings here
 		for url in self.ServerUrls:
 			if url.startswith('https://'):
-				ssl_context = self.SSLContextBuilder.build()
+				ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -673,7 +674,7 @@ class ElasticSearchUpsertor(UpsertorABC):
 			)
 
 			if url.startswith('https://'):
-				ssl_context = self.Storage.SSLContextBuilder.build()
+				ssl_context = self.Storage.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 			else:
 				ssl_context = None
 
@@ -719,7 +720,7 @@ class ElasticSearchUpsertor(UpsertorABC):
 
 			for url in self.Storage.ServerUrls:
 				if url.startswith('https://'):
-					ssl_context = self.Storage.SSLContextBuilder.build()
+					ssl_context = self.Storage.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
 

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -1,4 +1,3 @@
-import os
 import time
 import json
 import aiohttp
@@ -233,7 +232,7 @@ class StorageService(StorageServiceABC):
 					ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 				else:
 					ssl_context = None
-					
+
 				async with self.session().request(
 					method="DELETE",
 					url=request_url,
@@ -556,11 +555,11 @@ class StorageService(StorageServiceABC):
 					ssl_context = None
 
 				async with self.session().request(
-						method="GET", 
-						url=count_url, 
+						method="GET",
+						url=count_url,
 						ssl=ssl_context,
 						headers=self.Headers
-						) as resp:
+				) as resp:
 					assert resp.status == 200, "Unexpected response code: {}".format(resp.status)
 					total_count = await resp.json()
 					return total_count

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -114,7 +114,15 @@ class StorageService(StorageServiceABC):
 		return self._ClientSession
 
 
-	async def is_connected(self):
+	async def is_connected(self) -> bool:
+		"""Check if the service is connected to ElasticSearch cluster.
+
+		Raises:
+			ConnectionError: Connection failed.
+
+		Returns:
+			bool: True if the service is connected.
+		"""
 		for url in self.ServerUrls:
 			try:
 				async with self.session().request(
@@ -239,7 +247,7 @@ class StorageService(StorageServiceABC):
 							return json_response
 						assert json_response["result"] == "deleted", "Document was not deleted"
 						await self.session().close()
-						return resp
+						return json_response
 			except aiohttp.client_exceptions.ClientConnectorError:
 				if url == self.ServerUrls[-1]:
 					raise Exception("Failed to connect to '{}'".format(url))

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -573,7 +573,7 @@ class ElasticSearchUpsertor(UpsertorABC):
 		if version == 0:
 			self.ModSet['_c'] = now  # Set the creation timestamp
 
-		self.SSLcontext = ssl.create_default_context(cafile=self.Storage.SSLcontext)
+		self.SSLcontext = self.Storage.SSLcontext
 
 		api_key = Config.get('asab:storage', 'elasticsearch_api_key')
 		self.Headers = {'Content-Type': 'application/json'}

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -34,6 +34,8 @@ Config.add_defaults(
 			# see: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
 			'refresh': 'true',
 			'scroll_timeout': '1m',
+
+			# For SSL options such as `cafile`, please refer to tls.py
 		}
 	}
 )

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -555,10 +555,10 @@ class StorageService(StorageServiceABC):
 					ssl_context = None
 
 				async with self.session().request(
-						method="GET",
-						url=count_url,
-						ssl=ssl_context,
-						headers=self.Headers
+					method="GET",
+					url=count_url,
+					ssl=ssl_context,
+					headers=self.Headers
 				) as resp:
 					assert resp.status == 200, "Unexpected response code: {}".format(resp.status)
 					total_count = await resp.json()

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -237,7 +237,8 @@ class StorageService(StorageServiceABC):
 				async with self.session().request(
 					method="DELETE",
 					url=request_url,
-					ssl=ssl_context
+					ssl=ssl_context,
+					headers=self.Headers
 				) as resp:
 					if resp.status == 401:
 						raise ConnectionRefusedError("Response code 401: Unauthorized. Provide authorization by specifying either user name and password or api key.")
@@ -285,7 +286,8 @@ class StorageService(StorageServiceABC):
 				async with self.session().request(
 					method="GET",
 					url=request_url,
-					ssl=ssl_context
+					ssl=ssl_context,
+					headers=self.Headers
 				) as resp:
 					obj = await resp.json()
 					await self.session().close()
@@ -553,7 +555,12 @@ class StorageService(StorageServiceABC):
 				else:
 					ssl_context = None
 
-				async with self.session().request(method="GET", url=count_url, ssl=ssl_context) as resp:
+				async with self.session().request(
+						method="GET", 
+						url=count_url, 
+						ssl=ssl_context,
+						headers=self.Headers
+						) as resp:
 					assert resp.status == 200, "Unexpected response code: {}".format(resp.status)
 					total_count = await resp.json()
 					return total_count
@@ -580,7 +587,8 @@ class StorageService(StorageServiceABC):
 				async with self.session().request(
 					method="GET",
 					url=request_url,
-					ssl=ssl_context
+					ssl=ssl_context,
+					headers=self.Headers
 				) as resp:
 					assert resp.status == 200, "Unexpected response code: {}".format(resp.status)
 					return await resp.json()
@@ -608,7 +616,8 @@ class StorageService(StorageServiceABC):
 				async with self.session().request(
 					method="PUT",
 					url=request_url,
-					ssl=ssl_context
+					ssl=ssl_context,
+					headers=self.Headers
 				) as resp:
 					assert resp.status == 200, "Unexpected response code: {}".format(resp.status)
 					return await resp.json()

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -10,8 +10,7 @@ import typing
 from .service import StorageServiceABC
 from .upsertor import UpsertorABC
 from ..config import Config
-
-import ssl
+from ..tls import SSLContextBuilder
 
 
 #
@@ -113,7 +112,7 @@ class StorageService(StorageServiceABC):
 		"""
 		for url in self.ServerUrls:
 
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -167,7 +166,7 @@ class StorageService(StorageServiceABC):
 			request_url = "{}{}/_doc/{}".format(url, index, obj_id)
 			try:
 
-				if url.startwith('https://'):
+				if url.startswith('https://'):
 					ssl_context = self.SSLContextBuilder.build()
 				else:
 					ssl_context = None
@@ -227,7 +226,7 @@ class StorageService(StorageServiceABC):
 				else:
 					request_url = "{}{}".format(url, index)
 
-				if url.startwith('https://'):
+				if url.startswith('https://'):
 					ssl_context = self.SSLContextBuilder.build()
 				else:
 					ssl_context = None
@@ -274,7 +273,7 @@ class StorageService(StorageServiceABC):
 		for url in self.ServerUrls:
 			request_url = "{}{}/_mapping".format(url, index)
 
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -305,7 +304,7 @@ class StorageService(StorageServiceABC):
 		for url in self.ServerUrls:
 			request_url = "{}_template/{}?format=json".format(url, template_name)
 
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -339,7 +338,7 @@ class StorageService(StorageServiceABC):
 			request_url = "{}_template/{}?include_type_name".format(url, template_name)
 			L.warning("Posting index template into url: {}".format(request_url))
 
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -372,7 +371,7 @@ class StorageService(StorageServiceABC):
 				else:
 					request_url = "{}/_reindex".format(url)
 
-				if url.startwith('https://'):
+				if url.startswith('https://'):
 					ssl_context = self.SSLContextBuilder.build()
 				else:
 					ssl_context = None
@@ -427,7 +426,7 @@ class StorageService(StorageServiceABC):
 		while True:
 			for url in self.ServerUrls:
 
-				if url.startwith('https://'):
+				if url.startswith('https://'):
 					ssl_context = self.SSLContextBuilder.build()
 				else:
 					ssl_context = None
@@ -512,7 +511,7 @@ class StorageService(StorageServiceABC):
 			}
 		for url in self.ServerUrls:
 
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -546,7 +545,7 @@ class StorageService(StorageServiceABC):
 		for url in self.ServerUrls:
 			try:
 				count_url = "{}{}/_count".format(url, index)
-				if url.startwith('https://'):
+				if url.startswith('https://'):
 					ssl_context = self.SSLContextBuilder.build()
 				else:
 					ssl_context = None
@@ -568,7 +567,7 @@ class StorageService(StorageServiceABC):
 		:param search_string: A search string. Default to None.
 		"""
 		for url in self.ServerUrls:
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -596,7 +595,7 @@ class StorageService(StorageServiceABC):
 		'''
 		# TODO: There is an option here to specify settings (e.g. shard number, replica number etc) and mappings here
 		for url in self.ServerUrls:
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -673,7 +672,7 @@ class ElasticSearchUpsertor(UpsertorABC):
 				url, self.Collection, self.Storage.Refresh
 			)
 
-			if url.startwith('https://'):
+			if url.startswith('https://'):
 				ssl_context = self.Storage.SSLContextBuilder.build()
 			else:
 				ssl_context = None
@@ -719,7 +718,7 @@ class ElasticSearchUpsertor(UpsertorABC):
 				upsert_data["doc"][k] = serialize(self.ModSet[k])
 
 			for url in self.Storage.ServerUrls:
-				if url.startwith('https://'):
+				if url.startswith('https://'):
 					ssl_context = self.Storage.SSLContextBuilder.build()
 				else:
 					ssl_context = None

--- a/asab/tls.py
+++ b/asab/tls.py
@@ -23,6 +23,14 @@ class SSLContextBuilder(ConfigObject):
 	}
 
 	def build(self, protocol=ssl.PROTOCOL_TLS):
+		'''
+		## SSL Server
+		ssl_context = self.SSLContextBuilder.build()
+
+		## SSL Client 
+
+		ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
+		'''
 		ctx = ssl.SSLContext(protocol=protocol)
 
 		ctx.options |= ssl.OP_NO_SSLv2

--- a/asab/tls.py
+++ b/asab/tls.py
@@ -27,7 +27,7 @@ class SSLContextBuilder(ConfigObject):
 		## SSL Server
 		ssl_context = self.SSLContextBuilder.build()
 
-		## SSL Client 
+		## SSL Client
 
 		ssl_context = self.SSLContextBuilder.build(ssl.PROTOCOL_TLS_CLIENT)
 		'''

--- a/examples/storage_elasticsearch.py
+++ b/examples/storage_elasticsearch.py
@@ -9,9 +9,10 @@ asab.Config.add_defaults(
 		'asab:storage': {
 			'type': 'elasticsearch',
 			'elasticsearch_url': 'https://localhost:9200/',
-			'elasticsearch_api_key': 'RzNDVkc0a0JJdDJTS1JpMlFrSlc6SGdncDFJdFNRRE9HVEpvRGFwU2lsdw==',
-			# 'elasticsearch_username': 'elastic',
-			# 'elasticsearch_password': 'miraelena',
+			# 'elasticsearch_api_key': 'RzNDVkc0a0JJdDJTS1JpMlFrSlc6SGdncDFJdFNRRE9HVEpvRGFwU2lsdw==',
+			# 'elasticsearch_ssl_ca_file': '/home/mir/ca.crt',
+			'elasticsearch_username': 'elastic',
+			'elasticsearch_password': 'miraelena',
 		}
 	}
 )
@@ -27,6 +28,13 @@ class MyApplication(asab.Application):
 
 	async def main(self):
 		storage = self.get_service("asab.StorageService")
+
+
+		connected = await storage.is_connected()
+		if connected:
+			print("Connected to ElasticSearch.")
+		else:
+			print("Connection failed.")
 
 		# Obtain upsertor object which is associated with given "test-collection"
 		# To create new object we keep default `version` to zero
@@ -54,6 +62,7 @@ class MyApplication(asab.Application):
 		print("Reindexing the collection")
 		await storage.reindex("test-collection", "test-collection-reindex")
 		await storage.reindex("test-collection-reindex", "test-collection")
+
 
 		obj = await storage.get("test-collection-reindex", objid)
 		print("Result of get by id '{}'".format(objid))

--- a/examples/storage_elasticsearch.py
+++ b/examples/storage_elasticsearch.py
@@ -12,7 +12,7 @@ asab.Config.add_defaults(
 			'elasticsearch_username': '<username>',
 			'elasticsearch_password': '<password>',
 			# 'elasticsearch_api_key': '<your api key>',
-			# 'cafile': '<path to SSL certificate>',
+			# 'cafile': '<CA Certificate>',
 		}
 	}
 )

--- a/examples/storage_elasticsearch.py
+++ b/examples/storage_elasticsearch.py
@@ -8,7 +8,10 @@ asab.Config.add_defaults(
 	{
 		'asab:storage': {
 			'type': 'elasticsearch',
-			'elasticsearch_url': 'http://localhost:9200/',
+			'elasticsearch_url': 'https://localhost:9200/',
+			'elasticsearch_api_key': 'RzNDVkc0a0JJdDJTS1JpMlFrSlc6SGdncDFJdFNRRE9HVEpvRGFwU2lsdw==',
+			# 'elasticsearch_username': 'elastic',
+			# 'elasticsearch_password': 'miraelena',
 		}
 	}
 )
@@ -48,10 +51,16 @@ class MyApplication(asab.Application):
 		pprint.pprint(obj)
 
 		# Reindex the collection
+		print("Reindexing the collection")
 		await storage.reindex("test-collection", "test-collection-reindex")
 		await storage.reindex("test-collection-reindex", "test-collection")
 
+		obj = await storage.get("test-collection-reindex", objid)
+		print("Result of get by id '{}'".format(objid))
+		pprint.pprint(obj)
+
 		# Remove the reindexed collection
+		print("Deleting reindexed collection")
 		await storage.delete("test-collection-reindex")
 
 		# Delete the item

--- a/examples/storage_elasticsearch.py
+++ b/examples/storage_elasticsearch.py
@@ -12,7 +12,7 @@ asab.Config.add_defaults(
 			'elasticsearch_username': '<username>',
 			'elasticsearch_password': '<password>',
 			# 'elasticsearch_api_key': '<your api key>',
-			# 'elasticsearch_ssl_ca_file': '<path to SSL certificate>',
+			# 'cafile': '<path to SSL certificate>',
 		}
 	}
 )


### PR DESCRIPTION
# API Key authorization, SSL certificates and refactoring

## Refactoring the ElasticSearch StorageService

- Added new method `is_connected()` that checks the connection by sending GET requests to '/' endpoint.
- When no document with the specified ID is found, `KeyError` is raised.
- When authorization is needed and 401 code is returned, `ConnectionRefusedError` is raised.
- **Bugfix**: when `aiohttp.client_exceptions.ClientConnectorError` occured, the service should check all URLs and iterate through them till the last. If the last URL also gets the same Error, `ConnectionError` should be raised. Problem was that URLs were modified during the request processing so this case never happened and the only response was a warning message.
- **Bugfix**: some `StorageService` methods were referencing to `self.Storage` which is correct only for `Upsertor` methods.
- Methods `_insert_new_object()` and `_update_existing_object()` were renamed for readability.

## Authorization with API key
