### PR TITLE
Add type control to `LibraryService.subscribe()`

### DIFF
--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -386,12 +386,13 @@ class LibraryService(Service):
 		return fileobj
 
 
-	async def subscribe(self, paths):
+	async def subscribe(self, paths) -> None:
 		"""
 		It subscribes to the changes in the library
 
 		:param paths: A list of absolute paths to subscribe to
 		"""
+		assert isinstance(paths, list), "The 'paths' parameter in 'LibraryService.subscribe' method must be a list."
 		for path in paths:
 			assert path[:1] == '/', "Absolute path must be used when subscribing to the library changes"
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -386,13 +386,15 @@ class LibraryService(Service):
 		return fileobj
 
 
-	async def subscribe(self, paths) -> None:
+	async def subscribe(self, paths: typing.Union[str, typing.List[str]]) -> None:
 		"""
-		It subscribes to the changes in the library
+		Subscribe to changes for specified paths in the library.
 
-		:param paths: A list of absolute paths to subscribe to
+		:param paths: Either single path or list of paths to be subscribed. All the paths must be absolute (start with '/').
+		:type paths: list[str] | str
 		"""
-		assert isinstance(paths, list), "The 'paths' parameter in 'LibraryService.subscribe' method must be a list."
+		if isinstance(paths, str):
+			paths = [paths]
 		for path in paths:
 			assert path[:1] == '/', "Absolute path must be used when subscribing to the library changes"
 


### PR DESCRIPTION
`LibraryService.subscribe()` method now allows a single path as a string.