### PR TITLE
Find seacat auth without configuration

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -107,6 +107,24 @@ class ConfigParser(configparser.ConfigParser):
 			"limit": "05:00",
 			"run_at_startup": "no",
 		},
+
+		"auth": {
+			# URL location containing the authorization server's public JWK keys
+			# (often found at "/.well-known/jwks.json")
+			"public_keys_url": "",
+
+			# Whether the app is tenant-aware
+			"multitenancy": "yes",
+
+			# The "enabled" option switches authentication and authorization
+			# on, off or activates mock mode. The default value is True (on).
+			# In MOCK MODE
+			# - no authorization server is needed,
+			# - all incoming requests are mock-authorized with pre-defined user info,
+			# - custom mock user info can supplied in a JSON file.
+			# "enabled": "yes",
+			"mock_user_info_path": "/conf/mock-userinfo.json",
+		}
 	}
 
 	if 'ASAB_ZOOKEEPER_SERVERS' in os.environ:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -25,6 +25,8 @@ try:
 except ModuleNotFoundError:
 	jwcrypto = None
 
+from ...api.discovery import NotDiscoveredError
+
 #
 
 L = logging.getLogger(__name__)
@@ -111,6 +113,9 @@ class AuthService(asab.Service):
 		self.MultitenancyEnabled = asab.Config.getboolean("auth", "multitenancy")
 		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url")
 
+		# To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization
+		self.DiscoveryService = self.App.get_service("asab.DiscoveryService")
+
 		enabled = asab.Config.get("auth", "enabled", fallback=True)
 		if enabled == "mock":
 			self.Mode = AuthMode.MOCK
@@ -128,12 +133,16 @@ class AuthService(asab.Service):
 				"You are trying to use asab.web.auth module without 'jwcrypto' installed. "
 				"Please run 'pip install jwcrypto' "
 				"or install asab with 'authz' optional dependency.")
-		elif len(self.PublicKeysUrl) == 0:
+		elif len(self.PublicKeysUrl) == 0 and self.DiscoveryService is None:
 			self.PublicKeysUrl = self._PUBLIC_KEYS_URL_DEFAULT
 			L.warning(
-				"No 'public_keys_url' provided in [auth] config section. "
-				"Defaulting to {!r}.".format(self._PUBLIC_KEYS_URL_DEFAULT)
+				"""No 'public_keys_url' provided in [auth] config section. 
+				Defaulting to {!r}. 
+				To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization""".format(self._PUBLIC_KEYS_URL_DEFAULT) 
 			)
+		elif len(self.PublicKeysUrl) == 0 and self.DiscoveryService is not None:
+			self.PublicKeysUrl = "http://seacat-auth.service_id.asab/openidconnect/public_keys"
+			L.info("`public_keys_url` not configured, defaulting to discovery of SeaCat Auth with URL: {}".format(self.PublicKeysUrl))
 
 		self.AuthServerPublicKey = None  # TODO: Support multiple public keys
 		# Limit the frequency of auth server requests to save network traffic
@@ -257,8 +266,8 @@ class AuthService(asab.Service):
 			and now < self.AuthServerLastSuccessfulCheck + self.AuthServerCheckCooldown:
 			# Public keys have been fetched recently
 			return
-
-		async with aiohttp.ClientSession() as session:
+		
+		async def fetch_keys(session):
 			try:
 				async with session.get(self.PublicKeysUrl) as response:
 					if response.status != 200:
@@ -297,6 +306,24 @@ class AuthService(asab.Service):
 					"url": self.PublicKeysUrl,
 				})
 				return
+			return public_key
+		
+		if self.DiscoveryService is None:
+			async with aiohttp.ClientSession() as session:
+				public_key = await fetch_keys(session)
+
+		else:
+			async with self.DiscoveryService.session() as session:
+				try:
+					public_key = await fetch_keys(session)
+				except NotDiscoveredError as e:
+					L.error("Service Discovery error while loading public keys: {}".format(e), struct_data={
+						"url": self.PublicKeysUrl,
+					})
+					return
+
+		if public_key is None:
+			return
 
 		self.AuthServerPublicKey = public_key
 		self.AuthServerLastSuccessfulCheck = datetime.datetime.now(datetime.timezone.utc)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -81,37 +81,36 @@ class AuthMode(enum.Enum):
 	MOCK = enum.auto()
 
 
-asab.Config.add_defaults({
-	"auth": {
-		# URL location containing the authorization server's public JWK keys
-		# (often found at "/.well-known/jwks.json")
-		"public_keys_url": "",
-
-		# Whether the app is tenant-aware
-		"multitenancy": "yes",
-
-		# The "enabled" option switches authentication and authorization
-		# on, off or activates mock mode. The default value is True (on).
-		# In MOCK MODE
-		# - no authorization server is needed,
-		# - all incoming requests are mock-authorized with pre-defined user info,
-		# - custom mock user info can supplied in a JSON file.
-		# "enabled": "yes",
-		"mock_user_info_path": "/conf/mock-userinfo.json",
-	}
-})
-
-
 class AuthService(asab.Service):
 	"""
 	Provides authentication and authorization of incoming requests.
+
+	Configuration: 
+	- Configuration section: auth
+	- Configuration options:
+	  - public_keys_url:
+	    - default: ""
+		- URL location containing the authorization server's public JWK keys (often found at "/.well-known/jwks.json")
+	  - multitenancy:
+	    - default: "yes"
+		- Whether the app is tenant-aware
+	  - enabled:
+	    - default: "yes"
+		- The "enabled" option switches authentication and authorization on, off or activates mock mode. The default value is True (on).
+		- In MOCK MODE
+		  - no authorization server is needed,
+		  - all incoming requests are mock-authorized with pre-defined user info,
+		  - custom mock user info can supplied in a JSON file.
+	  -mock_user_info_path:
+	    - default: "/conf/mock-userinfo.json"
 	"""
+
 	_PUBLIC_KEYS_URL_DEFAULT = "http://localhost:3081/.well-known/jwks.json"
 
 	def __init__(self, app, service_name="asab.AuthzService"):
 		super().__init__(app, service_name)
 		self.MultitenancyEnabled = asab.Config.getboolean("auth", "multitenancy")
-		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url")
+		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url", fallback="")
 
 		# To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization
 		self.DiscoveryService = self.App.get_service("asab.DiscoveryService")

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -110,7 +110,7 @@ class AuthService(asab.Service):
 	def __init__(self, app, service_name="asab.AuthzService"):
 		super().__init__(app, service_name)
 		self.MultitenancyEnabled = asab.Config.getboolean("auth", "multitenancy")
-		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url", fallback="")
+		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url")
 
 		# To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization
 		self.DiscoveryService = self.App.get_service("asab.DiscoveryService")

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -85,24 +85,24 @@ class AuthService(asab.Service):
 	"""
 	Provides authentication and authorization of incoming requests.
 
-	Configuration: 
+	Configuration:
 	- Configuration section: auth
 	- Configuration options:
-	  - public_keys_url:
-	    - default: ""
+	- public_keys_url:
+		- default: ""
 		- URL location containing the authorization server's public JWK keys (often found at "/.well-known/jwks.json")
-	  - multitenancy:
-	    - default: "yes"
+	- multitenancy:
+		- default: "yes"
 		- Whether the app is tenant-aware
-	  - enabled:
-	    - default: "yes"
+	- enabled:
+		- default: "yes"
 		- The "enabled" option switches authentication and authorization on, off or activates mock mode. The default value is True (on).
 		- In MOCK MODE
-		  - no authorization server is needed,
-		  - all incoming requests are mock-authorized with pre-defined user info,
-		  - custom mock user info can supplied in a JSON file.
-	  -mock_user_info_path:
-	    - default: "/conf/mock-userinfo.json"
+		- no authorization server is needed,
+		- all incoming requests are mock-authorized with pre-defined user info,
+		- custom mock user info can supplied in a JSON file.
+	-mock_user_info_path:
+		- default: "/conf/mock-userinfo.json"
 	"""
 
 	_PUBLIC_KEYS_URL_DEFAULT = "http://localhost:3081/.well-known/jwks.json"
@@ -261,7 +261,7 @@ class AuthService(asab.Service):
 			and now < self.AuthServerLastSuccessfulCheck + self.AuthServerCheckCooldown:
 			# Public keys have been fetched recently
 			return
-		
+
 		async def fetch_keys(session):
 			try:
 				async with session.get(self.PublicKeysUrl) as response:
@@ -302,7 +302,7 @@ class AuthService(asab.Service):
 				})
 				return
 			return public_key
-		
+
 		if self.DiscoveryService is None:
 			async with aiohttp.ClientSession() as session:
 				public_key = await fetch_keys(session)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -133,16 +133,12 @@ class AuthService(asab.Service):
 				"You are trying to use asab.web.auth module without 'jwcrypto' installed. "
 				"Please run 'pip install jwcrypto' "
 				"or install asab with 'authz' optional dependency.")
-		elif len(self.PublicKeysUrl) == 0 and self.DiscoveryService is None:
+		elif len(self.PublicKeysUrl) == 0:
 			self.PublicKeysUrl = self._PUBLIC_KEYS_URL_DEFAULT
 			L.warning(
-				"""No 'public_keys_url' provided in [auth] config section. 
-				Defaulting to {!r}. 
-				To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization""".format(self._PUBLIC_KEYS_URL_DEFAULT) 
+				"No 'public_keys_url' provided in [auth] config section. "
+				"Defaulting to {!r}.".format(self._PUBLIC_KEYS_URL_DEFAULT)
 			)
-		elif len(self.PublicKeysUrl) == 0 and self.DiscoveryService is not None:
-			self.PublicKeysUrl = "http://seacat-auth.service_id.asab/openidconnect/public_keys"
-			L.info("`public_keys_url` not configured, defaulting to discovery of SeaCat Auth with URL: {}".format(self.PublicKeysUrl))
 
 		self.AuthServerPublicKey = None  # TODO: Support multiple public keys
 		# Limit the frequency of auth server requests to save network traffic


### PR DESCRIPTION
It makes seacat auth resolvable through Discovery Session. 
I think it is not a breaking change. 
I moved default configuration to config.py, because I could not use asab.Config.add_defaults() inside by microservice - it was overriden by the add_default from AuthService. 
I tested this in bs-query. I could resolve seacat-auth within maestro installation, but I got 401 as I am calling to private web container. That is related to this: https://github.com/TeskaLabs/seacat-auth/pull/319
