### PR TITLE
Set "environment" tag in Sentry to SITE_ID

### DIFF
--- a/asab/sentry/service.py
+++ b/asab/sentry/service.py
@@ -85,9 +85,6 @@ class SentryService(asab.Service):
 		self.LoggingBreadCrumbsLevel = levels.get(asab.Config.get("sentry:logging", "breadcrumbs").lower())
 		self.LoggingEventsLevel = levels.get(asab.Config.get("sentry:logging", "events").lower())
 
-		# ENVIRONMENT (e.g. "production", "testing", ...)
-		self.Environment = asab.Config.get("sentry", "environment")  # default: "development"
-
 		# RELEASE
 		# Release can be obtained from MANIFEST.json if exists
 		manifest = {}
@@ -132,14 +129,12 @@ class SentryService(asab.Service):
 				),
 			],
 			traces_sample_rate=self.TracesSampleRate,  # percentage of captured events
-			environment=self.Environment,  # e.g. "production", "develop"
+			environment="not specified",
 			release=self.Release,  # version of the microservice, e.g., v23.40-alpha
 			auto_session_tracking=True,  # session info about interaction between user and app
 			debug=False,  # ...sends many irrelevant messages
 			max_value_length=8192,  # longer messages are truncated, the default value (1024) is too short
 		)
-		# TODO: Investigate CA certs, TLS/SSL, Security Tokens, Allowed Domains
-
 
 		# ADDITIONAL GLOBAL TAGS
 		# These tags will be set manually or automatically by Remote Control
@@ -156,6 +151,7 @@ class SentryService(asab.Service):
 			sentry_sdk.set_tag("instance_id", self.InstanceId)
 		if self.SiteId:
 			sentry_sdk.set_tag("site_id", self.SiteId)
+			sentry_sdk.set_tag("environment", self.SiteId)
 
 		sentry_sdk.set_tag("appclass", app.__class__.__name__)  # e.g. 'LMIOParsecApplication'
 


### PR DESCRIPTION
Since "environment" is mandatory tag in Sentry.io, we can set that tag to SITE_ID.