### PR TITLE
Sentry.io: Disable transaction sampling

### DIFF
--- a/asab/sentry/__init__.py
+++ b/asab/sentry/__init__.py
@@ -6,7 +6,7 @@ Config.add_defaults(
 		"sentry": {
 			"data_source_name": "",
 			"environment": "not specified",
-			"traces_sample_rate": 1.0,
+			"traces_sample_rate": 0,  # https://docs.sentry.io/platforms/python/configuration/sampling/#configuring-the-transaction-sample-rate
 		},
 
 		"sentry:logging": {


### PR DESCRIPTION
Transaction sampling can be disabled by setting `traces_sample_rate=0`, see:
https://docs.sentry.io/platforms/python/configuration/sampling/#configuring-the-transaction-sample-rate