### PR TITLE
Api Service & Manifest: Fix timestamp, so it fits iso standard and can be further used

### DIFF
--- a/asab-manifest.py
+++ b/asab-manifest.py
@@ -59,7 +59,7 @@ envvars = [
 
 def create_manifest(args):
 	manifest = {
-		'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat() + 'Z',  # This is OK, no tzinfo needed
+		'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat()
 	}
 
 	try:

--- a/asab-manifest.py
+++ b/asab-manifest.py
@@ -59,7 +59,7 @@ envvars = [
 
 def create_manifest(args):
 	manifest = {
-		'created_at': datetime.datetime.now(datetime.timezone.utc).isoformat()
+		'created_at': datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),  # attention required: I used this datetime formatting with confidence I only use UTC time in this code. Do not copy blindly, mind the timezones.
 	}
 
 	try:

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -81,7 +81,7 @@ class ApiService(Service):
 
 		# if creation time for att_id is not present then add
 		if "_c" not in att:
-			att["_c"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+			att["_c"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")  # attention required: I used this datetime formatting with confidence I only use UTC time in this code. Do not copy blindly, mind the timezones.
 
 		# add to microservice json/dict section attention_required
 		self._do_zookeeper_adv_data()
@@ -207,7 +207,7 @@ class ApiService(Service):
 		adv_data = {
 			'host': self.App.HostName,
 			'appclass': self.App.__class__.__name__,
-			'launch_time': datetime.datetime.fromtimestamp(self.App.LaunchTime, datetime.timezone.utc).isoformat(),
+			'launch_time': datetime.datetime.fromtimestamp(self.App.LaunchTime, datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),  # attention required: I used this datetime formatting with confidence I only use UTC time in this code. Do not copy blindly, mind the timezones.
 			'process_id': os.getpid(),
 		}
 

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -81,7 +81,7 @@ class ApiService(Service):
 
 		# if creation time for att_id is not present then add
 		if "_c" not in att:
-			att["_c"] = datetime.datetime.now(datetime.timezone.utc).isoformat() + 'Z'  # This is OK, no tzinfo needed
+			att["_c"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 		# add to microservice json/dict section attention_required
 		self._do_zookeeper_adv_data()
@@ -207,7 +207,7 @@ class ApiService(Service):
 		adv_data = {
 			'host': self.App.HostName,
 			'appclass': self.App.__class__.__name__,
-			'launch_time': datetime.datetime.fromtimestamp(self.App.LaunchTime, datetime.timezone.utc).isoformat() + 'Z',
+			'launch_time': datetime.datetime.fromtimestamp(self.App.LaunchTime, datetime.timezone.utc).isoformat(),
 			'process_id': os.getpid(),
 		}
 


### PR DESCRIPTION
I'm fighting with Franta for months! why remote control cannot send proper timestamps to the UI and I still could not understand...

So I had to find the respective UI part: http://gitlab.teskalabs.int/ateska/webui-microfrontends-poc/-/blob/master/asab_webui_components/src/components/DateTime/timeToString.js?ref_type=heads
Learning that UI simply uses library translating datetime in some ISO format. So I went through the specs: https://en.wikipedia.org/wiki/ISO_8601

And... sure it does not say "Just put Z in the end": https://github.com/TeskaLabs/asab/commit/8c16dea53f6434b8cf5f88533c0784c2e455c1b6

Who had the wonderful idea of "improving" iso format, so that is especially difficult to find what's wrong?

The timestamps from asab are the only ones, that cannot be translated by the UI to the nice human readable thing. 
![Screenshot from 2024-08-29 17-12-49](https://github.com/user-attachments/assets/ca4fd03f-5480-414f-a812-0406e9ff715e)
![Screenshot from 2024-08-29 17-15-37](https://github.com/user-attachments/assets/ada2bf25-67f0-4ce2-83e5-0c748e581593)

