### PR TITLE
Handle error when address is already in use

### DIFF
--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -146,7 +146,11 @@ class WebContainer(Configurable):
 				host=addr, port=port, backlog=self.BackLog,
 				ssl_context=ssl_context,
 			)
-			await site.start()
+			try:
+				await site.start()
+			except OSError as err:
+				if "address already in use" in str(err):
+					L.error("Cannot start web server: address ({}, {}) is already in use.".format(addr, port))
 
 			if isinstance(site, aiohttp.web_runner.TCPSite):
 				for address in site._runner.addresses:

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -151,6 +151,8 @@ class WebContainer(Configurable):
 			except OSError as err:
 				if "address already in use" in str(err):
 					L.error("Cannot start web server: address ({}, {}) is already in use.".format(addr, port))
+				else:
+					L.error("Cannot start web server on address ({}, {}): {}".format(addr, port, err))
 
 			if isinstance(site, aiohttp.web_runner.TCPSite):
 				for address in site._runner.addresses:

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -149,10 +149,7 @@ class WebContainer(Configurable):
 			try:
 				await site.start()
 			except OSError as err:
-				if "address already in use" in str(err):
-					L.error("Cannot start web server: address ({}, {}) is already in use.".format(addr, port))
-				else:
-					L.error("Cannot start web server on address ({}, {}): {}".format(addr, port, err))
+				L.error("Cannot start web server: {}".format(err), struct_data={'address': addr, 'port': port})
 
 			if isinstance(site, aiohttp.web_runner.TCPSite):
 				for address in site._runner.addresses:


### PR DESCRIPTION
Handle the exception when user tries to bind on address that is already used.

Before:
```
12-Sep-2023 14:34:49.169395 ERROR asab.task Error '[Errno 98] error while attempting to bind on address ('0.0.0.0', 8080): address already in use' during task:
Traceback (most recent call last):
  File "/home/mir/Projects/Python/TeskaLabs/asab/asab/task.py", line 149, in main
    await task
  File "/home/mir/Projects/Python/TeskaLabs/asab/asab/web/container.py", line 149, in _start
    await site.start()
  File "/home/mir/.local/lib/python3.10/site-packages/aiohttp/web_runner.py", line 121, in start
    self._server = await loop.create_server(
  File "/usr/lib/python3.10/asyncio/base_events.py", line 1519, in create_server
    raise OSError(err.errno, 'error while attempting '
OSError: [Errno 98] error while attempting to bind on address ('0.0.0.0', 8080): address already in use
```

Now:
```
12-Sep-2023 14:36:24.676625 ERROR asab.web.container Cannot start web server: address (0.0.0.0, 8080) is already in use.
```