### PR TITLE
Sentry improvements

### DIFF
--- a/asab/sentry/__init__.py
+++ b/asab/sentry/__init__.py
@@ -11,7 +11,7 @@ Config.add_defaults(
 
 		"sentry:logging": {
 			"breadcrumbs": "info",
-			"events": "warning"
+			"events": "error"
 		}
 	}
 )

--- a/asab/sentry/service.py
+++ b/asab/sentry/service.py
@@ -70,7 +70,9 @@ class SentryService(asab.Service):
 		if len(self.DataSourceName) == 0:
 			self.DataSourceName = os.getenv("SENTRY_DSN", "")
 		if len(self.DataSourceName) == 0:
-			L.error("Data source name is not set. Specify it via SENTRY_DSN env variable or in configuration: [sentry] data_source_name.")
+			# We do not need Sentry enabled in development - if DSN is empty, do not initialize the service
+			L.info("Data source name is not set. Specify it via SENTRY_DSN env variable or in configuration: [sentry] data_source_name.")
+			return
 
 
 		# LOGGING LEVELS

--- a/asab/sentry/service.py
+++ b/asab/sentry/service.py
@@ -66,9 +66,9 @@ class SentryService(asab.Service):
 		if len(self.DataSourceName) == 0:
 			self.DataSourceName = os.getenv("SENTRY_DSN", "")
 		if len(self.DataSourceName) == 0:
-			# We do not need Sentry enabled in development - if DSN is empty, do not initialize the service
-			L.error("Data source name is not set. Specify it via SENTRY_DSN env variable or in configuration: '[sentry] data_source_name'.")
-			return
+			# We do not need Sentry enabled in development - empty DSN leads to failure
+			L.critical("Data source name is not set. Specify it in configuration: '[sentry] data_source_name'.")
+			raise SystemExit("Exit due to a critical configuration error.")
 
 
 		# LOGGING LEVELS

--- a/docs/reference/sentry.md
+++ b/docs/reference/sentry.md
@@ -37,17 +37,17 @@ After you create a new project in Sentry.io, [DSN (data source name)](https://do
 Then you can initialize the Sentry Service:
 
 ```python title='my_app.py'
-import asab.sentry
-
 class MyApplication(asab.Application):
 	async def initialize(self):
-		self.SentryService = asab.sentry.SentryService()
+		if "sentry" in asab.Config.sections():
+			import asab.sentry
+			self.SentryService = asab.sentry.SentryService(self)
 ```
 
 After the service is initialized:
 
 - all uncaught exceptions are sent as events
-- all logging messages with priority `ERROR` or higher are sent as events, messages with priority `LOG_NOTICE` or higher are sent as breadcrumbs
+- all logging messages with priority `ERROR` or higher are sent as events, messages with priority `INFO` or higher are sent as breadcrumbs
 
 ## Capturing errors
 


### PR DESCRIPTION
This MR has evolved into documentation changes...

 `SentryService` will be implemented into the code like this:

```python
if "sentry" in asab.Config.sections():
	import asab.sentry
	self.SentryService = asab.sentry.SentryService(self)
```

`data_source_name` is intended to be specified in the configuration, `$SENTRY_DSN` is the fallback.

Also, logging default levels were changed:
- ERRORS are sent as Events
- INFO+ are sent as breadcrumbs

