### PR TITLE
Draft: GitLibraryProvider: better error messages

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -38,7 +38,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 	def __init__(self, library, path):
 
 		# format: 'git+http[s]://[<username>:<deploy token>@]<url>[#<branch>]'
-		pattern = re.compile(r"git\+(https?://)((.*):(.*)@)?(.*)#?(.*)?")
+		pattern = re.compile(r"git\+(https?://)((.*):(.*)@)?([^#]*)(?:#(.*))?$")
 		path_split = pattern.findall(path)[0]
 		L.debug(path_split)
 		self.URLScheme, self.UserInfo, self.User, self.DeployToken, self.URLPath, self.Branch = path_split

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -45,7 +45,6 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self.URL = "".join([self.URLScheme, self.UserInfo, self.URLPath])
 		self.Branch = self.Branch if self.Branch != '' else None
 
-		print(self.URL)
 
 		repodir = Config.get("library:git", "repodir", fallback=None)
 		if repodir is not None:

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -116,7 +116,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 		try:
 			assert self.GitRepository.remotes["origin"] is not None
-		except (KeyError, AssertionError):
+		except (KeyError, AssertionError, AttributeError):
 			L.error("Connection to remote git repository failed.")
 			# The library will not get ready ... maybe we can retry init_test() in a while
 			return


### PR DESCRIPTION
`pygit2` library produces very generic `GitError` with unreadable error message. This is an attempt to obtain something more descriptive.

- Authentication fails:
```
ERROR asab.library.providers.git [sd url=... username=... deploy_token=...] Authentication failed when initializing git repository.
Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'
```

- Incorrect URL:
```
ERROR asab.library.providers.git [sd url=...] Git repository not found.
```

- Branch does not exist:
```
ERROR asab.library.providers.git [sd url=... branch=...] Branch does not exist.
```

