### PR TITLE
Refactor zookeeper error handling

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -235,11 +235,12 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		try:
 			node_data = await self.Zookeeper.get_data(node_path)
+			# NoNodeError is silent from the wrapper (returns None)
 		except kazoo.exceptions.ConnectionClosedError:
 			L.warning("Zookeeper library provider is not ready")
 			raise RuntimeError("Zookeeper library provider is not ready")
-		except kazoo.exceptions.NoNodeError:
-			return None
+		except kazoo.exceptions.KazooException:
+			return None  # TODO: should it be silent or propagated?
 
 		# Consider adding other exceptions from Kazoo to indicate common non-critical errors
 


### PR DESCRIPTION
Hi, @mithunbharadwaj , @ateska 

I would like to discuss error handling in zookeeper code. 

Catching NoNodeError in the library provider is useless, becuase this one is already caught in the wrapper. 

We experience uncaught kazoo errors in every microservice when zookeeper disconnects (see sentry for more detail). I think it originates from this point in the zookeeper library provider - we resigned to handle the errors. However, those should be either propagated further as a specific Library Error (so it can be caught in the microservice) or all the errors IN READ mode (i.e. in the library) should be silent and return None. 

Right now, we mix both approaches - NoNode Errors are ignored (returning None) and other errors are not caught at all. That means that in my microservice, I always have to check for None and also do try/except for the rest of kazoo errors (which we typically don't do).

On the other hand, I suggest to propagate all kazoo errors from WRITE operations in the wrapper to the microservice, so I can catch them and decide specifically what I want to do with them. (write operations are not in the library provider.) Ignoring NoNodeError in write operations does not seem very convenient to me. Especially, when I need to handle other errors, anyway. https://github.com/TeskaLabs/asab/blob/master/asab/zookeeper/wrapper.py#L78

I'm afraid I missed some use cases that won't fit my suggestions. However, I'd like to agree on some "ideal" approach how to read from ZK, so we diminish the kazoo errors in sentry.