### PR TITLE
Merge `enabled` and `dev_mode` config switch

### DIFF
--- a/asab/application.py
+++ b/asab/application.py
@@ -269,6 +269,11 @@ class Application(metaclass=Singleton):
 				Config._default_values['web'] = {}
 			Config._default_values['web']['listen'] = args.web_api
 
+		if args.no_auth:
+			if 'auth' not in Config._default_values:
+				Config._default_values['auth'] = {}
+			Config._default_values['auth']['enabled'] = False
+
 		if args.startup_housekeeping:
 			Config._default_values['housekeeping']['run_at_startup'] = True
 

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -110,10 +110,7 @@ class AuthService(asab.Service):
 		self.MultitenancyEnabled = asab.Config.getboolean("auth", "multitenancy")
 		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url")
 
-		if self.App.Args.no_auth:
-			enabled = "no"
-		else:
-			enabled = asab.Config.get("auth", "enabled")
+		enabled = asab.Config.get("auth", "enabled")
 		if enabled == "mock":
 			self.Mode = AuthMode.MOCK
 		elif asab.utils.string_to_boolean(enabled):

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -91,7 +91,7 @@ asab.Config.add_defaults({
 		# In MOCK MODE
 		# - no authorization server is needed,
 		# - all incoming requests are mock-authorized with pre-defined user info,
-		# - mock user info can be customized with a JSON file.
+		# - custom mock user info can supplied in a JSON file.
 		"enabled": "yes",
 		"mock_user_info_path": "/conf/mock-userinfo.json",
 	}

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -8,6 +8,7 @@ import logging
 import os.path
 import typing
 import time
+import enum
 
 import aiohttp
 import aiohttp.web

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -82,18 +82,19 @@ class AuthMode(enum.Enum):
 asab.Config.add_defaults({
 	"auth": {
 		# URL location containing the authorization server's public JWK keys
+		# (often found at "/.well-known/jwks.json")
 		"public_keys_url": "",
 
 		# Whether the app is tenant-aware
 		"multitenancy": "yes",
 
-		# Whether the authentication and authorization are enabled
-		# Expected values: either boolean or "mock"
+		# The "enabled" option switches authentication and authorization
+		# on, off or activates mock mode. The default value is True (on).
 		# In MOCK MODE
 		# - no authorization server is needed,
 		# - all incoming requests are mock-authorized with pre-defined user info,
 		# - custom mock user info can supplied in a JSON file.
-		"enabled": "yes",
+		# "enabled": "yes",
 		"mock_user_info_path": "/conf/mock-userinfo.json",
 	}
 })
@@ -110,7 +111,7 @@ class AuthService(asab.Service):
 		self.MultitenancyEnabled = asab.Config.getboolean("auth", "multitenancy")
 		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url")
 
-		enabled = asab.Config.get("auth", "enabled")
+		enabled = asab.Config.get("auth", "enabled", fallback=True)
 		if enabled == "mock":
 			self.Mode = AuthMode.MOCK
 		elif asab.utils.string_to_boolean(enabled):
@@ -156,7 +157,7 @@ class AuthService(asab.Service):
 			"AuthService is running in MOCK MODE. All web requests will be authorized with mock user info, which "
 			"currently grants access to the following tenants: {}. To customize mock mode authorization (add or "
 			"remove tenants and resources, change username etc.), provide your own user info in {!r}.".format(
-				list(t for t in self.MockUserInfo.get("resources", {}).keys() if t != "*"),
+				list(t for t in user_info.get("resources", {}).keys() if t != "*"),
 				mock_user_info_path))
 		return user_info
 

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -104,7 +104,7 @@ class AuthService(asab.Service):
 	"""
 	Provides authentication and authorization of incoming requests.
 	"""
-	_PUBLIC_KEYS_URL_DEFAULT = "http://localhost:8081/openidconnect/public_keys"
+	_PUBLIC_KEYS_URL_DEFAULT = "http://localhost:3081/.well-known/jwks.json"
 
 	def __init__(self, app, service_name="asab.AuthzService"):
 		super().__init__(app, service_name)
@@ -130,7 +130,8 @@ class AuthService(asab.Service):
 				"or install asab with 'authz' optional dependency.")
 		elif len(self.PublicKeysUrl) == 0:
 			self.PublicKeysUrl = self._PUBLIC_KEYS_URL_DEFAULT
-			L.warning(
+			L.log(
+				asab.LOG_NOTICE,
 				"No 'public_keys_url' provided in [auth] config section. "
 				"Defaulting to {!r}.".format(self._PUBLIC_KEYS_URL_DEFAULT))
 

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -8,7 +8,7 @@ asab.Config["web"] = {"listen": "0.0.0.0 8080"}
 
 # Disables or enables all authentication and authorization, or switches it into MOCK mode.
 # When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
-# asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
+asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
 # asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
 # asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
 
@@ -24,7 +24,7 @@ asab.Config["auth"]["mock_user_info_path"] = "./mock-userinfo.json"
 
 # URL of the authorization server's JWK public keys, used for ID token verification.
 # This option is ignored in mock mode or when authorization is disabled.
-# asab.Config["auth"]["public_keys_url"] = "http://localhost:3081/.well-known/jwks.json"
+asab.Config["auth"]["public_keys_url"] = "http://localhost:3081/.well-known/jwks.json"
 
 
 class MyApplication(asab.Application):

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -6,28 +6,25 @@ import typing
 # Set up a web container listening at port 8080
 asab.Config["web"] = {"listen": "0.0.0.0 8080"}
 
-# Disables or enables all authentication and authorization.
+# Disables or enables all authentication and authorization, or switches it into MOCK mode.
 # When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
-asab.Config["auth"]["enabled"] = "yes"
+asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
+asab.Config["auth"]["enabled"] = "yes"   # Normal
+asab.Config["auth"]["enabled"] = "no"    # Authorization is switched off
 
 # Changes the behavior of endpoints with configurable tenant parameter.
 # With multitenancy enabled, the `tenant` paramerter in query is required.
 # With multitenancy disabled, the `tenant` paramerter in query is ignored.
 asab.Config["auth"]["multitenancy"] = "yes"
 
-# Activating the dev mode disables communication with the authorization server.
+# Activating the mock mode disables communication with the authorization server.
 # The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
-# You can provide custom user info by specifying `dev_user_info_path` pointing to your JSON file.
-asab.Config["auth"]["dev_mode"] = "yes"
-asab.Config["auth"]["dev_user_info_path"] = "./dev-userinfo.json"
+# You can provide custom user info by specifying the path pointing to your JSON file.
+asab.Config["auth"]["mock_user_info_path"] = "./mock-userinfo.json"
 
 # URL of the authorization server's JWK public keys, used for ID token verification.
-# This option is ignored in dev mode.
+# This option is ignored in mock mode or when authorization is disabled.
 asab.Config["auth"]["public_keys_url"] = "http://localhost:8081/openidconnect/public_keys"
-
-# URL of the authorization server's tenant list, used for tenant verification.
-# This option is ignored in dev mode.
-asab.Config["auth"]["tenant_url"] = "http://localhost:8081/tenant"
 
 
 class MyApplication(asab.Application):

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -9,8 +9,8 @@ asab.Config["web"] = {"listen": "0.0.0.0 8080"}
 # Disables or enables all authentication and authorization, or switches it into MOCK mode.
 # When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
 asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
-asab.Config["auth"]["enabled"] = "yes"   # Normal
-asab.Config["auth"]["enabled"] = "no"    # Authorization is switched off
+# asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
+# asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
 
 # Changes the behavior of endpoints with configurable tenant parameter.
 # With multitenancy enabled, the `tenant` paramerter in query is required.

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -8,7 +8,7 @@ asab.Config["web"] = {"listen": "0.0.0.0 8080"}
 
 # Disables or enables all authentication and authorization, or switches it into MOCK mode.
 # When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
-asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
+# asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
 # asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
 # asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
 
@@ -24,7 +24,7 @@ asab.Config["auth"]["mock_user_info_path"] = "./mock-userinfo.json"
 
 # URL of the authorization server's JWK public keys, used for ID token verification.
 # This option is ignored in mock mode or when authorization is disabled.
-asab.Config["auth"]["public_keys_url"] = "http://localhost:8081/openidconnect/public_keys"
+# asab.Config["auth"]["public_keys_url"] = "http://localhost:3081/.well-known/jwks.json"
 
 
 class MyApplication(asab.Application):


### PR DESCRIPTION
# Breaking changes
- The `enabled` and `dev_mode` options in the `[auth]` config section are combined into one. To enable mock mode (formerly known as dev mode), specify `enabled=mock`.
- `dev_user_info_path` renamed to `mock_user_info_path`.
- Default `public_keys_url` changed to `http://localhost:3081/.well-known/jwks.json`, which is in line with the latest Seacat Auth.

# Changes
- "Dev mode" renamed to "mock mode".
- Fixed the `--no-auth` switch to act upon the app configuration.