### PR TITLE
Custom exceptions for LibraryService

### DIFF
--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -48,3 +48,21 @@ class Conflict(Exception):
 			super().__init__(*args)
 		else:
 			super().__init__(message, *args)
+
+
+class LibraryError(Exception):
+	"""
+	Base exception for `asab.LibraryService`.
+	"""
+	def __init__(self, *args) -> None:
+		super().__init__(*args)
+
+
+class LibraryInvalidPathError(LibraryError):
+	"""
+	Path in `asab.LibraryService` is invalid.
+	"""
+	def __init__(self, message="", path="", *args):
+		self.Path = path
+		message = "Invalid Library path '{}': {}".format(path, message)
+		super().__init__(message, *args)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -530,6 +530,18 @@ def _validate_path_item(path: str) -> None:
 			path=path,
 		)
 
+	if ".." in path:
+		raise LibraryInvalidPathError(
+			message="Item path cannot contain '..'",
+			path=path,
+		)
+
+	if "~" in path:
+		raise LibraryInvalidPathError(
+			message="Item path cannot contain '~'",
+			path=path,
+		)
+
 
 def _validate_path_directory(path: str) -> None:
 	# Directory path must start with '/'
@@ -550,5 +562,17 @@ def _validate_path_directory(path: str) -> None:
 	if "//" in path:
 		raise LibraryInvalidPathError(
 			message="Directory path cannot contain '//' (e.g. '/Templates/Email/')",
+			path=path,
+		)
+
+	if ".." in path:
+		raise LibraryInvalidPathError(
+			message="Directory path cannot contain '..'",
+			path=path,
+		)
+
+	if "~" in path:
+		raise LibraryInvalidPathError(
+			message="Directory path cannot contain '~'",
 			path=path,
 		)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -19,11 +19,12 @@ from ..log import LOG_NOTICE
 from .item import LibraryItem
 from ..application import Application
 from .providers.abc import LibraryProviderABC
+from ..exceptions import LibraryInvalidPathError
 
 #
 
 L = logging.getLogger(__name__)
-
+LogObsolete = logging.getLogger("OBSOLETE")
 
 #
 
@@ -184,10 +185,7 @@ class LibraryService(Service):
 			typing.Optional[typing.List[str]]: A list containing the paths to the found files,
 											`or an `empty list` if no files are found that match the filename.
 		"""
-		# File path must start with '/'
-		assert path[:1] == '/', "Item path '{}' must start with a forward slash (/). For example: /library/Templates/.setup.yaml".format(path)
-		# File path must end with the filename
-		assert len(os.path.splitext(path)[1]) > 0, "Item path '{}' must end with an extension. For example: /library/Templates/item.json".format(path)
+		_validate_path_item(path)
 
 		results = []
 		for library in self.Libraries:
@@ -219,10 +217,9 @@ class LibraryService(Service):
 				return itemio.read()
 		```
 		"""
-		# item path must start with '/'
-		assert path[:1] == '/', "Item path must start with a forward slash (/). For example: /library/Templates/item.json"
-		# Item path must end with the extension
-		assert len(os.path.splitext(path)[1]) > 0, "Item path must end with an extension. For example: /library/Templates/item.json"
+
+		LogObsolete.warning("Method 'LibraryService.read()' is obsolete. Use 'LibraryService.open()' method instead.")
+		_validate_path_item(path)
 
 		if self.check_disabled(path, tenant=tenant):
 			return None
@@ -253,6 +250,7 @@ class LibraryService(Service):
 		```
 		"""
 
+		_validate_path_item(path)
 		itemio = await self.read(path, tenant)
 		if itemio is None:
 			yield itemio
@@ -276,12 +274,7 @@ class LibraryService(Service):
 			List of items that are enabled for the tenant.
 		"""
 
-		# Directory path must start with '/'
-		assert path[:1] == '/', "Directory path must start with a forward slash (/). For example: /library/Templates/"
-		# Directory path must end with '/'
-		assert path[-1:] == '/', "Directory path must end with a forward slash (/). For example: /library/Templates/"
-		# Directory path cannot contain '//'
-		assert '//' not in path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
+		_validate_path_directory(path)
 
 		# List requested level using all available providers
 		items = await self._list(path, tenant, providers=self.Libraries)
@@ -399,7 +392,7 @@ class LibraryService(Service):
 			`True` if the item is disabled for the tenant.
 		"""
 		if not isinstance(path, str) or not path:
-			raise ValueError("The 'path' must be a non-empty string.")
+			raise LibraryInvalidPathError("Argument 'path' must be a non-empty string.")
 
 		# First check disabled by path
 		for dp, disabled in self.DisabledPaths:
@@ -442,12 +435,7 @@ class LibraryService(Service):
 			A file object containing a gzipped tar archive.
 		"""
 
-		# Directory path must start with '/'
-		assert path[:1] == '/', "Directory path must start with a forward slash (/). For example: /library/Templates/"
-		# Directory path must end with '/'
-		assert path[-1:] == '/', "Directory path must end with a forward slash (/). For example: /library/Templates/"
-		# Directory path cannot contain '//'
-		assert '//' not in path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
+		_validate_path_directory(path)
 
 		fileobj = tempfile.TemporaryFile()
 		tarobj = tarfile.open(name=None, mode='w:gz', fileobj=fileobj)
@@ -514,7 +502,50 @@ class LibraryService(Service):
 		if isinstance(paths, str):
 			paths = [paths]
 		for path in paths:
-			assert path[:1] == '/', "Absolute path must be used when subscribing to the library changes"
+			if not path.startswith("/"):
+				raise LibraryInvalidPathError(
+					message="Directory path must start with '/' when subscribing to Library changes.",
+					path=path,
+				)
 
 			for provider in self.Libraries:
 				await provider.subscribe(path)
+
+
+def _validate_path_item(path: str) -> None:
+	# File path must start with '/'
+	if not path.startswith("/"):
+		raise LibraryInvalidPathError(
+			message="Item path must start with '/' (e.g. '/Templates/item.json')",
+			path=path,
+		)
+
+	# File path must end with extension (e.g. '.json')
+	if not len(os.path.splitext(path)[1]) > 0:
+		raise LibraryInvalidPathError(
+			message="Item path must end with an extension (e.g. '/Templates/item.json')",
+			path=path,
+		)
+
+
+def _validate_path_directory(path: str) -> None:
+	# Directory path must start with '/'
+	if not path.startswith("/"):
+		raise LibraryInvalidPathError(
+			message="Directory path must start with '/' (e.g. '/Templates/Email/')",
+			path=path,
+		)
+
+	# Directory path must end with '/'
+	if not path.endswith("/"):
+		raise LibraryInvalidPathError(
+			message="Directory path must end with '/' (e.g. '/Templates/Email/')",
+			path=path,
+		)
+
+	# Directory path cannot contain '//'
+	if "//" in path:
+		raise LibraryInvalidPathError(
+			message="Directory path cannot contain '//' (e.g. '/Templates/Email/')",
+			path=path,
+		)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -392,7 +392,10 @@ class LibraryService(Service):
 			`True` if the item is disabled for the tenant.
 		"""
 		if not isinstance(path, str) or not path:
-			raise LibraryInvalidPathError("Argument 'path' must be a non-empty string.")
+			raise LibraryInvalidPathError(
+				message="Argument 'path' must be a non-empty string.",
+				path=path,
+			)
 
 		# First check disabled by path
 		for dp, disabled in self.DisabledPaths:


### PR DESCRIPTION
## Custom exception when Library path is invalid

Right now, when you use incorrect path in `asab.LibraryService`, `AssertionError` is raised without an information about what path caused the trouble.

I suggest to create a custom Exception where you can access the "problematic" path and handle that in your microservice.

```python
try:
  async with self.LibraryService.open(path) as f:
    do_stuff()
except asab.exceptions.LibraryInvalidPathError as err:
  L.error("Cannot read from path {}: invalid path!").format(err.Path)
```

Example of the exception message:
```
asab.exceptions.LibraryInvalidPathError: Invalid Library path '/lmio/library.lib': Directory path must end with '/' (e.g. '/Templates/Email/')
```

## Warn the user when using `read()` method

I also added `LogObsolete` warning when using `read()` method instead of `open()`...

## Disable "~" and ".." in path

Error is raised also when directory/item path contains "~" or "..".