### PR TITLE
Internal authorization via discovery service

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -89,7 +89,7 @@ class DiscoveryService(Service):
 			claims = json.loads(self.InternalAuthToken.claims)
 			if claims.get("exp") > (
 				datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=300)
-			):
+			).timestamp():
 				# Token is valid and does not expire soon
 				return
 

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -23,7 +23,7 @@ class DiscoveryService(Service):
 		super().__init__(app, service_name)
 		self.ZooKeeperContainer = zkc
 		self.ProactorService = zkc.ProactorService
-		self.InternalAuthKeyPath = "/vault/internal_auth.pem"
+		self.InternalAuthKeyPath = "/asab/auth/internal_auth_private_key"
 		self.InternalAuthKey: typing.Optional[jwcrypto.jwk.JWK] = None
 		self.InternalAuthToken: typing.Optional[jwcrypto.jwt.JWT] = None
 		self.InternalAuthTokenExpiration: datetime.timedelta = datetime.timedelta(seconds=5 * 300)

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -422,4 +422,3 @@ class DiscoveryResolver(aiohttp.DefaultResolver):
 
 class NotDiscoveredError(RuntimeError):
 	pass
-

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -103,7 +103,7 @@ class DiscoveryService(Service):
 		if self.InternalAuthToken:
 			claims = json.loads(self.InternalAuthToken.claims)
 			if claims.get("exp") > (
-				datetime.datetime.now(datetime.timezone.UTC) - datetime.timedelta(seconds=300)
+				datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=300)
 			).timestamp():
 				# Token is valid and does not expire soon
 				return
@@ -114,9 +114,9 @@ class DiscoveryService(Service):
 			# Issuer (URL of the app that created the token)
 			"iss": my_discovery_url,
 			# Issued at
-			"iat": int(datetime.datetime.now(datetime.timezone.UTC).timestamp()),
+			"iat": int(datetime.datetime.now(datetime.timezone.utc).timestamp()),
 			# Expires at
-			"exp": int((datetime.datetime.now(datetime.timezone.UTC) + self.InternalAuthTokenExpiration).timestamp()),
+			"exp": int((datetime.datetime.now(datetime.timezone.utc) + self.InternalAuthTokenExpiration).timestamp()),
 			# Authorized party
 			"azp": my_discovery_url,
 			# Audience (who is allowed to use this token)

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -23,7 +23,7 @@ class DiscoveryService(Service):
 		super().__init__(app, service_name)
 		self.ZooKeeperContainer = zkc
 		self.ProactorService = zkc.ProactorService
-		self.InternalAuthKeyPath = "/asab/auth/internal_auth_private_key"
+		self.InternalAuthKeyPath = "/asab/auth/internal_auth_private.key"
 		self.InternalAuthKey: typing.Optional[jwcrypto.jwk.JWK] = None
 		self.InternalAuthToken: typing.Optional[jwcrypto.jwt.JWT] = None
 		self.InternalAuthTokenExpiration: datetime.timedelta = datetime.timedelta(seconds=5 * 300)

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -5,6 +5,7 @@ import socket
 import typing
 import asyncio
 import logging
+import os
 
 import aiohttp
 import kazoo.exceptions

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -103,7 +103,7 @@ class DiscoveryService(Service):
 		if self.InternalAuthToken:
 			claims = json.loads(self.InternalAuthToken.claims)
 			if claims.get("exp") > (
-				datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=300)
+				datetime.datetime.now(datetime.timezone.UTC) - datetime.timedelta(seconds=300)
 			).timestamp():
 				# Token is valid and does not expire soon
 				return
@@ -114,9 +114,9 @@ class DiscoveryService(Service):
 			# Issuer (URL of the app that created the token)
 			"iss": my_discovery_url,
 			# Issued at
-			"iat": int(datetime.datetime.now(datetime.UTC).timestamp()),
+			"iat": int(datetime.datetime.now(datetime.timezone.UTC).timestamp()),
 			# Expires at
-			"exp": int((datetime.datetime.now(datetime.UTC) + self.InternalAuthTokenExpiration).timestamp()),
+			"exp": int((datetime.datetime.now(datetime.timezone.UTC) + self.InternalAuthTokenExpiration).timestamp()),
 			# Authorized party
 			"azp": my_discovery_url,
 			# Audience (who is allowed to use this token)

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -339,7 +339,7 @@ class DiscoveryService(Service):
 		elif auth == "internal":
 			if headers is None:
 				headers = {}
-			headers["Authorization"] = self.InternalAuthToken
+			headers["Authorization"] = "Bearer {}".format(self.InternalAuthToken.serialize())
 		else:
 			raise ValueError("Invalid 'auth' value. Only instances of aiohttp.ClientRequest or 'internal' are allowed.")
 		return aiohttp.ClientSession(

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -274,8 +274,8 @@ class AuthService(asab.Service):
 		Check if public keys have been fetched from the authorization server and fetch them if not yet.
 		"""
 		# Add internal shared auth key
-		if self.DiscoveryService is not None:
-			self.TrustedPublicKeys.add(self.DiscoveryService.InternalAuthorizationKey.get_public_key())
+		if self.DiscoveryService is not None and self.DiscoveryService.InternalAuthKey is not None:
+			self.TrustedPublicKeys.add(self.DiscoveryService.InternalAuthKey.get_public_key())
 			L.debug("Internal auth key loaded.")
 
 		now = datetime.datetime.now(datetime.timezone.utc)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -521,6 +521,10 @@ def _get_id_token_claims(bearer_token: str, auth_server_public_key):
 		L.error(
 			"Failed to parse JWT ID token ({}). Please check if the Authorization header contains ID token.".format(e))
 		raise aiohttp.web.HTTPBadRequest()
+	except jwcrypto.jws.InvalidJWSObject as e:
+		L.error(
+			"Failed to parse JWT ID token ({}). Please check if the Authorization header contains ID token.".format(e))
+		raise aiohttp.web.HTTPBadRequest()
 	except Exception:
 		L.exception("Failed to parse JWT ID token. Please check if the Authorization header contains ID token.")
 		raise aiohttp.web.HTTPBadRequest()

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -285,6 +285,9 @@ class AuthService(asab.Service):
 				# Only internal authorization is supported
 				return
 
+		# Either DiscoveryService or PublicKeysUrl must be defined
+		assert self.PublicKeysUrl
+
 		now = datetime.datetime.now(datetime.timezone.utc)
 		if self.AuthServerLastSuccessfulCheck is not None \
 			and now < self.AuthServerLastSuccessfulCheck + self.AuthServerCheckCooldown:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -274,7 +274,8 @@ class AuthService(asab.Service):
 		Check if public keys have been fetched from the authorization server and fetch them if not yet.
 		"""
 		# Add internal shared auth key
-		self.TrustedPublicKeys.add(self.DiscoveryService.InternalAuthorizationKey.get_public_key())
+		if self.DiscoveryService is not None:
+			self.TrustedPublicKeys.add(self.DiscoveryService.InternalAuthorizationKey.get_public_key())
 
 		now = datetime.datetime.now(datetime.timezone.utc)
 		if self.AuthServerLastSuccessfulCheck is not None \

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -274,9 +274,12 @@ class AuthService(asab.Service):
 		Check if public keys have been fetched from the authorization server and fetch them if not yet.
 		"""
 		# Add internal shared auth key
-		if self.DiscoveryService is not None and self.DiscoveryService.InternalAuthKey is not None:
-			self.TrustedPublicKeys.add(self.DiscoveryService.InternalAuthKey.get_public_key())
-			L.debug("Internal auth key loaded.")
+		if self.DiscoveryService is not None:
+			if self.DiscoveryService.InternalAuthKey is not None:
+				self.TrustedPublicKeys.add(self.DiscoveryService.InternalAuthKey.public())
+			else:
+				L.debug("Internal auth key is not ready yet.")
+				self.App.TaskService.schedule(self._fetch_public_keys_if_needed())
 
 		now = datetime.datetime.now(datetime.timezone.utc)
 		if self.AuthServerLastSuccessfulCheck is not None \

--- a/examples/internal-auth.py
+++ b/examples/internal-auth.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+"""
+You need to run two instances of this mini app, each on a different port.
+
+INSTANCE_ID=app-1 PORT=8081 TARGET=http://app-2.instance_id.asab python examples/internal-auth.py && INSTANCE_ID=app-2 PORT=8082 TARGET=http://app-1.instance_id.asab python examples/internal-auth.py
+"""
+
+import asab.web.rest
+import asab.web.auth
+import asab.zookeeper
+import typing
+import os
+
+if "web" not in asab.Config:
+	asab.Config["web"] = {
+		"listen": os.environ.get("PORT"),
+	}
+
+if "zookeeper" not in asab.Config:
+	asab.Config["zookeeper"] = {
+		"servers": "localhost:2181",
+	}
+
+if "auth" not in asab.Config:
+	asab.Config["auth"] = {}
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__()
+
+		self.add_module(asab.zookeeper.Module)
+
+		# Initialize web container
+		self.add_module(asab.web.Module)
+		self.WebService = self.get_service("asab.WebService")
+		self.WebContainer = asab.web.WebContainer(self.WebService, "web")
+
+		self.WebContainer.WebApp.middlewares.append(asab.web.rest.JsonExceptionMiddleware)
+
+		from asab.api import ApiService
+		self.ApiService = ApiService(self)
+		self.ApiService.initialize_web(self.WebContainer)
+
+		self.ZooKeeperService = self.get_service("asab.ZooKeeperService")
+		self.ZooKeeperContainer = asab.zookeeper.ZooKeeperContainer(self.ZooKeeperService, "zookeeper")
+		self.ApiService.initialize_zookeeper(self.ZooKeeperContainer)
+
+		self.DiscoveryService = self.get_service("asab.DiscoveryService")
+
+		# Initialize authorization
+		self.AuthService = asab.web.auth.AuthService(self)
+		self.AuthService.install(self.WebContainer)
+
+		# Add routes
+		self.WebContainer.WebApp.router.add_put("/send", self.send)
+		self.WebContainer.WebApp.router.add_put("/receive", self.receive)
+
+		self.Name = os.environ.get("INSTANCE_ID")
+		self.Target = os.environ.get("TARGET")
+
+	@asab.web.auth.noauth
+	async def send(self, request):
+		log = ["{} received request.".format(self.Name)]
+		async with self.DiscoveryService.session(auth="internal") as session:
+			async with session.put(
+				"{}/receive".format(self.Target.rstrip("/")),
+				json=log
+			) as resp:
+				log = await resp.json()
+				if resp.status != 200:
+					log.append("{} received error response.".format(self.Name))
+					return asab.web.rest.json_response(request, log)
+				log.append("{} received response.".format(self.Name))
+				return asab.web.rest.json_response(request, log)
+
+	@asab.web.rest.json_schema_handler({"type": "array"})
+	async def receive(self, request, *, json_data):
+		json_data.append("{} received request.".format(self.Name))
+		return asab.web.rest.json_response(request, json_data)
+
+
+if __name__ == "__main__":
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION
- There is one private key saved in zookeeper, shared by all cluster ASAB services.
- All services use it to generate JWTokens for the authorization of internal requests.
- AuthService adds the internal private key into its known keys.

# Usage

To use the shiny new internal auth via discovery service, open a discovery session with argument `auth="internal"`:
```python
async with self.DiscoveryService.session(auth="internal") as session:
	async with session.get("http://asab-myservice-1.instance_id.asab") as response:
		...
```

To use the authorization from the incoming request (usually from the UI), open a discovery session with argument `auth=request`:
```python
async def some_handler(request):
	async with self.DiscoveryService.session(auth=request) as session:
		async with session.get("http://asab-myservice-1.instance_id.asab") as response:
			...
```

# TODO

- [x] AuthService must be able to run in "internal-only" mode without errors.
- [ ] Reload private key from zookeeper when it changes (`jwcrypto.jwt.JWTMissingKey` error)