### PR TITLE
Add `getmultiline` method

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 import glob
 import logging
 import inspect
@@ -294,13 +295,13 @@ class ConfigParser(configparser.ConfigParser):
 		visited:
 			Praha
 			Brno
-			Ústí nad Labem
+			Pardubice Plzeň
 		unvisited:
 		```
 
 		```python
 		>>> asab.Config.getmultiline("places", "visited")
-		["Praha", "Brno", "Ústí nad Labem"]
+		["Praha", "Brno", "Pardubice", "Plzeň"]
 		>>> asab.Config.getmultiline("places", "unvisited")
 		[]
 		>>> asab.Config.getmultiline("places", "nonexisting", fallback=["Gottwaldov"])
@@ -309,7 +310,7 @@ class ConfigParser(configparser.ConfigParser):
 		"""
 		values = self.get(section, option, raw=raw, vars=vars, fallback=fallback)
 		if isinstance(values, str):
-			return [item.strip() for item in values.splitlines() if len(item) > 0]
+			return [item.strip() for item in re.split(r"\s+", values) if len(item) > 0]
 		else:
 			# fallback can be anything
 			return values

--- a/examples/config_getmultiline.py
+++ b/examples/config_getmultiline.py
@@ -14,7 +14,7 @@ asab.Config.read_string(
 	visited:
 			Praha
 			Brno
-			Ústí nad Labem
+			Pardubice Plzeň
 	"""
 )
 

--- a/examples/config_getmultiline.py
+++ b/examples/config_getmultiline.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import asab
+import logging
+
+#
+
+L = logging.getLogger(__name__)
+
+#
+
+asab.Config.read_string(
+	"""
+	[places]
+	visited:
+			Praha
+			Brno
+			Ústí nad Labem
+	"""
+)
+
+
+class MyApplication(asab.Application):
+
+	async def main(self):
+		visited = asab.Config.getmultiline("places", "visited")
+		unvisited = asab.Config.getmultiline("places", "unvisited", fallback=[])
+		nonexisting = asab.Config.getmultiline("places", "nonexisting", fallback=["Gottwaldov"])
+		L.log(asab.LOG_NOTICE, "Places I've already visited: {}".format(visited))
+		L.log(asab.LOG_NOTICE, "Places I want to visit: {}".format(unvisited))
+		L.log(asab.LOG_NOTICE, "Places that don't exist: {}".format(nonexisting))
+		self.stop()
+
+
+if __name__ == "__main__":
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION
Solves #460

It is just a small utility function for obtaining list from configuration where items are separated by space or newline.

```ini
[places]
visited:
	Praha
	Brno
	Pardubice Plzeň
unvisited:
```

```python
>>> asab.Config.getmultiline("places", "visited")
["Praha", "Brno", "Pardubice", "Plzeň"]
>>> asab.Config.getmultiline("places", "unvisited")
[]
>>> asab.Config.getmultiline("places", "nonexisting", fallback=["Gottwaldov"])
["Gottwaldov"]
```