### PR TITLE
Publish "Tenants.changed!" when new tenants are loaded

### DIFF
--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -82,7 +82,7 @@ class TenantService(Service):
 			new_tenants.update(self._StaticTenants)
 
 		if self.Tenants != new_tenants:
-			self.App.PubSub.publish("Tenants.changed!")
+			self.App.PubSub.publish("Tenants.change!")
 			self.Tenants = new_tenants
 
 

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -38,7 +38,7 @@ class TenantService(Service):
 		# Load tenants from URL
 		self.TenantUrl = Config.get("tenants", "tenant_url")
 		if len(self.TenantUrl) > 0:
-			app.PubSub.subscribe("Application.tick/10!", self._update_tenants)
+			app.PubSub.subscribe("Application.tick/300!", self._update_tenants)
 
 
 	async def initialize(self, app):


### PR DESCRIPTION
- When `asab.web.tenant.TenantService` loads new tenants different from the previous state, a pubsub message `"Tenants.changed!"` is published.
- `asab.web.tenant.TenantService` now loads all tenants (including the ones from config) in the asynchronous initialization stage. This is to prevent multiple pubsub messages on app startup.