### PR TITLE
Direct auth introspection in mock mode

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -95,6 +95,9 @@ class AuthService(Service):
 		# To enable Service Discovery, initialize Api Service and call its initialize_zookeeper() method before AuthService initialization
 		self.DiscoveryService = self.App.get_service("asab.DiscoveryService")
 
+		self.IntrospectionUrl = None
+		self.MockUserInfo = None
+
 		enabled = Config.get("auth", "enabled", fallback=True)
 		if enabled == "mock":
 			self.Mode = AuthMode.MOCK

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -142,12 +142,12 @@ class AuthService(Service):
 		"""
 		Try to set up direct introspection. In not available, set up static mock userinfo.
 		"""
-		mock_introspection_url = Config.get("auth", "mock_introspection_url", fallback=None)
-		if mock_introspection_url is not None:
-			self.MockIntrospectionUrl = mock_introspection_url
+		introspection_url = Config.get("auth", "introspection_url", fallback=None)
+		if introspection_url is not None:
+			self.IntrospectionUrl = introspection_url
 			L.warning(
 				"AuthService is running in MOCK MODE. Web requests will be authorized with direct introspection "
-				"call to {!r}.".format(self.MockIntrospectionUrl)
+				"call to {!r}.".format(self.IntrospectionUrl)
 			)
 			return
 
@@ -271,12 +271,12 @@ class AuthService(Service):
 		Validate the Authorizetion header and extract the Bearer token value
 		"""
 		if self.Mode == AuthMode.MOCK:
-			if not self.MockIntrospectionUrl:
+			if not self.IntrospectionUrl:
 				return "MOCK"
 
 			# Send the request headers for introspection
 			async with aiohttp.ClientSession() as session:
-				async with session.post(self.MockIntrospectionUrl, headers=request.headers) as response:
+				async with session.post(self.IntrospectionUrl, headers=request.headers) as response:
 					if response.status != 200:
 						L.warning("Access token introspection failed.")
 						raise aiohttp.web.HTTPUnauthorized()


### PR DESCRIPTION
# Summary

In MOCK mode, you can specify Seacat Auth nginx introspection URL in the configuration so that incoming requests are immediately introspected without the need for reverse proxy. The introspection URL is not used in production mode (`enabled=yes`).

# Config example
```ini
[auth]
enabled=mock
introspection_url=http://localhost:8900/nginx/introspect/openidconnect
```