### PR TITLE
Fix invalid hyperlinks

### DIFF
--- a/docs/getting-started/installation_first_app.md
+++ b/docs/getting-started/installation_first_app.md
@@ -56,8 +56,7 @@ ASAB is distributed via [pypi](https://pypi.org/project/asab/). There are three 
             app.run()
     ```
 
-    1. All ASAB applications use Python 3.7+. This is specified by a hashbang
-    line at the very beginning of the file.
+    1. All ASAB applications use Python 3.7+. This is specified by a "hashbang" line at the very beginning of the file.
 
     2. ASAB is included from as `asab` module via an import
     statement.
@@ -99,6 +98,6 @@ ASAB is distributed via [pypi](https://pypi.org/project/asab/). There are three 
 
     !!! info
         ASAB is designed around an [event loop](https://en.wikipedia.org/wiki/Event_loop). It is meant primarily
-        for server architectures. For that reason, an ASAB application keeps running and serving requests unless or until you terminate the application. See [run time](../reference/application/reference.md#run-time).
+        for server architectures. For that reason, an ASAB application keeps running and serving requests unless or until you terminate the application. See [run time](../../reference/application/#run-time).
 
 You can continue with a step-by-step tutorial on how to build an ASAB-based [web server](./web_server.md).

--- a/docs/how-tos/03_rest_api.md
+++ b/docs/how-tos/03_rest_api.md
@@ -1,6 +1,9 @@
 Creating a microservice with REST API
 =====================================
 
+!!! warning
+    Under construction!
+
 In the [previous tutorial](../getting-started/web_server.md), you learned how to create a web server.
 
 In this tutorial, you'll learn how to create a basic ASAB microservice that provides a REST HTTP API. This microservice will implement **CREATE**, **READ**, **UPDATE** and **DELETE** functionality, in another words: **CRUD**.

--- a/docs/how-tos/index.md
+++ b/docs/how-tos/index.md
@@ -2,4 +2,4 @@
 
 To make it easy for you to get started with ASAB, we created these tutorials to teach you the basics of ASAB and guide you through creating your first applications.
 
-Visit the [Reference](../reference/application/reference.md) guide for more information, and see examples of ASAB applications [here](../examples/application_states.md).
+Visit the [Reference](../../reference/application) guide for more information, and see [Examples of ASAB applications](../examples/application_states.md).

--- a/docs/how-tos/installing-asab.md
+++ b/docs/how-tos/installing-asab.md
@@ -99,6 +99,6 @@ ASAB is distributed via [pypi](https://pypi.org/project/asab/). There are three 
 
     !!! info
         ASAB is designed around an [event loop](https://en.wikipedia.org/wiki/Event_loop). It is meant primarily
-        for server architectures. For that reason, an ASAB application keeps running and serving requests unless or until you terminate the application. See [run time](../reference/application/reference.md#run-time).
+        for server architectures. For that reason, an ASAB application keeps running and serving requests unless or until you terminate the application. See [run time](../../reference/application/#run-time).
 
 You can continue with a step-by-step tutorial on how to build an ASAB-based [web server](./web_server.md).

--- a/docs/reference/application.md
+++ b/docs/reference/application.md
@@ -75,14 +75,14 @@ and exit-time.
 The init-time happens during `Application` constructor call.
 At this time:
 
-- [Configuration](/reference/config) and [command line arguments](#command-line-parser) are loaded and [`asab.Config`](/reference/config/reference/#asab.Config) object is accessed.
+- [Configuration](../config) and [command line arguments](#command-line-parser) are loaded and [`asab.Config`](../configuration/#asab.Config) object is accessed.
 - Asynchronous callback `Application.initialize()` is executed.
-- [Application housekeeping](/reference/pubsub/reference/#housekeeping) is scheduled.
-- [Publish-Subscribe](/reference/pubsub/reference/#well-known-messages) message **Application.init!** is published.
+- [Application housekeeping](../pubsub/#housekeeping) is scheduled.
+- [Publish-Subscribe](../pubsub/#well-known-messages) message **Application.init!** is published.
 
 
 The asynchronous callback `Application.initialize()` is intended to be overridden by a user.
-This is where you typically load Modules and register Services, see [Modules and Services](/reference/modules_services) section.
+This is where you typically load Modules and register Services, see [Modules and Services](../modules_services) section.
 
 ``` python
 class MyApplication(asab.Application):
@@ -97,7 +97,7 @@ class MyApplication(asab.Application):
 The *run-time* starts after all the modules and services are loaded. This is where the application typically spends the most time.
 At this time:
 
-- [Publish-Subscribe](/reference/pubsub/reference/#well-known-messages) message **Application.run!** is published.
+- [Publish-Subscribe](../pubsub/#well-known-messages) message **Application.run!** is published.
 - The asynchronous callback `Application.main()` is executed.
 
 The coroutine `Application.main()` is intended to be overwritten by a user.
@@ -125,7 +125,7 @@ The parameter `exit_code` allows you to specify the application exit code.
 
 At *exit-time*:
 
-- [Publish-Subscribe](/reference/pubsub/reference/#well-known-messages) message **Application.exit!** is published.
+- [Publish-Subscribe](../pubsub/#well-known-messages) message **Application.exit!** is published.
 - Asynchronous callback `Application.finalize()` is executed.
 
 `Application.finalize()` is intended to be overridden by an user.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -12,7 +12,7 @@ app = asab.Application() #(1)!
 my_conf_value = asab.Config['section_name']['key1'] #(2)!
 ```
 
-1. Configuration is initialized during the application [init-time](/reference/application/reference/init-time).
+1. Configuration is initialized during the application [init-time](../application/init-time).
 2. You can access the configuration values from anywhere in the code.
 
 
@@ -90,7 +90,7 @@ The class implements a basic configuration language that provides a structure si
 
 
 If a configuration file name is specified,the configuration is automatically
-loaded from a configuration file during [the Application init-time](../../application/reference/#init-time).
+loaded from a configuration file during [the Application init-time](../application/#init-time).
 There are two ways to include a configuration file:
 
 1. by using the `-c` command-line argument:

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -179,7 +179,7 @@ Non-empty `path` option in the section `[logging:file]` of the configuration fil
 
     When the deployment expects more instances of the same application to be
     logging into the same file, it is recommended to use
-    [`${HOSTNAME}`](../../config/reference/#environment-variables) variable in the file path:
+    [`${HOSTNAME}`](../../configuration/#environment-variables) variable in the file path:
 
     ```ini
     [logging:file]

--- a/docs/reference/metrics/reference.md
+++ b/docs/reference/metrics/reference.md
@@ -23,12 +23,12 @@ database. [Influx](https://www.influxdata.com/) and
 
 	1. Import the `asab.metrics` module and add it to the application.
 	2. Then, you can localize MetricsService.
-	3. Use MetricsService to intialize the counter.
+	3. Use MetricsService to initialize the counter.
 
 
 See the full example [here](https://github.com/TeskaLabs/asab/blob/master/examples/metrics.py).
 
-See reference [here](./../../../reference/metrics/service.md).
+See reference [here](../metrics/service.md).
 
 ## Types of Metrics
 

--- a/docs/reference/modules_services.md
+++ b/docs/reference/modules_services.md
@@ -20,10 +20,10 @@ def custom_function():
 	my_service.do_stuff()
 ```
 
-1. The method [`add_module()`](/reference/application/reference/#asab.Application.add_module) initializes and adds a new module.
+1. The method [`add_module()`](../application/#asab.Application.add_module) initializes and adds a new module.
 The `module_class` class will be instantiated during the method call.
-2. The method [`get_service()`](reference/application/reference/#asab.Application.get_service) locates a service by its name and returns the [`asab.Service`](#asab.Service) object.
-3. Modules that have been added to the application are stored in [`asab.Application.Modules`](/reference/application/reference/#asab.application.Application.Modules) list. Similarly, Services are stored in [`asab.Application.Services`](/reference/application/reference/#asab.Application.Services) dictionary.
+2. The method [`get_service()`](../application/#asab.Application.get_service) locates a service by its name and returns the [`asab.Service`](#asab.Service) object.
+3. Modules that have been added to the application are stored in [`asab.Application.Modules`](../application/#asab.application.Application.Modules) list. Similarly, Services are stored in [`asab.Application.Services`](../application/#asab.Application.Services) dictionary.
 
 
 ## Built-in Services
@@ -32,15 +32,15 @@ Table of ASAB built-in Services and Modules:
 
 | Service | Module | Features |
 | --- | --- | --- |
-| [`WebService`](/reference/web/web-server) | `asab.web` | Creating a web server |
-| [`StorageService`](/reference/storage) | `asab.storage` | Storing the data in various databases |
-| [`LibraryService`](/reference/library) | `asab.library` | Reading the data from various sources |
-| [`ZooKeeperService`](/reference/zookeeper) | `asab.zookeeper` | Synchronizing data with Apache Zookeeper |
-| [`MetricService`](/reference/metrics) | `asab.metric` | Analysis of the application state in a timescale manner |
-| [`AlertService`](/reference/alert) | `asab.alert` | Integration of Alert Managers |
+| [`WebService`](../web/web-server) | `asab.web` | Creating a web server |
+| [`StorageService`](../storage) | `asab.storage` | Storing the data in various databases |
+| [`LibraryService`](../library) | `asab.library` | Reading the data from various sources |
+| [`ZooKeeperService`](../zookeeper) | `asab.zookeeper` | Synchronizing data with Apache Zookeeper |
+| [`MetricService`](../metrics/reference) | `asab.metric` | Analysis of the application state in a timescale manner |
+| [`AlertService`](../alert) | `asab.alert` | Integration of Alert Managers |
 | `TaskService`| `asab.task`| Execution of one-off background tasks |
 | `ProactorService` | `asab.proactor` | Running long-time activities asynchronously |
-| [`ApiService`](/reference/web/rest*_api_docs) | `asab.api` | Implementation of Swagger documentation |
+| [`ApiService`](../web/rest*_api_docs) | `asab.api` | Implementation of Swagger documentation |
 
 
 ::: asab.Module

--- a/docs/reference/pubsub.md
+++ b/docs/reference/pubsub.md
@@ -149,10 +149,10 @@ ASAB itself publishes various well-known messages published on `Application.PubS
 
 | Message | Published when... |
 | ---: | --- |
-| **Application.init!** | ...the application is in the [init-time](/reference/application/reference/#init-time) after the configuration is loaded, logging is setup, the event loop is constructed etc. |
-| **Application.run!** | ...the application enters the [run-time](/reference/application/reference/#run-time). |
-| **Application.stop!** | ...the application wants to stop the [run-time](/reference/application/reference/#run-time). It can be sent multiple times because of a process of graceful run-time termination. The first argument of the message is a counter that increases with every **Application.stop!** event. |
-| **Application.exit!** | ...the application enters the [exit-time](/reference/application/reference/#exit-time). |
+| **Application.init!** | ...the application is in the [init-time](../application/#init-time) after the configuration is loaded, logging is setup, the event loop is constructed etc. |
+| **Application.run!** | ...the application enters the [run-time](../application/#run-time). |
+| **Application.stop!** | ...the application wants to stop the [run-time](../application/#run-time). It can be sent multiple times because of a process of graceful run-time termination. The first argument of the message is a counter that increases with every **Application.stop!** event. |
+| **Application.exit!** | ...the application enters the [exit-time](../application/#exit-time). |
 | **Application.hup!** | ...the application receives UNIX signal `SIGHUP` or equivalent.|
 | **Application.housekeeping!** | ...the application is on the time for [housekeeping](#housekeeping). |
 | Tick messages | ...periodically with the specified tick frequency. | 
@@ -201,7 +201,7 @@ There is also a time limit, which is set to 05:00 AM UTC by default.
 By default, the time for housekeeping is set to 03:00 AM UTC and the limit to 05:00 AM UTC.
 
 
-Housekeeping can be also configured to run during the application [init-time](/reference/application/reference/#init-time).
+Housekeeping can be also configured to run during the application [init-time](../application/#init-time).
 Housekeeping time, time limit, and housekeeping at startup can be changed in the configuration file:
 
 ``` ini

--- a/docs/reference/web/tls.md
+++ b/docs/reference/web/tls.md
@@ -5,7 +5,7 @@
 
 **Transport Layer Security** protocol (*TLS*, also known as *"Secure Sockets Layer"*) is a cryptographic protocol that provides communication security over a computer network, so that the web servers can use **HTTPS**.
 
-For adding the HTTPS to ASAB web applications, there is a `asab.tls.SSLContextBuilder` class that is connected to [`asab.web.WebContainer`](/reference/web/web-server/#asab.web.WebContainer).
+For adding the HTTPS to ASAB web applications, there is a `asab.tls.SSLContextBuilder` class that is connected to [`asab.web.WebContainer`](../web/web-server/#asab.web.WebContainer).
 
 ## Configuration options
 

--- a/docs/reference/web/web-server.md
+++ b/docs/reference/web/web-server.md
@@ -61,7 +61,7 @@ python3 -m pip install aiohttp
 		app.run()
 	```
 
-	1. Web server configuration should be prepared during [the init-time](/reference/application/reference/#init-time) of the application lifecycle.
+	1. Web server configuration should be prepared during [the init-time](../application/#init-time) of the application lifecycle.
 	2. `asab.web.create_web_server()` creates web server and returns instance of
 		[`aiohttp.web.UrlDispatcher` object](https://docs.aiohttp.org/en/stable/web_reference.html?highlight=router#router) (which is usually referred to as a "router"). The method takes the argument `app` which is used as the reference to the base `asab.Application` object, and optional parameters that expand configuration options.
 	3. You can easily create a new endpoint by [`aiohttp.web.UrlDispatcher.add_route()` method](https://docs.aiohttp.org/en/stable/web_reference.html?highlight=router#aiohttp.web.UrlDispatcher.add_route)
@@ -115,7 +115,7 @@ python3 -m pip install aiohttp
 
 	1. In order to use `asab.WebService`, first import the corresponding `asab.web.Module`...
 	2. ...and then locate the Service.
-	3. Creates the Web container, which is instance of [`asab.Config.Configurable`](http://localhost:8000/reference/config/reference/#asab.config.Configurable) object that stores the configuration such as the actual web application.
+	3. Creates the Web container, which is instance of [`asab.Config.Configurable`](../configuration/#asab.config.Configurable) object that stores the configuration such as the actual web application.
 	4. `asab.web.WebContainer.WebApp` is instance of `aiohttp.web.Application` object. To create a new endpoint, use methods for [`aiohttp.web.Application.router` object](https://docs.aiohttp.org/en/stable/web_reference.html?highlight=add_get#router).
 	5. A request handler must be a coroutine that accepts [`aiohttp.web.Request` instance](https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.Request) as its only parameter and returns [`aiohttp.web.Response` instance](https://docs.aiohttp.org/en/stable/web_reference.html#response).
 
@@ -142,7 +142,7 @@ Configuration is passed to the `asab.web.WebContainer` object.
 | `backlog` | A number of unaccepted connections that the system will allow before refusing new connections, see [`socket.socket.listen()`](https://docs.python.org/3/library/socket.html#socket.socket.listen) for details |
 | `rootdir` | The root path for the server. In case of many web containers, each one can implement a different root |
 | `servertokens` | Controls whether `'Server'` response header field is included (`'full'`) or faked (`'prod'`) |
-| `cors` | See [Cross-Origin Resource Sharing](/reference/web/cors) section |
+| `cors` | See [Cross-Origin Resource Sharing](../web/cors) section |
 | `body_max_size`| Client's maximum size in a request, in bytes. If a **POST** request exceeds this value, `aiohttp.HTTPRequestEntityTooLarge` exception is raised. See [the documentation](https://docs.aiohttp.org/en/stable/web_reference.html?highlight=client_max_size#aiohttp.web.Application) for more information |
 | `cors` | Contents of the Access-Control-Allow-Origin header. See the [CORS section](./cors) |
 | `cors_preflight_paths` | Pattern for endpoints that shall return responses to pre-flight requests (**OPTIONS**). Value must start with `"/"`. See the [CORS section](./cors) |


### PR DESCRIPTION
Some hyperlinks used absolute path (e.g. "/reference") which does not work on deployed documentation. This is now fixed.