### PR TITLE
Fix of the incorrect imports

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -11,7 +11,7 @@ import kazoo.exceptions
 from .abc import LibraryProviderABC
 from ..item import LibraryItem
 from ...zookeeper import ZooKeeperContainer
-from ... contextvars import Tenant
+from ...contextvars import Tenant
 
 #
 

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -107,10 +107,10 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 	Example:
 
 		# Import tenant context variable
-		from asab.contextvars import Tenant
+		import asab.contextvars
 
 		# Set your working tenant
-		tenant_token = Tenant.set('default')
+		tenant_token = asab.contextvars.Tenant.set('default')
 
 		# Use try-finally flow to ensure the context is always properly reset
 		try:
@@ -118,7 +118,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			LibraryService.read("asab/library/schema.json")
 		finally:
 			# Reset the tenant context
-			Tenant.reset(tenant_token)
+			asab.contextvars.Tenant.reset(tenant_token)
 
 	"""
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -20,8 +20,7 @@ from .item import LibraryItem
 from ..application import Application
 from .providers.abc import LibraryProviderABC
 from ..exceptions import LibraryInvalidPathError
-
-from asab.contextvars import Tenant
+from ..contextvars import Tenant
 
 #
 

--- a/asab/web/auth/__init__.py
+++ b/asab/web/auth/__init__.py
@@ -1,9 +1,8 @@
 from .decorator import require, noauth
-from .service import AuthService, Tenant
+from .service import AuthService
 
 __all__ = (
 	"AuthService",
-	"Tenant",
 	"require",
 	"noauth",
 )

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -2,7 +2,7 @@ import logging
 import functools
 import inspect
 
-import asab.exceptions
+from ...exceptions import AccessDeniedError
 
 #
 
@@ -40,7 +40,7 @@ def require(*resources):
 					"the handler method does not use both the '@noauth' and the '@require' decorators at once.")
 
 			if not request.has_resource_access(*resources):
-				raise asab.exceptions.AccessDeniedError()
+				raise AccessDeniedError()
 
 			return await handler(*args, **kwargs)
 

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -14,11 +14,12 @@ import aiohttp
 import aiohttp.web
 import aiohttp.client_exceptions
 
-# TODO: These MUST be relative imports ... as anywhere else in ASAB
-import asab
-import asab.exceptions
-import asab.utils
-import asab.contextvars
+from ...abc.service import Service
+from ...config import Config
+from ...exceptions import NotAuthenticatedError, AccessDeniedError
+from ...api.discovery import NotDiscoveredError
+from ...utils import string_to_boolean
+from ...contextvars import Tenant
 
 try:
 	import jwcrypto.jwk
@@ -26,8 +27,6 @@ try:
 	import jwcrypto.jws
 except ModuleNotFoundError:
 	jwcrypto = None
-
-from ...api.discovery import NotDiscoveredError
 
 #
 
@@ -79,7 +78,7 @@ class AuthMode(enum.Enum):
 	MOCK = enum.auto()
 
 
-class AuthService(asab.Service):
+class AuthService(Service):
 	"""
 	Provides authentication and authorization of incoming requests.
 
@@ -105,15 +104,15 @@ class AuthService(asab.Service):
 
 	def __init__(self, app, service_name="asab.AuthService"):
 		super().__init__(app, service_name)
-		self.PublicKeysUrl = asab.Config.get("auth", "public_keys_url") or None
+		self.PublicKeysUrl = Config.get("auth", "public_keys_url") or None
 
 		# To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization
 		self.DiscoveryService = self.App.get_service("asab.DiscoveryService")
 
-		enabled = asab.Config.get("auth", "enabled", fallback=True)
+		enabled = Config.get("auth", "enabled", fallback=True)
 		if enabled == "mock":
 			self.Mode = AuthMode.MOCK
-		elif asab.utils.string_to_boolean(enabled):
+		elif string_to_boolean(enabled):
 			self.Mode = AuthMode.ENABLED
 		else:
 			self.Mode = AuthMode.DISABLED
@@ -144,7 +143,7 @@ class AuthService(asab.Service):
 
 	def _prepare_mock_user_info(self):
 		# Load custom user info
-		mock_user_info_path = asab.Config.get("auth", "mock_user_info_path")
+		mock_user_info_path = Config.get("auth", "mock_user_info_path")
 		if os.path.isfile(mock_user_info_path):
 			with open(mock_user_info_path, "rb") as fp:
 				user_info = json.load(fp)
@@ -218,7 +217,7 @@ class AuthService(asab.Service):
 			return _get_id_token_claims(bearer_token, self.TrustedPublicKeys)
 		except (jwcrypto.jws.InvalidJWSSignature, jwcrypto.jwt.JWTMissingKey) as e:
 			L.error("Cannot authenticate request: {}".format(str(e)))
-			raise asab.exceptions.NotAuthenticatedError()
+			raise NotAuthenticatedError()
 
 
 	def get_authorized_tenant(self, request) -> typing.Optional[str]:
@@ -474,7 +473,7 @@ class AuthService(asab.Service):
 		# Check if tenant access is authorized
 		if not request.has_tenant_access(tenant):
 			L.warning("Tenant not authorized.", struct_data={"tenant": tenant, "sub": request._UserInfo.get("sub")})
-			raise asab.exceptions.AccessDeniedError()
+			raise AccessDeniedError()
 
 		# Extend globally granted resources with tenant-granted resources
 		request._AuthorizedResources = set(request._AuthorizedResources.union(
@@ -508,11 +507,11 @@ class AuthService(asab.Service):
 				assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
 				self._authorize_tenant_request(request, tenant)
 
-			tenant_ctx = asab.contextvars.Tenant.set(tenant)
+			tenant_ctx = Tenant.set(tenant)
 			try:
 				response = await handler(*args, **kwargs)
 			finally:
-				asab.contextvars.Tenant.reset(tenant_ctx)
+				Tenant.reset(tenant_ctx)
 			return response
 
 		return wrapper
@@ -527,7 +526,7 @@ class AuthService(asab.Service):
 		@functools.wraps(handler)
 		async def wrapper(*args, **kwargs):
 			request = args[-1]
-			tenant_from_header = asab.contextvars.Tenant.get(None)
+			tenant_from_header = Tenant.get(None)
 			tenant = request.match_info["tenant"]
 			if tenant_from_header and tenant != tenant_from_header:
 				L.warning("Tenant in path differs from tenant in X-Tenant header.", struct_data={
@@ -549,7 +548,7 @@ class AuthService(asab.Service):
 		@functools.wraps(handler)
 		async def wrapper(*args, **kwargs):
 			request = args[-1]
-			tenant_from_header = asab.contextvars.Tenant.get(None)
+			tenant_from_header = Tenant.get(None)
 			if "tenant" not in request.query:
 				return await handler(*args, tenant=tenant_from_header, **kwargs)
 
@@ -575,7 +574,7 @@ def _get_id_token_claims(bearer_token: str, auth_server_public_key):
 		token = jwcrypto.jwt.JWT(jwt=bearer_token, key=auth_server_public_key)
 	except jwcrypto.jwt.JWTExpired:
 		L.warning("ID token expired.")
-		raise asab.exceptions.NotAuthenticatedError()
+		raise NotAuthenticatedError()
 	except jwcrypto.jwt.JWTMissingKey as e:
 		raise e
 	except jwcrypto.jws.InvalidJWSSignature as e:

--- a/docs/reference/services/library.md
+++ b/docs/reference/services/library.md
@@ -294,18 +294,18 @@ self.AuthService.install(self.WebContainer)
 The following example demonstrates how to iterate through multiple tenants, setting and resetting the tenant context for each one:
 
 ```
-from asab.contextvars import Tenant
+import asab.contextvars
 
 async def process_tenants(self):
     for tenant in self.Tenants:
         # Set the tenant context
-        tenant_context = Tenant.set(tenant)
+        tenant_context = asab.contextvars.Tenant.set(tenant)
         try:
             # Process tenant-specific logic here
             print(f"Processing workflows for tenant: {tenant}")
         finally:
             # Reset the tenant context
-            Tenant.reset(tenant_context)
+            asab.contextvars.Tenant.reset(tenant_context)
 ```
 
 In this method:
@@ -317,15 +317,15 @@ In this method:
 If you need to handle only one tenant context, the process is straightforward:
 
 ```
-from asab.contextvars import Tenant
+import asab.contextvars
 
 async def process_single_tenant(self, tenant):
-    tenant_context = Tenant.set(tenant)
+    tenant_context = asab.contextvars.Tenant.set(tenant)
     try:
         # Perform operations for the tenant
         print(f"Processing data for tenant: {tenant}")
     finally:
-        Tenant.reset(tenant_context)
+        asab.contextvars.Tenant.reset(tenant_context)
 ```
 
 

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -2,7 +2,7 @@
 import typing
 import asab.web.rest
 import asab.web.auth
-from asab.contextvars import Tenant
+import asab.contextvars
 
 if "web" not in asab.Config:
 	asab.Config["web"] = {
@@ -83,7 +83,7 @@ class MyApplication(asab.Application):
 		- if there is a tenant ID in the X-Tenant header, the request must be authorized to access that tenant
 		- returns 401 if authentication not successful
 		"""
-		tenant = Tenant.get()
+		tenant = asab.contextvars.Tenant.get()
 		data = {
 			"tenant": tenant,
 			"resources": list(resources) if resources else None,
@@ -108,7 +108,7 @@ class MyApplication(asab.Application):
 		- returns 401 if authentication not successful
 		- returns 403 if authorization not successful
 		"""
-		tenant = Tenant.get()
+		tenant = asab.contextvars.Tenant.get()
 		data = {
 			"tenant": tenant,
 			"resources": list(resources) if resources else None,


### PR DESCRIPTION
Rules:

- In the module itself, we MUST use relative imports (no `import asab...` in ASAB but `from ...foo`)
- In 3rd party modules, we MUST use absolute imports, not `from` (no `from asab import ...`)

This MR also contains the extraction of the tenant from a Websocket Upgrade request.