### PR TITLE
New configuration section [elasticsearch]: better solution

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -70,15 +70,15 @@ class StorageService(StorageServiceABC):
 		# Authorization: username or API-key
 		username = Config.get(config_section_name, 'elasticsearch_username')
 		if len(username) == 0:
-			username = asab.Config.get('elasticsearch', 'username', fallback='')
+			username = Config.get('elasticsearch', 'username', fallback='')
 
 		password = Config.get(config_section_name, 'elasticsearch_password')
 		if len(password) == 0:
-			password = asab.Config.get('elasticsearch', 'password', fallback='')
+			password = Config.get('elasticsearch', 'password', fallback='')
 
 		api_key = Config.get(config_section_name, 'elasticsearch_api_key')
 		if len(api_key) == 0:
-			api_key = asab.Config.get('elasticsearch', 'api_key', fallback='')
+			api_key = Config.get('elasticsearch', 'api_key', fallback='')
 
 		# Create headers for requests
 		self.Headers = build_headers(username, password, api_key)


### PR DESCRIPTION
This MR deals with corner cases.
The previous solution was not optimal: https://github.com/TeskaLabs/asab/pull/521

For example, when there was no data in `[asab:storage]` + no `[elasticsearch]` section 

```
[asab:storage]
type=elasticsearch
```
we got the error:

```
    self.Headers = build_headers(username, password, api_key)
UnboundLocalError: local variable 'username' referenced before assignment
```

instead of a nice handling.

Also, there might be possible bugs introduced on lines 57 - 77 (for example, overwriting / ignoring variables) from different sections: https://github.com/TeskaLabs/asab/blob/5e8266210e9c0725273a376d79edcea120332f5e/asab/storage/elasticsearch.py#L57-L77 => for example, empty `[elasticsearch]` will overwrite `username/password/api_key` from `asab:storage`

*****//*****

**How this MR treats the following corner cases:**

1.

No `[asab:storage]`, no  `[elasticsearch]` sections in configurations:

```
07-Dec-2023 16:36:14.558703 CRITICAL asab.storage Missing configuration for [asab:storage] type.
Exit due to a critical configuration error.
````

2.

empty `[asab:storage]` + no `[elasticsearch]` section

```
07-Dec-2023 16:36:55.397904 CRITICAL asab.storage Missing configuration for [asab:storage] type.
Exit due to a critical configuration error.
```

3. 
 
No url and no auth data provided in any of the sections.
```
[asab:storage]
type=elasticsearch
```

or

```
[asab:storage]
type=elasticsearch

[elasticsearch]
```

```
RuntimeError: No ElasticSearch URL has been provided.
```

4.

No `username` / `password` or `api_key` provided in any of the sections.

```
[asab:storage]
type=elasticsearch

[elasticsearch]
url=https://localhost:9200/
```

```
ConnectionRefusedError: Response code 401: Unauthorized. Provide authorization by specifying either user name and password or api key.
```

*****//*****

**Possible supported configurations:**

**NEW LOGIC:**

```
[asab:storage]
type=elasticsearch

[elasticsearch]
url=https://localhost:9200/ 
    https://localhost:9200/ 
    https://localhost:9200/
# username=
# password=
api_key=
cafile=
```

**OR THE OLD ONE**

```
[asab:storage]
type=elasticsearch
elasticsearch_url=https://localhost:9200,localhost:9200,localhost:9200
                https://localhost:9200,localhost:9200,localhost:9200
                https://localhost:9200,localhost:9200,localhost:9200
# elasticsearch_username=
# elasticsearch_password=
elasticsearch_api_key=
cafile=
```