### PR TITLE
Fix AuthService name and introduce get_authorized_tenant utility method

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -225,6 +225,14 @@ class AuthService(asab.Service):
 			raise asab.exceptions.NotAuthenticatedError()
 
 
+	def get_authorized_tenant(self, request):
+		if hasattr(request, "_AuthorizedTenants"):
+			for tenant in request._AuthorizedTenants:
+				# Return the first authorized tenant
+				return tenant
+		return None
+
+
 	def has_superuser_access(self, authorized_resources: typing.Iterable) -> bool:
 		"""
 		Check if the superuser resource is present in the authorized resource list.

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -222,7 +222,10 @@ class AuthService(asab.Service):
 			raise asab.exceptions.NotAuthenticatedError()
 
 
-	def get_authorized_tenant(self, request):
+	def get_authorized_tenant(self, request) -> typing.Optional[str]:
+		"""
+		Get the request's authorized tenant.
+		"""
 		if hasattr(request, "_AuthorizedTenants"):
 			for tenant in request._AuthorizedTenants:
 				# Return the first authorized tenant

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -82,20 +82,21 @@ class AuthService(asab.Service):
 	Provides authentication and authorization of incoming requests.
 
 	Configuration:
-	- Configuration section: auth
-	- Configuration options:
-	- public_keys_url:
-		- default: ""
-		- URL location containing the authorization server's public JWK keys (often found at "/.well-known/jwks.json")
-	- enabled:
-		- default: "yes"
-		- The "enabled" option switches authentication and authorization on, off or activates mock mode. The default value is True (on).
-		- In MOCK MODE
-		- no authorization server is needed,
-		- all incoming requests are mock-authorized with pre-defined user info,
-		- custom mock user info can supplied in a JSON file.
-	-mock_user_info_path:
-		- default: "/conf/mock-userinfo.json"
+		Configuration section: auth
+		Configuration options:
+			public_keys_url:
+				- default: ""
+				- URL containing the authorization server's public JWKey set (usually found at "/.well-known/jwks.json")
+			enabled:
+				- default: "yes"
+				- options: "yes", "no", "mocked"
+				- Switch authentication and authorization on, off or activate mock mode.
+				- In MOCK MODE
+					- no authorization server is needed,
+					- all incoming requests are mock-authorized with pre-defined user info,
+					- custom mock user info can supplied in a JSON file.
+			mock_user_info_path:
+				- default: "/conf/mock-userinfo.json"
 	"""
 
 	_PUBLIC_KEYS_URL_DEFAULT = "http://localhost:3081/.well-known/jwks.json"

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -101,7 +101,7 @@ class AuthService(asab.Service):
 
 	_PUBLIC_KEYS_URL_DEFAULT = "http://localhost:3081/.well-known/jwks.json"
 
-	def __init__(self, app, service_name="asab.AuthzService"):
+	def __init__(self, app, service_name="asab.AuthService"):
 		super().__init__(app, service_name)
 		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url")
 

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -3,23 +3,29 @@ import asab.web.rest
 import asab.web.auth
 import typing
 
-# Set up a web container listening at port 8080
-asab.Config["web"] = {"listen": "8080"}
+if "web" not in asab.Config:
+	asab.Config["web"] = {
+		# Set up a web container listening at port 8080
+		"listen": "8080"
+	}
 
-# Disables or enables all authentication and authorization, or switches it into MOCK mode.
-# When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
-asab.Config["auth"]["enabled"] = "mock"  # Mock authorization, useful for debugging.
-# asab.Config["auth"]["enabled"] = "yes"   # Authorization is enabled.
-# asab.Config["auth"]["enabled"] = "no"    # Authorization is disabled.
+if "auth" not in asab.Config:
+	asab.Config["auth"] = {
+		# Disable or enable all authentication and authorization, or switch into MOCK mode.
+		# When disabled, the `resources` and `userinfo` handler arguments are set to `None`.
+		"enabled": "mock",  # Mock authorization, useful for debugging.
+		# "enabled": "yes",   # Authorization is enabled.
+		# "enabled": "no",   # Authorization is disabled.
 
-# Activating the mock mode disables communication with the authorization server.
-# The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
-# You can provide custom user info by specifying the path pointing to your JSON file.
-asab.Config["auth"]["mock_user_info_path"] = "./mock-userinfo.json"
+		# Activating the mock mode disables communication with the authorization server.
+		# The requests' Authorization headers are ignored and AuthService provides mock authorization with mock user info.
+		# You can provide custom user info by specifying the path pointing to your JSON file.
+		"mock_user_info_path": "./mock-userinfo.json",
 
-# URL of the authorization server's JWK public keys, used for ID token verification.
-# This option is ignored in mock mode or when authorization is disabled.
-asab.Config["auth"]["public_keys_url"] = "http://localhost:3081/.well-known/jwks.json"
+		# URL of the authorization server's JWK public keys, used for ID token verification.
+		# This option is ignored in mock mode or when authorization is disabled.
+		"public_keys_url": "http://localhost:3081/.well-known/jwks.json",
+	}
 
 
 class MyApplication(asab.Application):


### PR DESCRIPTION
# Summary

- **`BREAKING`**: Changed `asab.web.auth.AuthService`'s service_name to `asab.AuthService` (was incorrectly `asab.AuthzService`). I briefly checked our codebase and none of our services should be impacted by this potentially breaking change.
- Introducing `asab.web.auth.AuthService.get_authorized_tenant(request)`: A utility method for getting authorized tenant ID from the request's userinfo. If there is no authorized tenant or no authorization whatsoever, the return value is `None`.
- Updated auth examples and docstrings.

# Usage example

```python
async def endpoint(self, request):
	auth_service = self.App.get_service("asab.AuthService")
	tenant = auth_service.get_authorized_tenant(request)
	if tenant is None:
		return asab.web.rest.json_response(request, {"result": "ERROR"}, status=400)
	else:
		result = await do_stuff(tenant, ...)
		return asab.web.rest.json_response(request, result)
```