### PR TITLE
Use proper padding method when encrypting in asab.storage

### DIFF
--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -214,12 +214,7 @@ class StorageServiceABC(asab.Service):
 		# Strip padding
 		unpadder = cryptography.hazmat.primitives.padding.PKCS7(block_size).unpadder()
 		raw = unpadder.update(padded)
-		try:
-			raw += unpadder.finalize()
-		except ValueError:
-			# Back-compat
-			L.warning("Incorrectly padded value.", struct_data={"value": padded[:8] + b"..."})
-			raw = padded.rstrip(b"\x00")
+		raw += unpadder.finalize()
 
 		return raw
 

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -159,6 +159,9 @@ class StorageServiceABC(asab.Service):
 			else:
 				raise TypeError("Only 'bytes' objects can be encrypted")
 
+		# Append terminating character to separate padding from actual value
+		raw = raw + b"\xff"
+
 		# Pad the text to fit the blocks
 		pad_length = -len(raw) % block_size
 		if pad_length != 0:
@@ -212,6 +215,10 @@ class StorageServiceABC(asab.Service):
 
 		# Strip padding
 		raw = raw.rstrip(b"\x00")
+
+		# Remove terminating character
+		raw = raw[:-1]
+
 		return raw
 
 


### PR DESCRIPTION
# Issue
In `asab.storage` raw values are padded with `\x00` to fit the block size. When the raw value ends with `\x00`, it is mistakenly stripped away with `bytes.rstrip(b"\x00")` at decryption time, together with the padding.

# Solution
- Use proper padding method from `cryptography.hazmat.primitives.padding`.
- Provide backward compatibility for existing encrypted entries.