### PR TITLE
Improve Housekeeping logging

### DIFF
--- a/asab/application.py
+++ b/asab/application.py
@@ -776,7 +776,7 @@ class Application(metaclass=Singleton):
 				L.log(asab.LOG_NOTICE, "is performing housekeeping.")
 				self.PubSub.publish("Application.housekeeping!")
 			else:
-				L.warning(
+				L.error(
 					"Housekeeping has not been executed: It is past the time limit.",
 					struct_data={
 						"housekeeping_time": self.HousekeepingTime.strftime("%Y-%m-%d %H:%M:%S"),
@@ -791,7 +791,7 @@ class Application(metaclass=Singleton):
 			self.HousekeepingId = _housekeeping_id(self.HousekeepingTime)
 
 			if len(self.HousekeepingMissedEvents) > 0:
-				L.warning(
+				L.error(
 					"One or more Housekeeping events have not been executed.",
 					struct_data={
 						"missed_housekeeping_events": self.HousekeepingMissedEvents

--- a/asab/application.py
+++ b/asab/application.py
@@ -773,6 +773,7 @@ class Application(metaclass=Singleton):
 
 		if self.HousekeepingTime < now:
 			if now < self.HousekeepingTimeLimit and self.HousekeepingId <= today_id:
+				L.log(asab.LOG_NOTICE, "is performing housekeeping.")
 				self.PubSub.publish("Application.housekeeping!")
 			else:
 				L.warning(
@@ -788,15 +789,6 @@ class Application(metaclass=Singleton):
 			self.HousekeepingTime += datetime.timedelta(days=1)
 			self.HousekeepingTimeLimit += datetime.timedelta(days=1)
 			self.HousekeepingId = _housekeeping_id(self.HousekeepingTime)
-			L.log(
-				LOG_NOTICE,
-				"Setting time for the next housekeeping.",
-				struct_data={
-					"next_housekeeping_time": self.HousekeepingTime.strftime("%Y-%m-%d %H:%M:%S"),
-					"next_time_limit": self.HousekeepingTimeLimit.strftime("%Y-%m-%d %H:%M:%S"),
-					"next_housekeeping_id": self.HousekeepingId,
-				}
-			)
 
 			if len(self.HousekeepingMissedEvents) > 0:
 				L.warning(

--- a/asab/application.py
+++ b/asab/application.py
@@ -773,7 +773,7 @@ class Application(metaclass=Singleton):
 
 		if self.HousekeepingTime < now:
 			if now < self.HousekeepingTimeLimit and self.HousekeepingId <= today_id:
-				L.log(asab.LOG_NOTICE, "is performing housekeeping.")
+				L.log(asab.LOG_NOTICE, "Housekeeping started.")
 				self.PubSub.publish("Application.housekeeping!")
 			else:
 				L.error(


### PR DESCRIPTION
The message
```
05-May-2024 03:08:21.418922 NOTICE asab.application [sd next_housekeeping_time="2024-05-06 03:00:00" next_time_limit="2024-05-06 05:00:00" next_housekeeping_id="20240506"] Setting time for the next housekeeping.
```
looks a little quirky and was there mainly for debugging. I want to rather see
```
05-May-2024 03:08:21.418922 NOTICE asab.application is performing housekeeping.
```
Also, when Housekeeping is missed for some reason, we can show ERROR that will be visible in Sentry.io etc.
```
05-May-2024 03:08:21.418922 ERROR One or more Housekeeping events have not been executed.
```