### PR TITLE
Implicit discovery session authorization using Request context variable

### DIFF
--- a/asab/contextvars.py
+++ b/asab/contextvars.py
@@ -1,3 +1,6 @@
 import contextvars
 
 Tenant = contextvars.ContextVar("Tenant")
+
+# Contains aiohttp.web.Request
+Request = contextvars.ContextVar("Request")

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -138,14 +138,17 @@ class WebContainer(Configurable):
 			self.add_preflight_handlers(preflight_paths)
 
 		@aiohttp.web.middleware
-		async def store_request_in_context(request, handler):
+		async def set_request_context(request: aiohttp.web.Request, handler):
+			"""
+			Make sure that the incoming aiohttp.web.Request is available via Request context variable
+			"""
 			request_ctx = Request.set(request)
 			try:
 				return await handler(request)
 			finally:
 				Request.reset(request_ctx)
 
-		self.WebApp.middlewares.append(store_request_in_context)
+		self.WebApp.middlewares.append(set_request_context)
 
 
 	async def _start(self, app: Application):

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -11,6 +11,7 @@ from ..config import Configurable
 from ..tls import SSLContextBuilder
 from .service import WebService
 from ..application import Application
+from ...contextvars import Request
 
 #
 
@@ -137,15 +138,14 @@ class WebContainer(Configurable):
 			self.add_preflight_handlers(preflight_paths)
 
 		@aiohttp.web.middleware
-		async def request_context_middleware(request, handler):
-			from ...contextvars import Request
+		async def store_request_in_context(request, handler):
 			request_ctx = Request.set(request)
 			try:
 				return await handler(request)
 			finally:
 				Request.reset(request_ctx)
 
-		self.WebApp.middlewares.append(request_context_middleware)
+		self.WebApp.middlewares.append(store_request_in_context)
 
 
 	async def _start(self, app: Application):

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -136,6 +136,17 @@ class WebContainer(Configurable):
 			preflight_paths = re.split(r"[,\s]+", preflight_str, re.MULTILINE)
 			self.add_preflight_handlers(preflight_paths)
 
+		@aiohttp.web.middleware
+		async def request_context_middleware(request, handler):
+			from ...contextvars import Request
+			request_ctx = Request.set(request)
+			try:
+				return await handler(request)
+			finally:
+				Request.reset(request_ctx)
+
+		self.WebApp.middlewares.append(request_context_middleware)
+
 
 	async def _start(self, app: Application):
 		await self.WebAppRunner.setup()

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -11,7 +11,7 @@ from ..config import Configurable
 from ..tls import SSLContextBuilder
 from .service import WebService
 from ..application import Application
-from ...contextvars import Request
+from ..contextvars import Request
 
 #
 


### PR DESCRIPTION
# Summary

- `asab.web.WebContainer` stores every incoming request in `asab.contextvars.Request`.
- `DiscoveryService.session` now uses the Authorization header from the Request context by default, so it is no longer necessary to specify `auth=request`.

# Usage

```python

# In web handler
async def assign_ticket_to_user(self, request):
	ticket_id = request.match_info["ticket_id"]
	user_id = request.match_info["user_id"]
	await self.TicketService.assign_ticket(ticket_id, user_id)

# In TicketService
async def assign_ticket(self, ticket_id, user_id):
	await self.Storage.put(ticket_id, user_id)

	# Notify user about ticket using emailing microservice
	# NOTE that request does not have to be passed as argument to the session method;
	#   the authorization is passed on automatically.
	async with self.DiscoveryService.session(base_url="http://email-microservice.service_id.asab") as session:
		async with session.put("/send", json={"message": "You have been assigned a ticket.", ...}) as resp:
			...

```