### PR TITLE
Lock Yarl version to keep python 3.8 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
 		'aiohttp>=3.8.3,<4',
 		'fastjsonschema>=2.16.2,<3',
 		'kazoo>=2.9.0,<3',
-		'PyYAML>=6.0,<7'
+		'PyYAML>=6.0,<7',
+		'yarl<1.15.3',  # aiohttp dependency, later versions break Python 3.8 compatibility
 	],
 	extras_require={
 		'git': 'pygit2<1.12',  # For Alpine 3.16 / Python 3.10, use pygit2>=1.9,<1.10


### PR DESCRIPTION
# Issue
[Yarl 1.15.3 dropped support for Python 3.8](https://yarl.aio-libs.org/en/latest/changes/#removals-and-backward-incompatible-breaking-changes), as it has reached its end of life.

# Solution
Add version-locked Yarl to ASAB dependencies.