### PR TITLE
Improved error handing of metrics propagation into InfluxDB.

### DIFF
--- a/asab/metrics/influxdb.py
+++ b/asab/metrics/influxdb.py
@@ -110,7 +110,7 @@ class InfluxDBTarget(asab.Configurable):
 		rb = influxdb_format(m_tree, now)
 
 		if self.ProactorService is not None:
-			await self.ProactorService.execute(self._worker_upload, m_tree, rb)
+			self.ProactorService.schedule(self._worker_upload, m_tree, rb)
 
 		else:
 			try:


### PR DESCRIPTION
Reported errors:

```
02-Dec-2023 16:36:58.964712 ERROR asab.metrics.influxdb [sd url="http://lmio-box-testing-1:8086/"] Failed to send metrics to InfluxDB: [Errno -3] Try again
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/asab/metrics/influxdb.py", line 138, in _worker_upload
    conn.request("POST", self.WriteRequest, rb, self.Headers)
  File "/usr/lib/python3.10/http/client.py", line 1283, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1329, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1278, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.10/http/client.py", line 1038, in _send_output
    self.send(msg)
  File "/usr/lib/python3.10/http/client.py", line 976, in send
    self.connect()
  File "/usr/lib/python3.10/http/client.py", line 942, in connect
    self.sock = self._create_connection(
  File "/usr/lib/python3.10/socket.py", line 824, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
  File "/usr/lib/python3.10/socket.py", line 955, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -3] Try again
02-Dec-2023 16:36:59.003606 ERROR root Task exception was never retrieved
{'future': <Task finished name='Task-330835' coro=<InfluxDBTarget.process() done, defined at /usr/lib/python3.10/site-packages/asab/metrics/influxdb.py:109> exception=AttributeError("'NoneType' object has no attribute 'makefile'")>}
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/asab/metrics/influxdb.py", line 113, in process
    await self.ProactorService.execute(self._worker_upload, m_tree, rb)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.10/site-packages/asab/metrics/influxdb.py", line 145, in _worker_upload
    response = conn.getresponse()
  File "/usr/lib/python3.10/site-packages/sentry_sdk/integrations/stdlib.py", line 128, in getresponse
    rv = real_getresponse(self, *args, **kwargs)
  File "/usr/lib/python3.10/http/client.py", line 1371, in getresponse
    response = self.response_class(self.sock, method=self._method)
  File "/usr/lib/python3.10/http/client.py", line 256, in __init__
    self.fp = sock.makefile("rb")
AttributeError: 'NoneType' object has no attribute 'makefile'
```