### PR TITLE
Add target info to "Library.change!" pubsub message

### DIFF
--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -46,7 +46,7 @@ class LibraryProviderABC(object):
 		self.IsReady = ready
 		await self.Library._set_ready(self)
 
-	async def subscribe(self, path: str, target: typing.Union[str, tuple] = "global"):
+	async def subscribe(self, path: str, target: typing.Union[str, tuple, None] = None):
 		"""
 		Take a path and subscribe to changes in this directory.
 		When change occurs, publish PubSub signal "Library.change!"

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -46,7 +46,7 @@ class LibraryProviderABC(object):
 		self.IsReady = ready
 		await self.Library._set_ready(self)
 
-	async def subscribe(self, path: str):
+	async def subscribe(self, path: str, target: typing.Union[str, tuple] = "global"):
 		"""
 		Take a path and subscribe to changes in this directory.
 		When change occurs, publish PubSub signal "Library.change!"

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -197,7 +197,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			self.App.PubSub.publish("Library.change!", self, path)
 
 
-	async def subscribe(self, path):
+	async def subscribe(self, path, target: typing.Union[str, tuple] = "global"):
 		if not os.path.isdir(self.BasePath + path):
 			return
 		if self.FD is None:

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -197,7 +197,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			self.App.PubSub.publish("Library.change!", self, path)
 
 
-	async def subscribe(self, path, target: typing.Union[str, tuple] = "global"):
+	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		if not os.path.isdir(self.BasePath + path):
 			return
 		if self.FD is None:

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -3,6 +3,7 @@ import tempfile
 import logging
 import hashlib
 import re
+import typing
 
 from .filesystem import FileSystemLibraryProvider
 from ...config import Config
@@ -218,5 +219,5 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		return to_publish
 
 
-	async def subscribe(self, path):
+	async def subscribe(self, path, target: typing.Union[str, tuple] = "global"):
 		self.SubscribedPaths.add(path)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -219,5 +219,5 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		return to_publish
 
 
-	async def subscribe(self, path, target: typing.Union[str, tuple] = "global"):
+	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		self.SubscribedPaths.add(path)

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -7,6 +7,7 @@ import tarfile
 import asyncio
 import shutil
 import tempfile
+import typing
 import urllib.parse
 
 import aiohttp

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -210,5 +210,5 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 					L.exception("Error when fetching the library content from a registry")
 
 
-	async def subscribe(self, path, target: typing.Union[str, tuple] = "global"):
+	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		self.SubscribedPaths.add(path)

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -209,5 +209,5 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 					L.exception("Error when fetching the library content from a registry")
 
 
-	async def subscribe(self, path):
+	async def subscribe(self, path, target: typing.Union[str, tuple] = "global"):
 		self.SubscribedPaths.add(path)

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -11,7 +11,6 @@ import kazoo.exceptions
 from .abc import LibraryProviderABC
 from ..item import LibraryItem
 from ...zookeeper import ZooKeeperContainer
-from ...contextvars import Tenant
 
 #
 

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -321,7 +321,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			# Back-compat (pubsub callback must be called without `target` argument)
 			# Watch path globally
 			self.NodeDigests[path] = await self._get_directory_hash(path)
-		if target == "global":
+		elif target == "global":
 			# Watch path globally
 			self.NodeDigests[path] = await self._get_directory_hash(path)
 		elif target == "tenant":
@@ -426,7 +426,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		"""
 		try:
 			tenants = [
-				t for t in await self.Zookeeper.get_children("/.tenants")
+				t for t in await self.Zookeeper.get_children("{}/.tenants".format(self.BasePath))
 				if not t.startswith(".")
 			]
 		except kazoo.exceptions.NoNodeError:

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -98,43 +98,29 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 	If `path` from [zookeeper] section is missing, an application class name will be used
 	Ex. `/BSQueryApp/library`
 
-	Usage of TenantContextVar:
-		The 'TenantContextVar' context variable is used to specify the current tenant context.
+	Usage of asab.contextvars.Tenant:
+		The 'Tenant' context variable is used to specify the current tenant context.
 		It can be set at the beginning of an operation (e.g., a web request) to ensure that all
 		subsequent operations within that context are executed under the specified tenant.
 		The context variable is reset to its default value (None) at the end of the operation.
 
 	Example:
-		Usage of TenantContextVar:
-		The 'TenantContextVar' context variable is used to specify the current tenant context.
-		It can be set at the beginning of an operation (e.g., a web request) to ensure that all
-		subsequent operations within that context are executed under the specified tenant.
-		The context variable is reset to its default value (None) at the end of the operation.
 
-		Steps:
+		# Import tenant context variable
+		from asab.contextvars import Tenant
 
-		1. Import the necessary module:
+		# Set your working tenant
+		tenant_token = Tenant.set('default')
 
-			import asab.library.providers.zookeeper
-
-		2. Set the context variable at the beginning of the operation:
-
-			tenant_token = asab.library.providers.zookeeper.TenantContextVar.set('default')
-
-		3. Perform the desired operation within the specified tenant context:
-
+		# Use try-finally flow to ensure the context is always properly reset
+		try:
+			# Perform library operation in the selected tenant
 			LibraryService.read("asab/library/schema.json")
+		finally:
+			# Reset the tenant context
+			Tenant.reset(tenant_token)
 
-		4. Reset the context variable to its default value at the end of the operation:
-
-			asab.library.providers.zookeeper.TenantContextVar.reset(tenant_token)  # Reset to default context
-
-		Example:
-
-			tenant_token = asab.library.providers.zookeeper.TenantContextVar.set('default')
-			LibraryService.read("asab/library/schema.json")
-			asab.library.providers.zookeeper.TenantContextVar.reset(tenant_token)  # Reset to default context
-		"""
+	"""
 
 	def __init__(self, library, path, layer):
 		super().__init__(library, layer)

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -11,6 +11,7 @@ import kazoo.exceptions
 from .abc import LibraryProviderABC
 from ..item import LibraryItem
 from ...zookeeper import ZooKeeperContainer
+from ...contextvars import Tenant
 
 #
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -484,7 +484,11 @@ class LibraryService(Service):
 		return fileobj
 
 
-	async def subscribe(self, paths: typing.Union[str, typing.List[str]]) -> None:
+	async def subscribe(
+		self,
+		paths: typing.Union[str, typing.List[str]],
+		target: typing.Union[str, tuple] = "global"
+	) -> None:
 		"""
 		Subscribe to changes for specified paths of the library.
 
@@ -492,6 +496,10 @@ class LibraryService(Service):
 
 		Args:
 			paths (str | list[str]): Either single path or list of paths to be subscribed. All the paths must be absolute (start with '/').
+			target: In which target to watch the changes. Possible values:
+				- "global" to watch global path changes
+				- "tenant" to watch path changes in tenants
+				- ("tenant", TENANT_ID) to watch path changes in one specified tenant TENANT_ID
 
 		Examples:
 		```python
@@ -519,7 +527,7 @@ class LibraryService(Service):
 				)
 
 			for provider in self.Libraries:
-				await provider.subscribe(path)
+				await provider.subscribe(path, target)
 
 
 def _validate_path_item(path: str) -> None:

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -487,7 +487,7 @@ class LibraryService(Service):
 	async def subscribe(
 		self,
 		paths: typing.Union[str, typing.List[str]],
-		target: typing.Union[str, tuple] = "global"
+		target: typing.Union[str, tuple, None] = None,
 	) -> None:
 		"""
 		Subscribe to changes for specified paths of the library.

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -471,7 +471,7 @@ class AuthService(asab.Service):
 		Check access to requested tenant and add tenant resources to the request
 		"""
 		# Check if tenant access is authorized
-		if tenant not in request._AuthorizedTenants:
+		if not request.has_tenant_access(tenant):
 			L.warning("Tenant not authorized.", struct_data={"tenant": tenant, "sub": request._UserInfo.get("sub")})
 			raise asab.exceptions.AccessDeniedError()
 

--- a/examples/zookeeper-subscribe.py
+++ b/examples/zookeeper-subscribe.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+Simple app that watches global and tenant changes in library.
+"""
+
+import asab
+import asab.library
+import asab.zookeeper
+
+
+asab.Config["library"]["providers"] = "zk:///library"
+asab.Config["zookeeper"] = {
+	"servers": "localhost:2181",
+}
+if "web" not in asab.Config:
+	asab.Config["web"] = {
+		# Set up a web container listening at port 8080
+		"listen": "8084"
+	}
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+
+		super().__init__()
+
+		self.add_module(asab.zookeeper.Module)
+		self.LibraryService = asab.library.LibraryService(
+			self,
+			"LibraryService",
+		)
+
+		# Continue only if the library is ready
+		self.PubSub.subscribe("Library.ready!", self.on_library_ready)
+		self.PubSub.subscribe("Library.change!", self.on_library_change)
+
+
+	async def on_library_ready(self, event_name, library=None):
+		# Subscribe to global changes of Triangles directory
+		await self.LibraryService.subscribe("/Triangles")
+		# Subscribe to changes of Circles directory in any tenant
+		await self.LibraryService.subscribe("/Circles", target="tenant")
+		# Subscribe to changes of Squares directory in tenant "shapefactory"
+		await self.LibraryService.subscribe("/Squares", target=("tenant", "shapefactory"))
+
+
+	def on_library_change(self, msg, provider, path, target=None):
+		if target:
+			print("\N{sparkles} New changes in directory {} in target {}.".format(path, target))
+		else:
+			print("\N{sparkles} New global changes in directory {}.".format(path))
+
+
+if __name__ == "__main__":
+	app = MyApplication()
+	app.run()

--- a/examples/zookeeper-subscribe.py
+++ b/examples/zookeeper-subscribe.py
@@ -13,11 +13,6 @@ asab.Config["library"]["providers"] = "zk:///library"
 asab.Config["zookeeper"] = {
 	"servers": "localhost:2181",
 }
-if "web" not in asab.Config:
-	asab.Config["web"] = {
-		# Set up a web container listening at port 8080
-		"listen": "8084"
-	}
 
 
 class MyApplication(asab.Application):
@@ -39,18 +34,15 @@ class MyApplication(asab.Application):
 
 	async def on_library_ready(self, event_name, library=None):
 		# Subscribe to global changes of Triangles directory
-		await self.LibraryService.subscribe("/Triangles")
+		await self.LibraryService.subscribe("/Triangles", target="global")
 		# Subscribe to changes of Circles directory in any tenant
 		await self.LibraryService.subscribe("/Circles", target="tenant")
 		# Subscribe to changes of Squares directory in tenant "shapefactory"
 		await self.LibraryService.subscribe("/Squares", target=("tenant", "shapefactory"))
 
 
-	def on_library_change(self, msg, provider, path, target=None):
-		if target:
-			print("\N{sparkles} New changes in directory {} in target {}.".format(path, target))
-		else:
-			print("\N{sparkles} New global changes in directory {}.".format(path))
+	def on_library_change(self, msg, provider, path, target):
+		print("\N{sparkles} New changes in directory {!r} in target {!r}.".format(path, target))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
- `LibraryService.subscribe` is extended with optional `target` argument.
- Possible `target` values:
  - `None` (default) or `"global"` to watch global target changes,
  - `"tenant"` to watch changes in ANY tenant,
  - `("tenant", TENANT_ID)` to watch changes in a specific tenant.
- The callback method must expect `target` argument, whose value is either `"global"` or `("tenant", TENANT_ID)`.
- Backward compatibility: When  `LibraryService.subscribe` is called without `target` argument (or its value is `None`), the callback is called without `target` argument.

# Other changes
- Fix: Superuser has access to any tenant.
