### PR TITLE
Fix request authorization in discovery service

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -8,6 +8,7 @@ import logging
 import os
 
 import aiohttp
+import aiohttp.web
 import kazoo.exceptions
 
 try:
@@ -400,7 +401,8 @@ class DiscoveryService(Service):
 				...
 		"""
 		_headers = {}
-		if isinstance(auth, aiohttp.ClientRequest):
+		if isinstance(auth, aiohttp.web.Request):
+			# TODO: This should be the default option. Use contextvar to access the request.
 			assert "Authorization" in auth.headers
 			_headers["Authorization"] = auth.headers.get("Authorization")
 		elif auth == "internal":

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -417,7 +417,7 @@ class DiscoveryService(Service):
 		else:
 			raise ValueError(
 				"Invalid 'auth' value. "
-				"Only instances of aiohttp.ClientRequest or the literal string 'internal' are allowed. "
+				"Only instances of aiohttp.web.Request or the literal string 'internal' are allowed. "
 				"Found {}.".format(type(auth))
 			)
 


### PR DESCRIPTION
# Issue

Passing authorization from incoming request to discovery service does not work because of wrong instance check.

# Solution

The `auth` parameter must be instance of `aiohttp.web.Request`, not a client request.