### PR TITLE
Fix: library - GitProvider - provide nice feedback when remote repo cannot be reached

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -116,7 +116,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 		try:
 			assert self.GitRepository.remotes["origin"] is not None
-		except (KeyError, AssertionError):
+		except (KeyError, AssertionError, AttributeError):
 			L.error("Connection to remote git repository failed.")
 			# The library will not get ready ... maybe we can retry init_test() in a while
 			return


### PR DESCRIPTION
I got this bug in a train w/o connection. 
Try to reconnect when this happens?
```
10-Jul-2023 18:53:52.426900 NOTICE asab.application is ready.
10-Jul-2023 18:53:57.442157 ERROR asab.library.providers.git Initialize git repo failed.
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/asab/library/providers/git.py", line 113, in intialize_git_repo
    await self.ProactorService.execute(init_task)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.10/site-packages/asab/library/providers/git.py", line 106, in init_task
    self.GitRepository = pygit2.clone_repository(self.URL, self.RepoPath, checkout_branch=self.Branch)
  File "/usr/lib/python3.10/site-packages/pygit2/__init__.py", line 222, in clone_repository
    payload.check_error(err)
  File "/usr/lib/python3.10/site-packages/pygit2/callbacks.py", line 93, in check_error
    check_error(error_code)
  File "/usr/lib/python3.10/site-packages/pygit2/errors.py", line 65, in check_error
    raise GitError(message)
_pygit2.GitError: failed to resolve address for github.com: Try again
10-Jul-2023 18:53:57.444658 ERROR asab.task Error ''NoneType' object has no attribute 'remotes'' during task:
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/asab/task.py", line 149, in main
    await task
  File "/usr/lib/python3.10/site-packages/asab/library/providers/git.py", line 118, in intialize_git_repo
    assert self.GitRepository.remotes["origin"] is not None
AttributeError: 'NoneType' object has no attribute 'remotes'
```