### PR TITLE
ASAB library libsreg provider is more prone to failures

### DIFF
--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -84,7 +84,12 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 		self.SubscribedPaths = set()
 
 		self.App.TaskService.schedule(self._periodic_pull(None))
-		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
+
+		if version.startswith('v'):
+			# Fixed versions (ie v24.04) are much less likely to change, therefore we can check only every 12 hours
+			self.App.PubSub.subscribe("Application.tick/43200!", self._periodic_pull)
+		else:
+			self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
 
 
 	async def _periodic_pull(self, event_name):

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -184,7 +184,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 								# The repository has not changed ...
 								if not self.IsReady:
 									await self._set_ready()
-								
+
 								return  # We are done, leaving the loop
 
 							else:

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -165,6 +165,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 										tar.extractall(temp_extract_dir)
 								except lzma.LZMAError:
 									L.exception("LZMAError", struct_data={'size': dwnld_size})
+									continue
 
 								# Synchronize the temp_extract_dir into the library
 								synchronize_dirs(self.RepoPath, temp_extract_dir)

--- a/examples/library-git-provider.py
+++ b/examples/library-git-provider.py
@@ -49,13 +49,12 @@ class MyApplication(asab.Application):
 		for item in items:
 			print("*", item.name)
 			if item.type == 'item':
-				itemio = await self.LibraryService.read(item.name)
-				if itemio is not None:
-					with itemio:
+				async with self.LibraryService.open(item.name) as itemio:
+					if itemio is not None:
 						content = itemio.read()
 						print("  - content: {} bytes".format(len(content)))
-				else:
-					print("  - N/A")  # Item is likely disabled
+					else:
+						print("  - N/A")  # Item is likely disabled
 		print("\n", "=" * 10, sep="")
 		self.stop()
 


### PR DESCRIPTION
This MR addresses frequent "Failed to download the library (ClientError)." errors.

Also decreases the frequency of change checks for `v*` versions to once per 12 hours.