### PR TITLE
Allow providers specification on separate lines

### DIFF
--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -125,7 +125,7 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 			raise RuntimeError("Not ready")
 
 		assert path[:1] == '/'
-		assert '//' not in path
+		assert '//' not in path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
 		assert len(path) == 1 or path[-1:] != '/'
 
 		if path == '/':
@@ -156,8 +156,8 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 	async def read(self, path: str) -> typing.IO:
 
 		assert path[:1] == '/'
-		assert '//' not in path
-		assert len(path) == 1 or path[-1:] != '/'
+		assert '//' not in path, "Item path cannot contain double slashes (//). Example format: /library/Templates/item.json"
+		assert len(path) == 1 or path[-1:] != '/', "Item path must end with an extension. Example format: /library/Templates/item.json"
 
 		headers = {}
 

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -66,7 +66,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		# File path must end with the extension
 		assert len(os.path.splitext(node_path)[1]) > 0, "File path must end with an extension. For example: /library/Templates/item.json"
 		# File cannot contain '//'
-		assert '//' not in node_path
+		assert '//' not in node_path, "File path cannot contain double slashes (//). Example format: /library/Templates/item.json"
 
 		try:
 			return io.FileIO(node_path, 'rb')
@@ -92,7 +92,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		# Directory path must end with '/'
 		assert node_path[-1:] == '/', "Directory path must end with a forward slash (/). For example: /library/Templates/"
 		# Directory cannot contain '//'
-		assert '//' not in node_path
+		assert '//' not in node_path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
 
 		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
 		if not exists:

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -301,8 +301,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		# Zookeeper path should not have forward slash at the end of path
 		node_path = node_path.rstrip("/")
 
-		assert '//' not in node_path
-		assert node_path[0] == '/'
+		assert '//' not in node_path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
+		assert node_path[0] == '/', "Directory path must start with a forward slash (/). For example: /library/Templates/"
 
 		return node_path
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -211,7 +211,7 @@ class LibraryService(Service):
 		# Directory path must end with '/'
 		assert path[-1:] == '/', "Directory path must end with a forward slash (/). For example: /library/Templates/"
 		# Directory path cannot contain '//'
-		assert '//' not in path
+		assert '//' not in path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
 
 		# List requested level using all available providers
 		items = await self._list(path, tenant, providers=self.Libraries)
@@ -341,7 +341,7 @@ class LibraryService(Service):
 		# Directory path must end with '/'
 		assert path[-1:] == '/', "Directory path must end with a forward slash (/). For example: /library/Templates/"
 		# Directory path cannot contain '//'
-		assert '//' not in path
+		assert '//' not in path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
 
 		fileobj = tempfile.TemporaryFile()
 		tarobj = tarfile.open(name=None, mode='w:gz', fileobj=fileobj)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -77,12 +77,14 @@ class LibraryService(Service):
 		self.Disabled: dict = {}
 
 		if paths is None:
+			# load them from configuration
 			try:
-				paths = Config.get("library", "providers")
+				paths = Config.getmultiline("library", "providers")
 			except configparser.NoOptionError:
 				L.critical("'providers' option is not present in configuration section 'library'.")
 				raise SystemExit("Exit due to a critical configuration error.")
 
+		# paths can be string if specified as argument
 		if isinstance(paths, str):
 			paths = re.split(r"\s+", paths)
 


### PR DESCRIPTION
Since the new `getmultiline()` method exist, I would like to use it when listing providers.

List of providers can be now listed on separate lines as well as on one line separated by spaces or tabs.

```ini
[library]
providers:
    ./library
    zk://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/lmio-testing/library.lib 
    git+http://lmio-box-testing:@gitlab.teskalabs.int/lmio/lmio-common-library.git
```