### PR TITLE
Introduce generic ASAB error class

### DIFF
--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -6,7 +6,7 @@ class ASABError(Exception):
 	Base class for ASAB errors that can be communicated to the client (in HTTP response or other)
 	"""
 
-	self.Prefix = "ASABError"
+	Prefix = "ASABError"
 
 	def __init__(
 		self,

--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -1,6 +1,30 @@
 import aiohttp.web
 
 
+class ASABError(Exception):
+	"""
+	Base class for ASAB errors that can be communicated to the client (in HTTP response or other)
+	"""
+
+	self.Prefix = "ASABError"
+
+	def __init__(
+		self,
+		error_code: str,
+		tech_message: str,
+		error_i18n_key: str | None = None,
+		error_dict: dict | None = None,
+	):
+		super().__init__(tech_message)
+		self.ErrorCode = error_code
+		self.TechMessage = tech_message
+		self.ErrorDict = error_dict
+		if error_i18n_key is not None:
+			self.ErrorI18nKey = "{}|{}".format(self.Prefix, error_i18n_key)
+		else:
+			self.ErrorI18nKey = "{}|".format(self.Prefix)
+
+
 class ValidationError(Exception):
 	"""
 	Request cannot be processed because it does not match expected schema

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -102,11 +102,11 @@ def json_error_response(
 
 	payload = {
 		"result": "ERROR",
-		"error": e.ErrorI18nKey,
-		"tech_err": e.TechMessage,
+		"error": error.ErrorI18nKey,
+		"tech_err": error.TechMessage,
 	}
-	if e.ErrorDict is not None:
-		payload["error_dict"] = e.ErrorDict
+	if error.ErrorDict is not None:
+		payload["error_dict"] = error.ErrorDict
 
 	return aiohttp.web.json_response(request, payload, status=status, pretty=pretty, dumps=dumps, **kwargs)
 


### PR DESCRIPTION
- [x] Introduce generic `exceptions.ASABError`, which follows the structure outlined by Elena.
- [x] ASABError can be subclassed by different applications for their custom purposes.
- [x] Introduce `asab.web.rest.json.json_error_response` function, which generates a HTTP JSON response from ASABError.
- [ ] Add examples.
- [ ] Add documentation.


```python
async def my_handler(request):
  try:
    await create_something()
  except ASABError as e:
    L.log(asab.LOG_NOTICE, e.TechMessage)
    return asab.web.rest.json.json_error_response(request, e, status=409)

async def create_something():
  # Oops...
  raise ASABError(
    error_code=1000,
    tech_message="A record for {!r} already exists".format("stuff"),
    error_i18n_key="Unable to create '{{what}}', because it has already been created by '{{user}}'.",
    error_dict={"what": "stuff", "user": "the queen"},
  )
```