### PR TITLE
Warn on dangerous internal authorization usage

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
 	jwcrypto = None
 
 from .. import Service
-from ..contextvars import Tenant, Request
+from ..contextvars import Tenant, Request, Authz
 
 
 L = logging.getLogger(__name__)
@@ -418,6 +418,14 @@ class DiscoveryService(Service):
 					"You are trying to use internal auth without 'jwcrypto' installed. "
 					"Please run 'pip install jwcrypto' or install asab with 'authz' optional dependency."
 				)
+
+			authz = Authz.get(None)
+			if authz is not None:
+				L.warning(
+					"Using internal (superuser) authorization in an already authorized context. "
+					"This is potentially unwanted and dangerous.",
+				)
+
 			_headers["Authorization"] = "Bearer {}".format(self.InternalAuthToken.serialize())
 
 		else:


### PR DESCRIPTION
When `DiscoveryService.session(auth="internal")` is called and there is authorization in the context already, the following warning will be logged:

_25-Oct-2024 16:43:35.171971 WARNING asab.api.discovery Using internal (superuser) authorization in an already authorized context. This is potentially unwanted and dangerous._
