### PR TITLE
Library - different approach for listing items from providers

### DIFF
--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -20,8 +20,10 @@ class LibraryProviderABC(object):
 		"""
 		Reads a library item on the given path.
 
-		:param path: The path to the item to read
-		:return: I/O stream (read) with the content of the library item.
+		Args:
+			path: The path to the item to read.
+		Returns:
+			I/O stream (read) with the content of the library item.
 		"""
 		raise NotImplementedError("{}.read()".format(self.__class__.__name__))
 
@@ -30,8 +32,12 @@ class LibraryProviderABC(object):
 		"""
 		It lists all items in the library at the given path.
 
-		:param path: The path to the directory in the library to list
-		:return: A list (or iterable) of `LibraryItem`s.
+		Args:
+			path: The path to the directory in the library to list
+		Returns:
+			A list (or iterable) of `LibraryItem`s.
+		Raises:
+			`KeyError` when the path to item is not found by the library provider.
 		"""
 		raise NotImplementedError("{}.list()".format(self.__class__.__name__))
 
@@ -42,14 +48,19 @@ class LibraryProviderABC(object):
 
 	async def subscribe(self, path: str):
 		"""
-		It takes a path and subscribes to changes in this directory.
-		When change occurs, it creates a PubSub signal.
-		Use absolute path, startng with "/".
-		Keep in mind every provider requires specific implementation. These might vary in lag between change if the librarby and its propagation.
+		Take a path and subscribe to changes in this directory.
+		When change occurs, publish PubSub signal "Library.change!"
+
+		Note:
+		Keep in mind every provider requires specific implementation.
+		These might vary in lag between change if the library and its propagation.
 
 		Mind following when implementing this method:
-		- user can subscribe only on existing directory. -> Check whether subscribed path is a directory, specifically in the provider
+		- user can subscribe only on existing directory. -> Check whether subscribed path is a directory,
+			specifically in the provider
 		- subscribing to nonexisting directory or file should lead to silent error
 
+		Args:
+			path: Absolute path to subscribe (starting with "/")
 		"""
 		raise NotImplementedError("{}.subscribe()".format(self.__class__.__name__))

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -137,9 +137,9 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 		for p in pathparts:
 			curmodel = curmodel.sub.get(p)
 			if curmodel is None:
-				raise KeyError("Not '{}' found".format(path))
+				raise KeyError("Path '{}' not found by AzureStorageLibraryProvider.".format(path))
 			if curmodel.type != 'dir':
-				raise KeyError("Not '{}' found".format(path))
+				raise KeyError("Path '{}' not found by AzureStorageLibraryProvider.".format(path))
 
 		items = []
 		for i in curmodel.sub.values():

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -219,8 +219,6 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		except KeyError:
 			# subscribing to non-existing directory is silent
 			return
-		except ValueError:
-			return
 
 		for item in items:
 			if item.type == "dir":

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -86,17 +86,9 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 	def _list(self, path: str):
 
 		node_path = self.BasePath + path
-
-		# Directory path must start with '/'
-		assert node_path[:1] == '/', "Directory path must start with a forward slash (/). For example: /library/Templates/"
-		# Directory path must end with '/'
-		assert node_path[-1:] == '/', "Directory path must end with a forward slash (/). For example: /library/Templates/"
-		# Directory cannot contain '//'
-		assert '//' not in node_path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
-
 		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
 		if not exists:
-			raise KeyError(" '{}' not found".format(path))
+			raise KeyError("Path '{}' not found by FileSystemLibraryProvider.".format(path))
 
 		items = []
 		for fname in glob.iglob(os.path.join(node_path, "*")):
@@ -226,6 +218,8 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			items = self._list(path_to_be_listed)
 		except KeyError:
 			# subscribing to non-existing directory is silent
+			return
+		except ValueError:
 			return
 
 		for item in items:

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -258,7 +258,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		nodes = await self.Zookeeper.get_children(node_path)
 		if nodes is None:
-			raise KeyError("Not '{}' found".format(node_path))
+			raise KeyError("Path '{}' not found by ZookeeperLibraryProvider.".format(node_path))
 
 		items = []
 		for node in nodes:

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -307,31 +307,27 @@ class LibraryService(Service):
 		return items
 
 	async def _list(self, path, tenant, providers):
-		# Execute the list query in all providers in-parallel
-		result = await asyncio.gather(*[
-			library.list(path)
-			for library in providers
-		], return_exceptions=True)
+		items: list[LibraryItem] = []
+		unique_items: dict[str, LibraryItem] = dict()
 
-		items = []
-		uniq = dict()
-		for ress in result:
-
-			if isinstance(ress, KeyError):
+		# List items from every provider concurrently
+		tasks = [asyncio.create_task(provider.list(path)) for provider in providers]
+		for layer, task in enumerate(asyncio.as_completed(tasks)):
+			try:
+				items_list_from_provider: list[LibraryItem] = await task
+			except KeyError:
 				# The path doesn't exists in the provider
 				continue
-
-			if isinstance(ress, Exception):
-				L.exception("Error when listing items from provider", exc_info=ress)
+			except Exception:
+				L.exception("Unexpected error when listing path '{}' by {}".format(path, providers[layer]))
 				continue
 
-			for item in ress:
+			for item in items_list_from_provider:
 				item.disabled = self.check_disabled(item.name, tenant=tenant)
 
 				# If the item already exists, merge or override it
-				pitem = uniq.get(item.name)
+				pitem = unique_items.get(item.name)
 				if pitem is not None:
-					pitem = uniq[item.name]
 					if pitem.type == 'dir' and item.type == 'dir':
 						# Directories are joined
 						pitem.providers.extend(item.providers)
@@ -341,10 +337,12 @@ class LibraryService(Service):
 								index = i
 								break
 						pitem.override = index
-				# Other item types are skipped
 				else:
-					uniq[item.name] = item
+					# Other item types are skipped
+					unique_items[item.name] = item
 					items.append(item)
+
+		# Sort items by name
 		items.sort(key=lambda x: x.name)
 		return items
 


### PR DESCRIPTION
## Issue description

It seems like Sentry.io cannot handle properly some Exceptions driven by `asyncio.gather()` method, see this:

https://teskalabs.sentry.io/issues/5066136431/?query=start%3D2024-06-19T10%3A58%3A30%26end%3D2024-06-26T10%3A58%3A30%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream

- Some provider raises `KeyError` in `list()` method.
- This exception is handled in `LibraryService._list()` method so it is not propagated further in the application, you do not even receive error in logging,
- However, the error is apparently propagated to Sentry.io without full stack trace.

## Solution

- `asyncio.as_completed()` method is used instead for concurrent listing from all providers
- `KeyError` error messages are more specific
- Some docstrings were modified 
 