### PR TITLE
Fix web requests histogram

### DIFF
--- a/asab/web/metrics.py
+++ b/asab/web/metrics.py
@@ -1,5 +1,6 @@
 from ..config import Config
 
+
 class WebRequestsMetrics(object):
 
 	def __init__(self, metrics_svc):

--- a/asab/web/metrics.py
+++ b/asab/web/metrics.py
@@ -32,7 +32,7 @@ class WebRequestsMetrics(object):
 		)
 		self.DurationHistogram = self.MetricsService.create_histogram(
 			"web_requests_duration_hist",
-			buckets=[0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 1, 5, 10, 50],
+			buckets=[0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 50],
 			unit="seconds",
 			help="Categorizes requests based on their duration.",
 			dynamic_tags=True,

--- a/asab/web/metrics.py
+++ b/asab/web/metrics.py
@@ -1,8 +1,15 @@
+from ..config import Config
 
 class WebRequestsMetrics(object):
 
 	def __init__(self, metrics_svc):
 		self.MetricsService = metrics_svc
+		# to customize duration histogram, provide bucket upper bound values separated by comma ","
+		duration_histogram_buckets = Config.get("asab:metrics", "web_requests_duration_histogram_buckets", fallback=None)
+		if duration_histogram_buckets is None:
+			duration_histogram_buckets = [0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 50]
+		else:
+			duration_histogram_buckets = [float(bucket.strip()) for bucket in duration_histogram_buckets.split(",")]
 
 		self.MaxDurationCounter = self.MetricsService.create_aggregation_counter(
 			"web_requests_duration_max",
@@ -32,7 +39,7 @@ class WebRequestsMetrics(object):
 		)
 		self.DurationHistogram = self.MetricsService.create_histogram(
 			"web_requests_duration_hist",
-			buckets=[0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 50],
+			buckets=duration_histogram_buckets,
 			unit="seconds",
 			help="Categorizes requests based on their duration.",
 			dynamic_tags=True,

--- a/examples/metrics-web-requests.py
+++ b/examples/metrics-web-requests.py
@@ -37,6 +37,7 @@ listen=0.0.0.0 8089
 
 [asab:metrics]
 target=influxdb
+web_requests_metrics=true
 
 [asab:metrics:influxdb]
 url=http://localhost:8086


### PR DESCRIPTION
The first commit is a fix of the web requests histogram, where I missed one value in the buckets.

The second commit is there because Robin wanted the buckets to be configurable. I don't like it. But it cannot harm anything, either.

I think the default configuration should live here: https://github.com/TeskaLabs/asab/blob/master/asab/config.py#L48
But then, when you look into the code of web request metrics, it is not obvious what are the histogram buckets upper bound values.  