### PR TITLE
Allow paths without trailing slash in Elasticsearch config

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -53,6 +53,8 @@ class StorageService(StorageServiceABC):
 		self.URL = Config.get(config_section_name, 'elasticsearch_url')
 		parsed_url = urllib.parse.urlparse(self.URL)
 		url_path = parsed_url.path if parsed_url.path != "" else "/"
+		if not url_path.endswith("/"):
+			url_path += "/"
 
 		self.ServerUrls = [
 			urllib.parse.urlunparse((parsed_url.scheme, netloc, url_path, None, None, None))

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -52,8 +52,10 @@ class StorageService(StorageServiceABC):
 
 		self.URL = Config.get(config_section_name, 'elasticsearch_url')
 		parsed_url = urllib.parse.urlparse(self.URL)
+		url_path = parsed_url.path if parsed_url.path != "" else "/"
+
 		self.ServerUrls = [
-			urllib.parse.urlunparse((parsed_url.scheme, netloc, parsed_url.path, None, None, None))
+			urllib.parse.urlunparse((parsed_url.scheme, netloc, url_path, None, None, None))
 			for netloc in parsed_url.netloc.split(',')
 		]
 

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -52,7 +52,7 @@ class StorageService(StorageServiceABC):
 
 		self.URL = Config.get(config_section_name, 'elasticsearch_url')
 		parsed_url = urllib.parse.urlparse(self.URL)
-		url_path = parsed_url.path if parsed_url.path != "" else "/"
+		url_path = parsed_url.path
 		if not url_path.endswith("/"):
 			url_path += "/"
 


### PR DESCRIPTION
```ini
[asab:storage]
elasticsearch_url=http://es01:9200,es02:9200,es03:9200
```
...the path will be "/".

```ini
[asab:storage]
elasticsearch_url=http://es01:9200,es02:9200,es03:9200/miluju/knedliky
```
...the path will be "/miluju/knedliky/"