### PR TITLE
Rename ConfigObject to Configurable

### DIFF
--- a/asab/__init__.py
+++ b/asab/__init__.py
@@ -4,7 +4,7 @@ from .abc.module import Module
 from .abc.service import Service
 from .abc.singleton import Singleton
 from .application import Application
-from .config import Config, ConfigObject, Configurable
+from .config import Config, Configurable
 from .log import LOG_NOTICE
 from .pdict import PersistentDict
 from .pubsub import subscribe, PubSub, Subscriber
@@ -25,7 +25,6 @@ __all__ = (
 	'Singleton',
 	'Application',
 	'Config',
-	'ConfigObject',
 	'Configurable',
 	'LOG_NOTICE',
 	'PersistentDict',

--- a/asab/__init__.py
+++ b/asab/__init__.py
@@ -4,7 +4,7 @@ from .abc.module import Module
 from .abc.service import Service
 from .abc.singleton import Singleton
 from .application import Application
-from .config import Config, Configurable
+from .config import Config, ConfigObject, Configurable
 from .log import LOG_NOTICE
 from .pdict import PersistentDict
 from .pubsub import subscribe, PubSub, Subscriber
@@ -26,6 +26,7 @@ __all__ = (
 	'Application',
 	'Config',
 	'Configurable',
+	'ConfigObject',
 	'LOG_NOTICE',
 	'PersistentDict',
 	'subscribe',

--- a/asab/alert.py
+++ b/asab/alert.py
@@ -14,7 +14,7 @@ L = logging.getLogger(__name__)
 #
 
 
-class AlertProviderABC(asab.ConfigObject, abc.ABC):
+class AlertProviderABC(asab.Configurable, abc.ABC):
 
 	ConfigDefaults = {
 	}

--- a/asab/config.py
+++ b/asab/config.py
@@ -344,10 +344,6 @@ class Configurable(object):
 			self.Config.update(config)
 
 
-# This is for backward compatibility
-ConfigObject = Configurable
-
-
 class ConfigObjectDict(collections.abc.MutableMapping):
 
 

--- a/asab/config.py
+++ b/asab/config.py
@@ -344,6 +344,10 @@ class Configurable(object):
 			self.Config.update(config)
 
 
+# This is for backward compatibility
+ConfigObject = Configurable
+
+
 class ConfigurableDict(collections.abc.MutableMapping):
 
 

--- a/asab/config.py
+++ b/asab/config.py
@@ -318,7 +318,7 @@ class Configurable(object):
 
 
 	def __init__(self, config_section_name, config=None):
-		self.Config = ConfigObjectDict()
+		self.Config = ConfigurableDict()
 
 		for base_class in inspect.getmro(self.__class__):
 			if not hasattr(base_class, 'ConfigDefaults'):
@@ -344,7 +344,7 @@ class Configurable(object):
 			self.Config.update(config)
 
 
-class ConfigObjectDict(collections.abc.MutableMapping):
+class ConfigurableDict(collections.abc.MutableMapping):
 
 
 	def __init__(self):

--- a/asab/metrics/http.py
+++ b/asab/metrics/http.py
@@ -11,7 +11,7 @@ L = logging.getLogger(__name__)
 #
 
 
-class HTTPTarget(asab.ConfigObject):
+class HTTPTarget(asab.Configurable):
 
 	def __init__(self, svc, config_section_name, config=None):
 		super().__init__(config_section_name, config)

--- a/asab/metrics/influxdb.py
+++ b/asab/metrics/influxdb.py
@@ -13,7 +13,7 @@ L = logging.getLogger(__name__)
 #
 
 
-class InfluxDBTarget(asab.ConfigObject):
+class InfluxDBTarget(asab.Configurable):
 	"""
 InfluxDB 2.0 API parameters:
 	url - [required] url string of your influxDB

--- a/asab/tls.py
+++ b/asab/tls.py
@@ -1,8 +1,8 @@
 import ssl
-from .config import ConfigObject
+from .config import Configurable
 
 
-class SSLContextBuilder(ConfigObject):
+class SSLContextBuilder(Configurable):
 
 	ConfigDefaults = {
 		'cert': '',  # The certfile string must be the path to a PEM file containing the certificate as well as any number of CA certificates needed to establish the certificate’s authenticity.

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -4,7 +4,7 @@ import logging
 import aiohttp
 
 from .accesslog import AccessLogger
-from ..config import ConfigObject
+from ..config import Configurable
 from ..tls import SSLContextBuilder
 
 #
@@ -14,7 +14,7 @@ L = logging.getLogger(__name__)
 #
 
 
-class WebContainer(ConfigObject):
+class WebContainer(Configurable):
 
 	'''
 # Configuration examples

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -11,7 +11,7 @@ import kazoo.recipe.watchers
 import kazoo.protocol.states
 
 from .wrapper import KazooWrapper
-from ..config import ConfigObject
+from ..config import Configurable
 
 #
 
@@ -20,7 +20,7 @@ L = logging.getLogger(__name__)
 #
 
 
-class ZooKeeperContainer(ConfigObject):
+class ZooKeeperContainer(Configurable):
 	"""
 	Create a Zookeeper container with a specifications of the connectivity.
 	"""


### PR DESCRIPTION
`asab.ConfigObject` -> `asab.Configurable`
`asab.ConfigObjectDict` -> `asab.ConfigurableDict`

fixes #464 

I will do the corrections in the new documentation later. I will inform TeskaLabs people about this since SeaCat Auth uses these objects.