### PR TITLE
Fix: Metrics must be sent even when tag is None

### DIFF
--- a/asab/metrics/influxdb.py
+++ b/asab/metrics/influxdb.py
@@ -220,6 +220,8 @@ def escape_tags(tags: dict):
 	"""
 	clean: dict = {}
 	for k, v in tags.items():
+		if v is None:
+			v = "unknown"
 		clean[k.replace(" ", "\\ ").replace(",", "\\,").replace("=", "\\=")] = v.replace(" ", "\\ ").replace(",", "\\,").replace("=", "\\=")
 	return clean
 


### PR DESCRIPTION
or - maybe "cleaner" solution:
```python
return {k.replace(" ", "\\ ").replace(",", "\\,").replace("=", "\\="): str(v).replace(" ", "\\ ").replace(",", "\\,").replace("=", "\\=") for k,  v in tags.items()}
```
In this case, the None tag would be "None". Which is still better than nothing and comprehensions are faster.

Original bug:
```
25-Aug-2023 09:01:34.107737 ERROR root Task exception was never retrieved
{'future': <Task finished coro=<InfluxDBTarget.process() done, defined at /usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py:104> exception=AttributeError("'NoneType' object has no attribute 'replace'")>}
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py", line 105, in process
    rb = influxdb_format(m_tree, now)
  File "/usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py", line 243, in influxdb_format
    influx_records = metric_to_influxdb(metric_record, now)
  File "/usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py", line 206, in metric_to_influxdb
    values_lines.append(build_metric_line(field.get("tags"), (field.get("values")), timestamp))
  File "/usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py", line 169, in build_metric_line
    return combine_tags_and_field(tags, values, timestamp)
  File "/usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py", line 158, in combine_tags_and_field
    tags = escape_tags(tags)
  File "/usr/local/lib/python3.7/site-packages/asab/metrics/influxdb.py", line 223, in escape_tags
    clean[k.replace(" ", "\\ ").replace(",", "\\,").replace("=", "\\=")] = v.replace(" ", "\\ ").replace(",", "\\,").replace("=", "\\=")
AttributeError: 'NoneType' object has no attribute 'replace'
```