### PR TITLE
Fix: Allow exceptions in main function

### DIFF
--- a/asab/application.py
+++ b/asab/application.py
@@ -358,8 +358,8 @@ class Application(metaclass=Singleton):
 		finally:
 			if self.ExitCode == "!RESTART!":
 				os.execv(sys.executable, [os.path.basename(sys.executable)] + sys.argv)
-			else:
-				return self.ExitCode
+
+		return self.ExitCode
 
 
 	def stop(self, exit_code: int = None):


### PR DESCRIPTION
```
#!/usr/bin/env python3
import logging
import asab

L = logging.getLogger(__name__)


class MyApplication(asab.Application):
	async def main(self):
		print("ahoj!")
		raise Exception("this one is obvious")

if __name__ == "__main__":
	app = MyApplication()
	app.run()
```