### PR TITLE
Removes OBSOLETE warning: multiple MongoDB providers

### DIFF
--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -30,11 +30,7 @@ class StorageService(StorageServiceABC):
 
 		# Check the old section and then the new section for uri
 		uri = asab.Config.get(config_section_name, 'mongodb_uri', fallback='')
-		if len(uri) > 0:
-			asab.LogObsolete.warning(
-				"Do not configure mongodb connection in {}. Please use [mongo] section with uri and database parameters.".format(config_section_name)
-			)
-		else:
+		if len(uri) == 0:
 			uri = asab.Config.get("mongo", 'uri', fallback='')
 
 		if len(uri) == 0:


### PR DESCRIPTION
Related to: https://github.com/TeskaLabs/asab/issues/573

The new MongoDB Storage configuration (https://github.com/TeskaLabs/asab/pull/553) will raise OBSOLETE warning for any provider that is not configured in the new section. 

```
[mongo]
uri=<.....>
database=<....>
```

However there are installations with multiple MongoDB providers that require separate sections in configuration file.