### PR TITLE
Log to console by default

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -66,6 +66,7 @@ class ConfigParser(configparser.ConfigParser):
 		"logging:console": {
 			"format": "%(asctime)s %(levelname)s %(name)s %(struct_data)s%(message)s",
 			"datefmt": "%d-%b-%Y %H:%M:%S.%f",
+			"enabled": True
 		},
 
 		"logging:syslog": {

--- a/asab/log.py
+++ b/asab/log.py
@@ -56,7 +56,7 @@ class Logging(object):
 		if not self.RootLogger.hasHandlers():
 
 			# Add console logger if needed
-			if os.isatty(sys.stdout.fileno()) or os.environ.get('ASABFORCECONSOLE', '0') != '0':
+			if os.isatty(sys.stdout.fileno()) or os.environ.get('ASABFORCECONSOLE', '0') != '0' or Config.getboolean("logging:console", "enabled"):
 				self._configure_console_logging()
 
 			# Initialize file handler


### PR DESCRIPTION
I probably forgot some important piece...

But why don't we log into console by default? Always...? I don't recall any case when I would like NOT to see the logs. 