### PR TITLE
LZMAError: Corrupt input data in libsreg library provider

### DIFF
--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -174,8 +174,8 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 
 			except asyncio.TimeoutError as e:
 				L.error("Failed to download the library (TimeoutError).", struct_data={"url": url, 'error': e, 'exception': e.__class__.__name__})
-			
-			excep Exception:
+
+			except Exception:
 				L.exception("Error when fetching the library content from a registry")
 
 

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -174,6 +174,9 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 
 			except asyncio.TimeoutError as e:
 				L.error("Failed to download the library (TimeoutError).", struct_data={"url": url, 'error': e, 'exception': e.__class__.__name__})
+			
+			excep Exception:
+				L.exception("Error when fetching the library content from a registry")
 
 
 	async def subscribe(self, path):


### PR DESCRIPTION
Fixed - issue was manifested only if 2 and more libsreg layers were present in the configuration.
This is non-breaking change.