### PR TITLE
Repair items encrypted with broken padding method

### DIFF
--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -55,7 +55,7 @@ class StorageService(StorageServiceABC):
 		return MongoDBUpsertor(self, collection, obj_id, version)
 
 
-	async def get(self, collection: str, obj_id, decrypt=None) -> dict:
+	async def get(self, collection: str, obj_id, decrypt=None, use_obsolete_padding=False) -> dict:
 		coll = self.Database[collection]
 		ret = await coll.find_one({'_id': obj_id})
 		if ret is None:
@@ -63,7 +63,7 @@ class StorageService(StorageServiceABC):
 		if decrypt is not None:
 			for field in decrypt:
 				if field in ret:
-					ret[field] = self.aes_decrypt(ret[field])
+					ret[field] = self.aes_decrypt(ret[field], use_obsolete_padding)
 		return ret
 
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -73,8 +73,8 @@ class StorageService(StorageServiceABC):
 
 			# Update fields encrypted with flawed padding in previous versions (before #587)
 			if re_encrypt_fields:
-				upsertor = self.upsertor(collection, ret["_id"], ret["v"])
-				for k, v in re_encrypt_fields:
+				upsertor = self.upsertor(collection, ret["_id"], ret["_v"])
+				for k, v in re_encrypt_fields.items():
 					upsertor.set(k, v, encrypt=True)
 				await upsertor.execute()
 
@@ -95,8 +95,8 @@ class StorageService(StorageServiceABC):
 
 			# Update fields encrypted with flawed padding in previous versions (before #587)
 			if re_encrypt_fields:
-				upsertor = self.upsertor(collection, ret["_id"], ret["v"])
-				for k, v in re_encrypt_fields:
+				upsertor = self.upsertor(collection, ret["_id"], ret["_v"])
+				for k, v in re_encrypt_fields.items():
 					upsertor.set(k, v, encrypt=True)
 				await upsertor.execute()
 

--- a/asab/storage/service.py
+++ b/asab/storage/service.py
@@ -176,12 +176,13 @@ class StorageServiceABC(asab.Service):
 		return encrypted
 
 
-	def aes_decrypt(self, encrypted: bytes, use_obsolete_padding: bool = False) -> bytes:
+	def aes_decrypt(self, encrypted: bytes, _obsolete_padding: bool = False) -> bytes:
 		"""
 		Decrypt encrypted data using AES-CBC.
 
 		Args:
 			encrypted: The encrypted data to decrypt. It must start with b"$aes-cbc$" prefix, followed by one-block-long initialization vector.
+			_obsolete_padding: Back-compat option: Use incorrect old padding method
 
 		Returns:
 			The decrypted data.
@@ -212,7 +213,7 @@ class StorageServiceABC(asab.Service):
 		padded = decryptor.update(encrypted) + decryptor.finalize()
 
 		# Strip padding
-		if use_obsolete_padding:
+		if _obsolete_padding:
 			# Back-compat: Incorrect old padding method
 			raw = padded.rstrip(b"\x00")
 		else:


### PR DESCRIPTION
# Issues
#587 actually introduced a breaking change where items encrypted the old way cannot be decrypted anymore.

# Solution
When proper decryption fails, try to decrypt the item the old flawed way and then update the database item with the new encryption.