### PR TITLE
Better exception handling in PubSub

### DIFF
--- a/asab/pubsub.py
+++ b/asab/pubsub.py
@@ -278,7 +278,7 @@ def _deliver_async_exited(task):
 		task.result()
 	except asyncio.CancelledError:
 		pass
-	except Exception as e:
+	except Exception:
 		L.exception("Error during pubsub delivery", struct_data={'task': task.get_name()})
 
 


### PR DESCRIPTION
When exception is thrown in async PubSub message handler, then it is now collected and logged properly.