### PR TITLE
When libsreg directory contains no files, it forces re-download

### DIFF
--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -110,9 +110,15 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 			# Check for existing E-Tag
 			etag_fname = os.path.join(self.RootPath, "etag")
 			if os.path.exists(etag_fname):
-				with open(etag_fname, 'r') as f:
-					etag = f.read().strip()
-					headers['If-None-Match'] = etag
+
+				# Count number of files in self.RootPath recursively
+				file_count = sum([len(files) for _, _, files in os.walk(self.RootPath)])
+				
+				# If less than 5 files, we ignore the E-Tag and re-download everything
+				if file_count > 5:
+					with open(etag_fname, 'r') as f:
+						etag = f.read().strip()
+						headers['If-None-Match'] = etag
 
 			# Prepare a list of URLs to try
 			# Randomize the order of the URLs (there might be more than one server to try)


### PR DESCRIPTION
On my laptop (Mac OS X), the local cache of the libsreg sometimes ends up corrupted - all files were removed, the directory structure was present.
Not sure what was a root cause - but this is a fix that detects that situation and forces re-download  by ignoring E-Tag.