### PR TITLE
Add SITE_ID identifier

### DIFF
--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -195,7 +195,7 @@ class ApiService(Service):
 		if instance_id is not None:
 			adv_data["instance_id"] = instance_id
 
-		# A identified of the host machine (node); added if available at environment variables
+		# An identifier of the host machine (node); added if available at environment variables
 		node_id = os.getenv('NODE_ID', None)
 		if node_id is not None:
 			adv_data["node_id"] = node_id
@@ -203,6 +203,11 @@ class ApiService(Service):
 		service_id = os.getenv('SERVICE_ID', None)
 		if service_id is not None:
 			adv_data["service_id"] = service_id
+
+		# An identifier of a site, of a specific deployment
+		site_id = os.getenv('SITE_ID', None)
+		if site_id is not None:
+			adv_data["site_id"] = site_id
 
 		if running_in_container():
 			adv_data["containerized"] = True

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -46,6 +46,10 @@ class MetricsService(Service):
 		if instance_id is not None:
 			self.Tags["instance_id"] = instance_id
 
+		site_id = os.getenv('SITE_ID', None)
+		if site_id is not None:
+			self.Tags["site_id"] = site_id
+
 		self.Storage = Storage()
 
 		app.PubSub.subscribe("Application.tick/60!", self._on_flushing_event)

--- a/asab/sentry/service.py
+++ b/asab/sentry/service.py
@@ -146,6 +146,7 @@ class SentryService(asab.Service):
 		self.NodeId = os.getenv("NODE_ID", None)  # e.g. "lmio-box-testing-1"
 		self.ServiceId = os.getenv("SERVICE_ID", None)  # e.g. "lmio-service"
 		self.InstanceId = os.getenv("INSTANCE_ID", None)  # e.g. "lmio-service-01"
+		self.SiteId = os.getenv("SITE_ID", None)
 
 		if self.NodeId:
 			sentry_sdk.set_tag("node_id", self.NodeId)
@@ -153,6 +154,8 @@ class SentryService(asab.Service):
 			sentry_sdk.set_tag("service_id", self.ServiceId)
 		if self.InstanceId:
 			sentry_sdk.set_tag("instance_id", self.InstanceId)
+		if self.SiteId:
+			sentry_sdk.set_tag("site_id", self.SiteId)
 
 		sentry_sdk.set_tag("appclass", app.__class__.__name__)  # e.g. 'LMIOParsecApplication'
 

--- a/docs/reference/services/metrics/tags.md
+++ b/docs/reference/services/metrics/tags.md
@@ -35,6 +35,8 @@ Present if SERVICE_ID environmental variable is specified. It names a service in
 - `instance_id`: 
 Present if INSTANCE_ID environmental variable is specified. It names an instance in the cluster.
 
+- `site_id`:
+Present if SITE_ID environmental variable is specified. It is a name a site, of a specific deployment.
 
 ## Dynamic Tags
 !!! example

--- a/docs/reference/services/sentry.md
+++ b/docs/reference/services/sentry.md
@@ -60,7 +60,7 @@ events=notice  # logging level for capturing events
 
 !!! tip
 	If the application is properly containerized, other tags for Sentry.io are created automatically (using Manifest), such as:
-	`appclass`, `release`, `server_name`, `service_id`, `instance_id`, `node_id`.
+	`appclass`, `release`, `server_name`, `service_id`, `instance_id`, `node_id`, `site_id`.
 
 ## Integration
 


### PR DESCRIPTION
SITE ID environment variable will propagate:
- to data advertised into zookeeper through API Service
- to tags of metrics
- to sentry tags