### PR TITLE
Separate read() and open() methods

### DIFF
--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -251,7 +251,16 @@ class LibraryService(Service):
 		"""
 
 		_validate_path_item(path)
-		itemio = await self.read(path, tenant)
+
+		# Same functionality as in read() method
+		itemio = None
+		disabled = self.check_disabled(path, tenant=tenant)
+		if not disabled:
+			for library in self.Libraries:
+				itemio = await library.read(path)
+				if itemio is None:
+					continue
+
 		if itemio is None:
 			yield itemio
 		else:

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -258,8 +258,8 @@ class LibraryService(Service):
 		if not disabled:
 			for library in self.Libraries:
 				itemio = await library.read(path)
-				if itemio is None:
-					continue
+				if itemio is not None:
+					break
 
 		if itemio is None:
 			yield itemio


### PR DESCRIPTION
`open()` method internally used function `read()` and therefore obsolete warning was displayed every time. This separates these two methods completely.