### PR TITLE
Draft: asab.config

### DIFF
--- a/asab/zk_config/__init__.py
+++ b/asab/zk_config/__init__.py
@@ -1,0 +1,14 @@
+import logging
+
+from ..config import Config
+from .service import ConfigService
+
+#
+
+L = logging.getLogger(__name__)
+
+#
+
+__all__ = [
+	"ConfigService",
+]

--- a/asab/zk_config/exception.py
+++ b/asab/zk_config/exception.py
@@ -1,0 +1,31 @@
+import enum
+
+
+class ASABConfigException(Exception):
+
+	def __init__(self, error_code, error_dict=None, tech_message=None, error_i18n_key=None):
+		super().__init__()
+		self.ErrorCode = error_code
+		if error_dict is None:
+			self.ErrorDict = {}
+		else:
+			self.ErrorDict = error_dict
+		self.TechMessage = tech_message
+		# Adds a prefix to an error key (internationalization)
+		if error_i18n_key is not None:
+			self.Errori18nKey = "ConfigError|" + error_i18n_key
+		else:
+			self.Errori18nKey = "ConfigError|"
+
+
+class ErrorCode(enum.Enum):
+	GENERAL = 0  # This should not be actually used, if yes, then replace by existing/new error code
+	CONFIGS_MISSING = 1
+	CONFIG_MISSING = 2
+	INVALID_JSON = 3
+	INVALID_CONFIG = 4
+	ZOOKEEPER_LOST = 5
+	CONFIG_TYPE_MISSING = 6
+	RESTORE_FAILED = 7
+	INVALID_LINK = 8
+	EXPIRED_LINK = 9

--- a/asab/zk_config/service.py
+++ b/asab/zk_config/service.py
@@ -1,0 +1,42 @@
+import os
+
+from ..abc import Service
+from ..application import Application
+from ..zookeeper.container import ZooKeeperContainer
+
+
+from .zookeeper_provider import ZooKeeperProvider
+
+
+
+class ConfigService(Service):
+	def __init__(self, app: Application, zk_container: ZooKeeperContainer, service_name = "asab.ConfigService"):
+		super().__init__(app, service_name)
+		self.Provider = ZooKeeperProvider(app, zk_container=zk_container)
+
+	async def finalize(self, app):
+		await self.Provider.finalize(app)
+
+
+	async def list_configs(self, config_type):
+		return await self.Provider.list_configs(config_type)
+
+	async def get_config(self, config_type, config_name):
+		"""
+		Only JSON format of the configuration is allowed. You can search by config name or the file name with the extension.
+		Provider expects config types without extensions and config with extensions.
+		"""
+		_, node_extension = os.path.splitext(config_name)
+		if node_extension == '':
+			config_name = config_name + '.json'
+
+		return await self.Provider.get_config(config_type, config_name)
+
+
+
+	async def list_config_types(self):
+		return await self.Provider.list_config_types()
+
+	async def get_config_type(self, config_type):
+		return await self.Provider.get_config_type(config_type)
+

--- a/asab/zk_config/zookeeper_provider.py
+++ b/asab/zk_config/zookeeper_provider.py
@@ -1,0 +1,98 @@
+import os
+import json
+import logging
+
+from .exception import ASABConfigException, ErrorCode
+
+###
+
+L = logging.getLogger(__name__)
+
+
+###
+
+class ZooKeeperProvider():
+
+	def __init__(self, app, zk_container):
+		self.ZooKeeperContainer = zk_container
+		self.ZK = self.ZooKeeperContainer.ZooKeeper
+		self.ConfigPath = self.ZooKeeperContainer.Path + "/config"
+		self.App = app
+
+		self.IsReady = False
+		self.App.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_connected)
+		self.App.PubSub.subscribe("ZooKeeperContainer.state/LOST!", self._on_zk_lost)
+		self.App.PubSub.subscribe("ZooKeeperContainer.state/SUSPENDED!", self._on_zk_lost)
+
+	# Lifecycle
+
+	async def _on_zk_connected(self, event_name, zookeeper):
+		if zookeeper != self.ZooKeeperContainer:
+			return
+		
+		await self.ZooKeeperContainer.ZooKeeper.ensure_path(self.ConfigPath)
+		self._set_ready(ready=True)
+		self.App.PubSub.publish("ASABConfig.ready!")
+
+	async def _on_zk_lost(self, event_name, zkcontainer):
+		if zkcontainer != self.ZooKeeperContainer:
+			return
+		self._set_ready(ready=False)
+
+	def _set_ready(self, ready=True):
+		self.IsReady = ready
+
+	async def finalize(self, app):
+		await self.ZK._stop()
+
+	# Config
+
+	async def list_configs(self, config_type) -> list:
+		"""
+		List configs for the given config type.self.App.PubSub.publish("ASABConfig.ready!")
+		"""
+		if not self.IsReady:
+			raise ASABConfigException(ErrorCode.ZOOKEEPER_LOST, {"config_type": config_type}, tech_message="Connection to ZooKeeper lost. Action could not be proceeed.")
+		res = await self.ZK.get_children(os.path.join(self.ConfigPath, config_type))
+		if res is None:
+			raise ASABConfigException(ErrorCode.CONFIGS_MISSING, {"path": os.path.join(self.ConfigPath, config_type), "config_type": config_type}, tech_message="Configs of config type '{}' were not found.".format(config_type))
+		return res
+
+	async def get_config(self, config_type, config_name):
+		"""
+		Get a configuration file from a specified path, check if it
+		exists, and parse it as JSON.
+		"""
+		if not self.IsReady:
+			raise ASABConfigException(ErrorCode.ZOOKEEPER_LOST, {"config_type": config_type, "config_name": config_name}, tech_message="Connection to ZooKeeper lost. Action could not be proceeed.")
+		path = os.path.join(self.ConfigPath, config_type, config_name)
+
+		data = await self.ZK.get_data(path)
+		if data is None:
+			raise ASABConfigException(ErrorCode.CONFIG_MISSING, {"path": path, "config_type": config_type, "config_name": config_name}, tech_message="Config '{}' of config type '{}' was not found.".format(config_name, config_type))
+		try:
+			return json.loads(data)
+		except json.decoder.JSONDecodeError as e:
+			raise ASABConfigException(ErrorCode.INVALID_JSON, {"path": path, "config_type": config_type, "config_name": config_name, "reason": str(e)}, tech_message="Config '{}' of config type '{}' doesn't have a valid JSON format.".format(config_name, config_type))
+
+	# Config type
+
+	async def list_config_types(self):
+		if not self.IsReady:
+			raise ASABConfigException(ErrorCode.ZOOKEEPER_LOST, tech_message="Connection to ZooKeeper lost. Action could not be proceeed.")
+		res = await self.ZK.get_children(self.ConfigPath)
+		if res is None:
+			raise ASABConfigException(ErrorCode.CONFIGS_MISSING, {"path": os.path.join(self.ConfigPath)}, tech_message="No config types available.")
+		return res
+
+	async def get_config_type(self, config_type):
+		if not self.IsReady:
+			raise ASABConfigException(ErrorCode.ZOOKEEPER_LOST, tech_message="Connection to ZooKeeper lost. Action could not be proceeed.")
+		path = os.path.join(self.ConfigPath, config_type)
+		data = await self.ZK.get_data(path)
+		if data is None:
+			raise ASABConfigException(ErrorCode.CONFIG_TYPE_MISSING, {"path": path, "config_type": config_type}, tech_message="Config type '{}' was not found.".format(config_type))
+		try:
+			return json.loads(data)
+		except json.decoder.JSONDecodeError as e:
+			raise ASABConfigException(ErrorCode.INVALID_JSON, {"path": path, "config_type": config_type, "reason": str(e)}, tech_message="Config type '{}' doesn't have a valid JSON format.".format(config_type))

--- a/examples/zk_config.py
+++ b/examples/zk_config.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import os.path
+import sys
+
+import asab
+import asab.zk_config
+import asab.zookeeper
+
+asab.Config.add_defaults({
+	"zookeeper": {
+		# "servers": "zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181",
+		"servers": "10.173.34.137:2181",
+		"path": "/asab"
+	},
+
+})
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__(modules=[asab.zookeeper.Module])
+
+		# Locate the zookeeper service and initialize 'zookeeper'
+		self.ZooKeeperService = self.get_service("asab.ZooKeeperService")
+		self.ZooKeeperContainer = asab.zookeeper.ZooKeeperContainer(self.ZooKeeperService, "zookeeper")
+
+		self.ConfigService = asab.zk_config.ConfigService(
+			self,
+			self.ZooKeeperContainer,
+		)
+
+		self.PubSub.subscribe("ASABConfig.ready!", self.on_config_ready)
+
+
+	async def on_config_ready(self, _):
+		types = await self.ConfigService.list_config_types()
+		print("# Config types: \n")
+		for type in types:
+			print(type)
+		self.stop()
+
+
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION
The need to read from asab/config ZK node from BE services is getting more important (bs-query, depositor, parsec). So I promised to provide some tool for that in ASAB. I took "read" part from ASAB Config microservice. I think it should provide similar interface as asab.library

- I further simplified initialization of the provider. There is no configuration possible, though.
- there is config in naming - I would love to name it asab.config, but there is already asab.config file handling the service configuration
- I must do something with the Errors. I am not very sure whether I should remove them and return None when data is not found (as asab.library often does). 
- example provided

Similarly to ASAB Library, when this is done, I can remove the read part from ASAB Config making it the smallest microservice :tada: 
