### PR TITLE
Remove multitenancy switch

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -113,9 +113,6 @@ class ConfigParser(configparser.ConfigParser):
 			# (often found at "/.well-known/jwks.json")
 			"public_keys_url": "",
 
-			# Whether the app is tenant-aware
-			"multitenancy": "yes",
-
 			# The "enabled" option switches authentication and authorization
 			# on, off or activates mock mode. The default value is True (on).
 			# In MOCK MODE

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -471,18 +471,6 @@ class AuthService(asab.Service):
 		return wrapper
 
 
-	def _add_tenant_none(self, handler):
-		"""
-		Add tenant=None to the handler arguments
-		"""
-
-		@functools.wraps(handler)
-		async def wrapper(*args, **kwargs):
-			return await handler(*args, tenant=None, **kwargs)
-
-		return wrapper
-
-
 def _get_id_token_claims(bearer_token: str, auth_server_public_key):
 	"""
 	Parse and validate JWT ID token and extract the claims (user info)

--- a/docs/examples/web-auth.md
+++ b/docs/examples/web-auth.md
@@ -10,256 +10,243 @@ title: Web auth
 
 	```python title='web-auth.py' linenums="1"
 	#!/usr/bin/env python3
-	import asab.web.rest
-	import asab.web.auth
-	import typing
-	
-	# Set up a web container listening at port 8080
-	asab.Config["web"] = {"listen": "0.0.0.0 8080"}
-	
-	# Disables or enables all authentication and authorization, or switches it into MOCK mode.
-	# When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
-	asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
-	# asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
-	# asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
-	
-	# Changes the behavior of endpoints with configurable tenant parameter.
-	# With multitenancy enabled, the `tenant` paramerter in query is required.
-	# With multitenancy disabled, the `tenant` paramerter in query is ignored.
-	asab.Config["auth"]["multitenancy"] = "yes"
-	
-	# Activating the mock mode disables communication with the authorization server.
-	# The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
-	# You can provide custom user info by specifying the path pointing to your JSON file.
-	asab.Config["auth"]["mock_user_info_path"] = "./mock-userinfo.json"
-	
-	# URL of the authorization server's JWK public keys, used for ID token verification.
-	# This option is ignored in mock mode or when authorization is disabled.
-	asab.Config["auth"]["public_keys_url"] = "http://localhost:3081/.well-known/jwks.json"
-	
-	
-	class MyApplication(asab.Application):
-	
-		def __init__(self):
-			super().__init__()
-	
-			# Initialize web container
-			self.add_module(asab.web.Module)
-			self.WebService = self.get_service("asab.WebService")
-			self.WebContainer = asab.web.WebContainer(self.WebService, "web")
-	
-			self.WebContainer.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
-	
-			from asab.api import ApiService
-			self.ApiService = ApiService(self)
-			self.ApiService.initialize_web(self.WebContainer)
-	
-			# Initialize authorization
-			self.AuthService = asab.web.auth.AuthService(self)
-			self.AuthService.install(self.WebContainer)
-	
-			# Add routes
-			self.WebContainer.WebApp.router.add_get("/no_auth", self.no_auth)
-			self.WebContainer.WebApp.router.add_get("/auth", self.auth)
-			self.WebContainer.WebApp.router.add_get("/auth/resource_check", self.auth_resource)
-			self.WebContainer.WebApp.router.add_put("/auth/resource_check", self.auth_resource_put)
-			self.WebContainer.WebApp.router.add_get("/{tenant}/required_tenant", self.tenant_in_path)
-			self.WebContainer.WebApp.router.add_get("/{tenant}/required_tenant/resource_check", self.tenant_in_path_resources)
-			self.WebContainer.WebApp.router.add_get("/configurable_tenant", self.tenant_in_query)
-			self.WebContainer.WebApp.router.add_get("/configurable_tenant/resource_check", self.tenant_in_query_resources)
-	
-	
-		@asab.web.auth.noauth
-		async def no_auth(self, request):
-			"""
-			NO AUTH
-			- authentication skipped
-	
-			- `tenant`, `user_info`, `resources` params not allowed
-			"""
-			data = {
-				"tenant": "NOT AVAILABLE",
-				"resources": "NOT AVAILABLE",
-				"user_info": "NOT AVAILABLE",
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		async def auth(self, request, *, user_info: typing.Optional[dict], resources: typing.Optional[frozenset]):
-			"""
-			TENANT-AGNOSTIC
-			- returns 401 if authentication not successful
-	
-			- `user_info`, `resources` params allowed
-			- `tenant` param not allowed
-			- `resources` contain only globally granted resources
-			"""
-			data = {
-				"tenant": "NOT AVAILABLE",
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		@asab.web.auth.require("something:access", "something:edit")
-		async def auth_resource(self, request, *, user_info: typing.Optional[dict], resources: typing.Optional[frozenset]):
-			"""
-			TENANT-AGNOSTIC + RESOURCE CHECK
-			- returns 401 if authentication not successful
-			- globally granted resources checked
-			- returns 403 if resource access not granted
-	
-			- `user_info`, `resources` params allowed
-			- `tenant` param not allowed
-			- `resources` contain only globally granted resources
-			"""
-			data = {
-				"tenant": "NOT AVAILABLE",
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		@asab.web.rest.json_schema_handler({
-			"type": "object"
-		})
-		@asab.web.auth.require("something:access", "something:edit")
-		async def auth_resource_put(
-			self, request, *,
-			user_info: typing.Optional[dict],
-			resources: typing.Optional[frozenset],
-			json_data: dict
-		):
-			"""
-			Decorator asab.web.auth.require can be used together with other decorators.
-			"""
-			data = {
-				"tenant": "NOT AVAILABLE",
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-				"json_data": json_data,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		async def tenant_in_path(
-			self, request, *,
-			tenant: typing.Optional[str],
-			user_info: typing.Optional[dict],
-			resources: typing.Optional[frozenset]
-		):
-			"""
-			TENANT-AWARE
-			- returns 401 if authentication not successful
-			- `tenant` access checked
-			- returns 403 if tenant not accessible
-	
-			- `user_info`, `resources` params allowed
-			- `tenant` param required in path, cannot be None
-			- `resources` contain tenant-granted resources
-			"""
-			data = {
-				"tenant": tenant,
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		async def tenant_in_query(
-			self, request, *,
-			tenant: typing.Optional[str],
-			user_info: typing.Optional[dict],
-			resources: typing.Optional[frozenset]
-		):
-			"""
-			CONFIGURABLY TENANT-AWARE
-			- returns 401 if authentication not successful
-			- if multitenancy is enabled
-				- `tenant` required in query string
-				- tenant access checked
-				- returns 400 if `tenant` not in query
-				- returns 403 if tenant not accessible
-			- if multitenancy is disabled
-				- `tenant` is set to `None`
-	
-			- `user_info`, `resources` params allowed
-			- `tenant` param required in query only if multitenancy is enabled
-			- `resources` contain tenant-granted resources if multitenancy is enabled,
-				otherwise only globally-granted resources
-			"""
-			data = {
-				"tenant": tenant,
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		@asab.web.auth.require("something:access", "something:edit")
-		async def tenant_in_path_resources(
-			self, request, *,
-			tenant: typing.Optional[str],
-			user_info: typing.Optional[dict],
-			resources: typing.Optional[frozenset]
-		):
-			"""
-			TENANT-AWARE + RESOURCE CHECK
-			- returns 401 if authentication not successful
-			- `tenant` access checked
-			- returns 403 if tenant not accessible
-			- tenant-accessible resources checked
-			- returns 403 if resource access not granted
-	
-			- `user_info`, `resources` params allowed
-			- `tenant` param required, cannot be None
-			- `resources` contain only resources granted within tenant
-			"""
-			data = {
-				"tenant": tenant,
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-		@asab.web.auth.require("something:access", "something:edit")
-		async def tenant_in_query_resources(
-			self, request, *,
-			tenant: typing.Optional[str],
-			user_info: typing.Optional[dict],
-			resources: typing.Optional[frozenset]
-		):
-			"""
-			CONFIGURABLY TENANT-AWARE + RESOURCE CHECK
-			- returns 401 if authentication not successful
-			- if multitenancy is enabled
-				- `tenant` required in query string
-				- tenant access checked
-				- returns 400 if `tenant` not in query
-				- returns 403 if tenant not accessible
-				- returns 403 if resource access not granted within tenant
-			- if multitenancy is disabled
-				- `tenant` is set to `None`
-				- returns 403 if resources not granted globally
-	
-			- `user_info`, `resources` params allowed
-			- `tenant` param required only if multitenancy is enabled
-			- `resources` contain tenant-granted resources if multitenancy is enabled,
-				otherwise only globally-granted resources
-			"""
-			data = {
-				"tenant": tenant,
-				"resources": list(resources) if resources else None,
-				"user_info": user_info,
-			}
-			return asab.web.rest.json_response(request, data)
-	
-	
-	if __name__ == "__main__":
-		app = MyApplication()
-		app.run()
-	
+    import asab.web.rest
+    import asab.web.auth
+    import typing
+    
+    # Set up a web container listening at port 8080
+    asab.Config["web"] = {"listen": "8080"}
+    
+    # Disables or enables all authentication and authorization, or switches it into MOCK mode.
+    # When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
+    asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
+    # asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
+    # asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
+    
+    # Activating the mock mode disables communication with the authorization server.
+    # The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
+    # You can provide custom user info by specifying the path pointing to your JSON file.
+    asab.Config["auth"]["mock_user_info_path"] = "./mock-userinfo.json"
+    
+    # URL of the authorization server's JWK public keys, used for ID token verification.
+    # This option is ignored in mock mode or when authorization is disabled.
+    asab.Config["auth"]["public_keys_url"] = "http://localhost:3081/.well-known/jwks.json"
+    
+    
+    class MyApplication(asab.Application):
+    
+        def __init__(self):
+            super().__init__()
+    
+            # Initialize web container
+            self.add_module(asab.web.Module)
+            self.WebService = self.get_service("asab.WebService")
+            self.WebContainer = asab.web.WebContainer(self.WebService, "web")
+    
+            self.WebContainer.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
+    
+            from asab.api import ApiService
+            self.ApiService = ApiService(self)
+            self.ApiService.initialize_web(self.WebContainer)
+    
+            # Initialize authorization
+            self.AuthService = asab.web.auth.AuthService(self)
+            self.AuthService.install(self.WebContainer)
+    
+            # Add routes
+            self.WebContainer.WebApp.router.add_get("/no_auth", self.no_auth)
+            self.WebContainer.WebApp.router.add_get("/auth", self.auth)
+            self.WebContainer.WebApp.router.add_get("/auth/resource_check", self.auth_resource)
+            self.WebContainer.WebApp.router.add_put("/auth/resource_check", self.auth_resource_put)
+            self.WebContainer.WebApp.router.add_get("/{tenant}/required_tenant", self.tenant_in_path)
+            self.WebContainer.WebApp.router.add_get("/{tenant}/required_tenant/resource_check", self.tenant_in_path_resources)
+            self.WebContainer.WebApp.router.add_get("/configurable_tenant", self.tenant_in_query)
+            self.WebContainer.WebApp.router.add_get("/configurable_tenant/resource_check", self.tenant_in_query_resources)
+    
+    
+        @asab.web.auth.noauth
+        async def no_auth(self, request):
+            """
+            NO AUTH
+            - authentication skipped
+    
+            - `tenant`, `user_info`, `resources` params not allowed
+            """
+            data = {
+                "tenant": "NOT AVAILABLE",
+                "resources": "NOT AVAILABLE",
+                "user_info": "NOT AVAILABLE",
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        async def auth(self, request, *, user_info: typing.Optional[dict], resources: typing.Optional[frozenset]):
+            """
+            TENANT-AGNOSTIC
+            - returns 401 if authentication not successful
+    
+            - `user_info`, `resources` params allowed
+            - `tenant` param not allowed
+            - `resources` contain only globally granted resources
+            """
+            data = {
+                "tenant": "NOT AVAILABLE",
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        @asab.web.auth.require("something:access", "something:edit")
+        async def auth_resource(self, request, *, user_info: typing.Optional[dict], resources: typing.Optional[frozenset]):
+            """
+            TENANT-AGNOSTIC + RESOURCE CHECK
+            - returns 401 if authentication not successful
+            - globally granted resources checked
+            - returns 403 if resource access not granted
+    
+            - `user_info`, `resources` params allowed
+            - `tenant` param not allowed
+            - `resources` contain only globally granted resources
+            """
+            data = {
+                "tenant": "NOT AVAILABLE",
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        @asab.web.rest.json_schema_handler({
+            "type": "object"
+        })
+        @asab.web.auth.require("something:access", "something:edit")
+        async def auth_resource_put(
+            self, request, *,
+            user_info: typing.Optional[dict],
+            resources: typing.Optional[frozenset],
+            json_data: dict
+        ):
+            """
+            Decorator asab.web.auth.require can be used together with other decorators.
+            """
+            data = {
+                "tenant": "NOT AVAILABLE",
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+                "json_data": json_data,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        async def tenant_in_path(
+            self, request, *,
+            tenant: typing.Optional[str],
+            user_info: typing.Optional[dict],
+            resources: typing.Optional[frozenset]
+        ):
+            """
+            TENANT-AWARE
+            - returns 401 if authentication not successful
+            - `tenant` access checked
+            - returns 403 if tenant not accessible
+    
+            - `user_info`, `resources` params allowed
+            - `tenant` param required in path, cannot be None
+            - `resources` contain tenant-granted resources
+            """
+            data = {
+                "tenant": tenant,
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        async def tenant_in_query(
+            self, request, *,
+            tenant: typing.Optional[str],
+            user_info: typing.Optional[dict],
+            resources: typing.Optional[frozenset]
+        ):
+            """
+            CONFIGURABLY TENANT-AWARE
+            - returns 401 if authentication not successful
+            - `tenant` expected in query string
+            - tenant access checked
+            - returns 403 if tenant not accessible
+            - `tenant` is set to `None` if `tenant` not in query
+    
+            - `user_info`, `resources` params allowed
+            - `resources` contain tenant-granted resources if tenant is not None,
+                otherwise only globally-granted resources
+            """
+            data = {
+                "tenant": tenant,
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        @asab.web.auth.require("something:access", "something:edit")
+        async def tenant_in_path_resources(
+            self, request, *,
+            tenant: typing.Optional[str],
+            user_info: typing.Optional[dict],
+            resources: typing.Optional[frozenset]
+        ):
+            """
+            TENANT-AWARE + RESOURCE CHECK
+            - returns 401 if authentication not successful
+            - `tenant` access checked
+            - returns 403 if tenant not accessible
+            - tenant-accessible resources checked
+            - returns 403 if resource access not granted
+    
+            - `user_info`, `resources` params allowed
+            - `tenant` param required, cannot be None
+            - `resources` contain only resources granted within tenant
+            """
+            data = {
+                "tenant": tenant,
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+        @asab.web.auth.require("something:access", "something:edit")
+        async def tenant_in_query_resources(
+            self, request, *,
+            tenant: typing.Optional[str],
+            user_info: typing.Optional[dict],
+            resources: typing.Optional[frozenset]
+        ):
+            """
+            CONFIGURABLY TENANT-AWARE + RESOURCE CHECK
+            - returns 401 if authentication not successful
+            - `tenant` expected in query string
+            - tenant access checked
+            - returns 403 if tenant not accessible
+            - returns 403 if resource access not granted within tenant
+            - `tenant` is set to `None` if `tenant` not in query
+            - returns 403 if tenant is None resource access is not granted globally
+    
+            - `user_info`, `resources` params allowed
+            - `resources` contain tenant-granted resources if tenant is not None,
+                otherwise only globally-granted resources
+            """
+            data = {
+                "tenant": tenant,
+                "resources": list(resources) if resources else None,
+                "user_info": user_info,
+            }
+            return asab.web.rest.json_response(request, data)
+    
+    
+    if __name__ == "__main__":
+        app = MyApplication()
+        app.run()
+
 	```

--- a/docs/reference/services/web/authorization_multitenancy.md
+++ b/docs/reference/services/web/authorization_multitenancy.md
@@ -71,7 +71,6 @@ in the `[auth]` section with the following options:
 | Option                | Type             | Meaning |
 |-----------------------|------------------| --- |
 | `public_keys_url`     | URL              | The URL of the authorization server's public keys (also known as `jwks_uri` in [OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8414#section-2)) |
-| `multitenancy`        | boolean          | Toggles the behavior of endpoints with configurable tenant parameter. When enabled, the tenant query paramerter is required. When disabled, the tenant query parameter is ignored and set to `None`. In dev mode, the multitenancy switch is ignored and the tenant parameter is taken into account only when it is present in query, otherwise it is set to `None`. |
 | `enabled`             | boolean or `"mock"` | Enables or disables authentication and authorization or switches to mock authorization. In mock mode, all incoming requests are authorized with mock user info. There is no communication with the authorization server (so it is not necessary to configure `public_keys_url` in dev mode).
 | `mock_user_info_path` | path             | Path to JSON file that contains user info claims used in mock mode. The structure of user info should follow the [OpenID Connect userinfo definition](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse) and also contain the `resources` object.
 
@@ -79,7 +78,6 @@ Default options:
 
 ```ini
 public_keys_url=http://localhost:3081/.well-known/jwks.json
-multitenancy=yes
 enabled=yes
 mock_user_info_path=/conf/mock-userinfo.json
 ```
@@ -118,21 +116,12 @@ checks if the request is authorized for the tenant, and finally passes the tenan
 
 ### Configurable multitenant endpoints
 
-Configurable multitenant endpoints usually operate within a tenant, but they can also operate in tenantless mode if the application is configured for that. 
+Configurable multitenant endpoints usually operate within a tenant, 
+but they can also operate in tenantless mode if the application is designed for that. 
 
-When you create an endpoint *without* `tenant` parameter in the URL path and *with* `tenant` argument in the handler method, the
-Auth service will either expect the `tenant` parameter
-to be provided in the **URL query** if mutlitenancy is enabled,
-or to not be provided at all if multitenancy is disabled. 
-
-Use the `multitenancy` boolean switch in the `[auth]` config section to control the multitenancy setting.
-
-
-If multitenancy is **enabled**, the request's **query string** must include a tenant parameter.
-Requests without the tenant query result in Bad request (HTTP 400).
-
-If multitenancy is **disabled**, the tenant argument in the handler method is set to `None`.
-Any `tenant` parameter in the query string is ignored.
+When you create an endpoint *without* `tenant` parameter in the URL path and *with* `tenant` argument in the 
+handler method, the Auth service will either expect the `tenant` parameter to be provided in the **URL query**. 
+If it is not in the query, the tenant variable is set to `None`.
 
 !!! example "Example handler:"
 
@@ -152,17 +141,9 @@ Any `tenant` parameter in the query string is ignored.
 
 !!! example "Example requests:"
 
-	1. with multitenancy on:.
-
-		```
-		GET http://localhost:8080/todays-menu?tenant=lazy-raccoon-bistro
-		```
-
-	2. with multitenancy off:
-
-		```
-		GET http://localhost:8080/todays-menu
-		```
+    ```
+    GET http://localhost:8080/todays-menu?tenant=lazy-raccoon-bistro
+    ```
 
 ## Mock mode
 

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -4,18 +4,13 @@ import asab.web.auth
 import typing
 
 # Set up a web container listening at port 8080
-asab.Config["web"] = {"listen": "0.0.0.0 8080"}
+asab.Config["web"] = {"listen": "8080"}
 
 # Disables or enables all authentication and authorization, or switches it into MOCK mode.
 # When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
 asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
 # asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
 # asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
-
-# Changes the behavior of endpoints with configurable tenant parameter.
-# With multitenancy enabled, the `tenant` paramerter in query is required.
-# With multitenancy disabled, the `tenant` paramerter in query is ignored.
-asab.Config["auth"]["multitenancy"] = "yes"
 
 # Activating the mock mode disables communication with the authorization server.
 # The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
@@ -166,17 +161,13 @@ class MyApplication(asab.Application):
 		"""
 		CONFIGURABLY TENANT-AWARE
 		- returns 401 if authentication not successful
-		- if multitenancy is enabled
-			- `tenant` required in query string
-			- tenant access checked
-			- returns 400 if `tenant` not in query
-			- returns 403 if tenant not accessible
-		- if multitenancy is disabled
-			- `tenant` is set to `None`
+		- `tenant` expected in query string
+		- tenant access checked
+		- returns 403 if tenant not accessible
+		- `tenant` is set to `None` if `tenant` not in query
 
 		- `user_info`, `resources` params allowed
-		- `tenant` param required in query only if multitenancy is enabled
-		- `resources` contain tenant-granted resources if multitenancy is enabled,
+		- `resources` contain tenant-granted resources if tenant is not None,
 			otherwise only globally-granted resources
 		"""
 		data = {
@@ -224,19 +215,15 @@ class MyApplication(asab.Application):
 		"""
 		CONFIGURABLY TENANT-AWARE + RESOURCE CHECK
 		- returns 401 if authentication not successful
-		- if multitenancy is enabled
-			- `tenant` required in query string
-			- tenant access checked
-			- returns 400 if `tenant` not in query
-			- returns 403 if tenant not accessible
-			- returns 403 if resource access not granted within tenant
-		- if multitenancy is disabled
-			- `tenant` is set to `None`
-			- returns 403 if resources not granted globally
+		- `tenant` expected in query string
+		- tenant access checked
+		- returns 403 if tenant not accessible
+		- returns 403 if resource access not granted within tenant
+		- `tenant` is set to `None` if `tenant` not in query
+		- returns 403 if tenant is None resource access is not granted globally
 
 		- `user_info`, `resources` params allowed
-		- `tenant` param required only if multitenancy is enabled
-		- `resources` contain tenant-granted resources if multitenancy is enabled,
+		- `resources` contain tenant-granted resources if tenant is not None,
 			otherwise only globally-granted resources
 		"""
 		data = {


### PR DESCRIPTION
The `[auth] multitenancy` switch is disposable and this is a proposal to remove it for the sake of simplification. This will slightly change the behavior when tenant parameter is supplied in request query.

# Old behavior

When an endpoint has a `tenant` argument in its method, but the tenant is not supplied in URL path nor in URL query:
- the request is handled with `tenant=None` when multitenancy is disabled.
- the request results in HTTP 400 when multitenancy is disabled.

# New behavior

When an endpoint has a `tenant` argument in its method, but the tenant is not supplied in URL path nor in URL query:
- the request is handled with `tenant=None`.
