### PR TITLE
Get OpenAPI route tag form class docstring

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -77,11 +77,8 @@ class DocWebHandler(object):
 		}
 
 		# Application specification
-		try:
-			app_info: dict = get_docstring_yaml_dict(self.App)
-			specification.update(app_info)
-		except yaml.YAMLError as e:
-			L.error("Failed to parse YAML data in {!r} docstring: {}".format(self.App.__class__.__name__, e))
+		app_info: dict = get_docstring_yaml_dict(self.App)
+		specification.update(app_info)
 
 		# Find asab and microservice routes, sort them alphabetically by the first tag
 		asab_routes = []
@@ -132,10 +129,7 @@ class DocWebHandler(object):
 		docstring: str = route.handler.__doc__
 		docstring_description: str = get_docstring_description(docstring)
 		docstring_description += "\n\n**Handler:** `{}`".format(handler_name)
-		try:
-			docstring_yaml_dict: dict = get_docstring_yaml_dict(route.handler)
-		except yaml.YAMLError as e:
-			L.error("Failed to parse YAML data in {!r} docstring: {}".format(route.__class__.__name__, e))
+		docstring_yaml_dict: dict = get_docstring_yaml_dict(route.handler)
 
 		# Create route info dictionary
 		route_info_data: dict = {
@@ -374,12 +368,12 @@ def get_first_tag(route_data: dict) -> str:
 				return method.get("tags")[0].lower()
 
 
-def get_docstring_yaml_dict(component) -> typing.Optional[dict]:
+def get_docstring_yaml_dict(component) -> dict:
 	"""
 	Inspect the docstring of a component for YAML data and parse it if there is any.
 	"""
 	docstring = component.__doc__
-	parsed_yaml_docstring_dict: typing.Optional[dict] = {}
+	parsed_yaml_docstring_dict = {}
 
 	if docstring is not None:
 		docstring = inspect.cleandoc(docstring)

--- a/asab/api/doc_templates.py
+++ b/asab/api/doc_templates.py
@@ -94,7 +94,7 @@ SWAGGER_DOC_PAGE = """<!DOCTYPE html>
 		<script
 			id="api-reference"
 			data-url="{openapi_url}"></script>
-		<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+		<script src="https://unpkg.com/@scalar/api-reference"></script>
 	</body>
 </html>
 """

--- a/asab/api/doc_templates.py
+++ b/asab/api/doc_templates.py
@@ -94,7 +94,7 @@ SWAGGER_DOC_PAGE = """<!DOCTYPE html>
 		<script
 			id="api-reference"
 			data-url="{openapi_url}"></script>
-		<script src="https://www.unpkg.com/@scalar/api-reference"></script>
+		<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
 	</body>
 </html>
 """


### PR DESCRIPTION
- Route tag is now extracted from the YAML part of class dosctring. If not available, the tags are generated from class name or module name as before.
- ~~Updated CDN URL of scalar/api-reference since it has been updated on their github (https://github.com/scalar/scalar?tab=readme-ov-file#from-a-cdn) and the old one (on dpkg.com) stopped working.~~ The old URL still works, it just had a temporary outage.