### PR TITLE
Fix typo in Zookeeper

### DIFF
--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -101,7 +101,7 @@ class LibraryService(Service):
 
 	def _create_library(self, path, layer):
 		library_provider = None
-		if path.startswith('zk://') or path.startswith('zookeeeper://'):
+		if path.startswith('zk://') or path.startswith('zookeeper://'):
 			from .providers.zookeeper import ZooKeeperLibraryProvider
 			library_provider = ZooKeeperLibraryProvider(self, path, layer)
 


### PR DESCRIPTION
I don't know if anyone actually uses this option, but still...

```ini
[library]
providers=zookeeper://...
```