### PR TITLE
Pass tenant to discovery session

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -19,6 +19,7 @@ except ModuleNotFoundError:
 	jwcrypto = None
 
 from .. import Service
+from ..contextvars import Tenant
 
 
 L = logging.getLogger(__name__)
@@ -404,6 +405,12 @@ class DiscoveryService(Service):
 				"Only instances of aiohttp.ClientRequest or the literal string 'internal' are allowed. "
 				"Found {}.".format(type(auth))
 			)
+
+		# Set tenant header if we are in tenant context
+		tenant = Tenant.get()
+		if tenant is not None:
+			headers["X-Tenant"] = tenant
+
 		return aiohttp.ClientSession(
 			base_url,
 			connector=aiohttp.TCPConnector(resolver=DiscoveryResolver(self)),

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -366,7 +366,7 @@ class DiscoveryService(Service):
 		base_url: typing.Optional[str] = None,
 		tenant: typing.Optional[str] = None,
 		auth: typing.Union[str, aiohttp.ClientRequest, None] = None,
-		headers: typing.Optional[typing.Mapping[str]] = None,
+		headers: typing.Optional[typing.Mapping[str, str]] = None,
 		**kwargs
 	) -> aiohttp.ClientSession:
 		"""
@@ -425,7 +425,7 @@ class DiscoveryService(Service):
 			_headers["X-Tenant"] = tenant
 		else:
 			# Use tenant from context
-			tenant = Tenant.get()
+			tenant = Tenant.get(None)
 			if tenant is not None:
 				_headers["X-Tenant"] = tenant
 
@@ -435,7 +435,7 @@ class DiscoveryService(Service):
 		return aiohttp.ClientSession(
 			base_url,
 			connector=aiohttp.TCPConnector(resolver=DiscoveryResolver(self)),
-			headers=headers,
+			headers=_headers,
 			**kwargs
 		)
 


### PR DESCRIPTION
# Summary

- When `asab.contextvars.Tenant` is set, `DiscoveryService.session()` automatically adds `X-Tenant` header to the request.
- There is also a new optional `tenant` argument in the `session()` method that can override the tenant context.
- Updated internal auth example.

# Usage

## When in tenant context already

No special action required, tenant is set automatically:

```python
discovery_svc = app.get_service("asab.DiscoveryService")
async with discovery_svc.session(auth="internal") as session:
	async with session.get("http://my_application.service_id.asab/users") as resp:
		data = await resp.json()
		await do_stuff(data)
```

## Manually setting/switching tenant context

Before creating the session you need to set the value of `asab.contextvars.Tenant`, and reset the context after you are done with the session:

```python
import asab.contextvars

tenant_id = "cupcakes-corp"
discovery_svc = app.get_service("asab.DiscoveryService")
tenant_ctx = asab.contextvars.Tenant.set(tenant_id)
try:
	async with discovery_svc.session(auth="internal") as session:
		async with session.get("http://my_application.service_id.asab/users") as resp:
			data = await resp.json()
			await do_stuff(data)
finally:
	asab.contextvars.Tenant.reset(tenant_ctx)
```

## Using the tenant argument

When switching the context is too overkill:

```python
tenant_id = "cupcakes-corp"
discovery_svc = app.get_service("asab.DiscoveryService")
async with discovery_svc.session(auth="internal", tenant=tenant_id) as session:
	async with session.get("http://my_application.service_id.asab/users") as resp:
		data = await resp.json()
		await do_stuff(data)
```