### PR TITLE
Restore AuthService.get_authorized_tenant as a legacy method

### DIFF
--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -137,6 +137,21 @@ class AuthService(Service):
 		self._try_auto_install()
 
 
+	def get_authorized_tenant(self, request=None) -> typing.Optional[str]:
+		"""
+		DEPRECATED. Get the request's authorized tenant.
+		"""
+		authz = Authz.get()
+		resources = authz._UserInfo.get("resources", {})
+		for tenant in resources.keys():
+			if tenant == "*":
+				continue
+			# Return the first authorized tenant
+			return tenant
+
+		return None
+
+
 	async def initialize(self, app):
 		self._check_if_installed()
 


### PR DESCRIPTION
# Issue
`AuthService.get_authorized_tenant` has been removed but it is still used by baseliner.

# Solution
Restore `AuthService.get_authorized_tenant` method and mark it as deprecated. It should be removed as soon as it is fixed and replaced in baseliner.