### PR TITLE
Method for checking if AuthService is enabled

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -168,6 +168,13 @@ class AuthService(asab.Service):
 			await self._fetch_public_keys_if_needed()
 
 
+	def is_enabled(self) -> bool:
+		"""
+		Check if the AuthService is enabled. Mock mode counts as enabled too.
+		"""
+		return self.Mode in {AuthMode.ENABLED, AuthMode.MOCK}
+
+
 	def install(self, web_container):
 		"""
 		Apply authorization to all web handlers in a web container, according to their arguments and path parameters.


### PR DESCRIPTION
# Summary

Introduced `is_enabled` method in `AuthService`.

# Usage
```python
auth_service = app.get_service("asab.AuthService")
if auth_service.is_enabled():
    ...
```