### PR TITLE
Discovery Service: rescan threadsafe

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -36,7 +36,8 @@ class DiscoveryService(Service):
 	def _on_tick(self, msg):
 		self._update_cache()
 
-	def _on_rescan(self, msg):
+	async def _on_rescan(self, msg):
+		# async method to provide threadsafe callback
 		self._update_cache()
 
 	def _on_zk_ready(self, msg, zkc):

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -28,8 +28,6 @@ class DiscoveryService(Service):
 		self._cache_lock = asyncio.Lock()
 		self._ready_event = asyncio.Event()
 
-		self._concurrent_future = None
-
 		self.App.PubSub.subscribe("Application.tick/300!", self._on_tick)
 		self.App.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_ready)
 		self.App.PubSub.subscribe("Discover.Rescan!", self._on_rescan)


### PR DESCRIPTION
Error was found:
`Non-thread-safe operation invoked on an event loop other than the current one`

The callback from kazoo has to stay on the "other" thread created in the proactor service. 

Přemek told me to use `asyncio.run_coroutine_threadsafe` to "return" the callback into the main thread.
However, I need to somehow take care of the resulting `Future` object as much as TaskService takes care of its tasks. 

It's a mess...