### PR TITLE
Configurable OpenAPI server URL

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -40,12 +40,17 @@ class DocWebHandler(object):
 
 		self.DefaultRouteTag: str = asab.Config["asab:doc"].get("default_route_tag")
 		if self.DefaultRouteTag not in ["module_name", "class_name"]:
-			raise ValueError("Unknown default_route_tag: {}. Choose between options 'module_name' and 'class_name'.".format(self.DefaultRouteTag))
+			raise ValueError(
+				"Unknown default_route_tag: {}. Choose between options "
+				"'module_name' and 'class_name'.".format(self.DefaultRouteTag))
 
+		self.ServerUrl: str = asab.Config.get(config_section_name, "server_url", fallback="/")
 
 
 	def build_swagger_documentation(self) -> dict:
-		"""Take a docstring of the class and a docstring of methods and merge them into Swagger data."""
+		"""
+		Take a docstring of the class and a docstring of methods and merge them into Swagger data.
+		"""
 		app_doc_string: str = self.App.__doc__
 		app_description: str = get_description(app_doc_string)
 		specification: dict = {
@@ -60,7 +65,7 @@ class DocWebHandler(object):
 				"version": "1.0.0",
 			},
 			"servers": [
-				{"url": "/", "description": "Here"}
+				{"url": self.ServerUrl}
 			],
 
 			# Base path relative to openapi endpoint

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -44,7 +44,7 @@ class DocWebHandler(object):
 				"Unknown default_route_tag: {}. Choose between options "
 				"'module_name' and 'class_name'.".format(self.DefaultRouteTag))
 
-		self.ServerUrl: str = asab.Config.get(config_section_name, "server_url", fallback="/")
+		self.ServerUrls: str = asab.Config.get(config_section_name, "server_urls", fallback="/").strip().split("\n")
 
 
 	def build_swagger_documentation(self) -> dict:
@@ -65,7 +65,7 @@ class DocWebHandler(object):
 				"version": "1.0.0",
 			},
 			"servers": [
-				{"url": self.ServerUrl}
+				{"url": url} for url in self.ServerUrls
 			],
 
 			# Base path relative to openapi endpoint


### PR DESCRIPTION
Configure OpenAPI server URL (or multiple URLs) using the `[asab:doc] server_urls` option.