### PR TITLE
Deploy documentation from 'master' branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,4 +43,4 @@ deploy production:
     # - (cd ./cs && mkdocs build --site-dir /output/cs)
     - rsync -r -a -v -e ssh --delete /output/ "$RSYNC_USER"@"$TARGET_SERVER":"$PRODUCTION_DIR"
   only:
-    - production
+    - master


### PR DESCRIPTION
Documentation is deployed to docs.teskalabs.com/asab