### PR TITLE
Library: Fix subscribe mechanism in ZK provider

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -314,11 +314,12 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 
 	async def subscribe(self, path):
-		path = self.BasePath + path
 		self.Subscriptions[path] = await self._get_directory_hash(path)
 
 
 	async def _get_directory_hash(self, path):
+		path = self.BasePath + path
+
 		def recursive_traversal(path, digest):
 			if not self.Zookeeper.Client.exists(path):
 				return


### PR DESCRIPTION
Hi, I have this is my microservice:

```
class ModelService(asab.Service):

	def __init__(self, app, service_name='ModelService'):
		super().__init__(app, service_name)

		self.App.PubSub.subscribe("Library.ready!", self._on_library_ready)
		self.App.PubSub.subscribe("Library.change!", self._on_library_change)

	async def _on_library_ready(self, event_name, library=None):
		await self.App.LibraryService.subscribe(["/Site/"])

	async def _on_library_change(self, message, provider, path):
		print(path)
```

the output of the print is 
`/Site/` for filesystem provider

and 
`/library/Site/` for ZK provider

The library methods should talk in library paths, so I want to change it to `/Site/` also for ZK provider. 
That means that the subscribed path cannot be changed. 