### PR TITLE
Deprecate X-Tenant header

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
 	jwcrypto = None
 
 from .. import Service
-from ..contextvars import Tenant, Request, Authz
+from ..contextvars import Request, Authz
 
 
 L = logging.getLogger(__name__)

--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -365,7 +365,6 @@ class DiscoveryService(Service):
 	def session(
 		self,
 		base_url: typing.Optional[str] = None,
-		tenant: typing.Optional[str] = None,
 		auth: typing.Union[str, aiohttp.ClientRequest, None] = None,
 		headers: typing.Optional[typing.Mapping[str, str]] = None,
 		**kwargs
@@ -375,7 +374,6 @@ class DiscoveryService(Service):
 
 		Args:
 			:param base_url: Base URL to use for requests.
-			:param tenant: Request tenant ID.
 			:param auth: Client request to extract authorization from, or the string "internal", to use internal authorization.
 			:param headers: Custom session HTTP headers.
 
@@ -434,16 +432,6 @@ class DiscoveryService(Service):
 				"Only instances of aiohttp.web.Request or the literal string 'internal' are allowed. "
 				"Found {}.".format(type(auth))
 			)
-
-		# Set tenant header
-		if tenant is not None:
-			# Use tenant from argument
-			_headers["X-Tenant"] = tenant
-		else:
-			# Use tenant from context
-			tenant = Tenant.get(None)
-			if tenant is not None:
-				_headers["X-Tenant"] = tenant
 
 		if headers is not None:
 			_headers.update(headers)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -692,7 +692,7 @@ def _set_tenant_context_from_url_query(handler):
 		request = args[-1]
 		tenant = request.query.get("tenant", None)
 
-		assert tenant is not None or len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
+		assert tenant is None or len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
 		tenant_ctx = Tenant.set(tenant)
 		try:
 			response = await handler(*args, **kwargs)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -17,7 +17,7 @@ import aiohttp.client_exceptions
 from ... import LogObsolete
 from ...abc.service import Service
 from ...config import Config
-from ...exceptions import NotAuthenticatedError, AccessDeniedError
+from ...exceptions import NotAuthenticatedError
 from ...api.discovery import NotDiscoveredError
 from ...utils import string_to_boolean
 from ...contextvars import Tenant, Authz
@@ -471,8 +471,6 @@ class AuthService(Service):
 
 		if hasattr(handler_method, "__func__"):
 			handler_method = handler_method.__func__
-
-		is_websocket = isinstance(handler_method, WebSocketFactory)
 
 		if hasattr(handler_method, "NoAuth"):
 			return

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -692,7 +692,7 @@ def _set_tenant_context_from_url_query(handler):
 		request = args[-1]
 		tenant = request.query.get("tenant", None)
 
-		assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
+		assert tenant is not None or len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
 		tenant_ctx = Tenant.set(tenant)
 		try:
 			response = await handler(*args, **kwargs)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -21,7 +21,6 @@ from ...exceptions import NotAuthenticatedError
 from ...api.discovery import NotDiscoveredError
 from ...utils import string_to_boolean
 from ...contextvars import Tenant, Authz
-from ..websocket import WebSocketFactory
 from .authorization import Authorization
 
 try:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -507,19 +507,12 @@ class AuthService(Service):
 		# 2) Authenticate and authorize request, authorize tenant from context, set Authorization context
 		handler = self._authorize_request(handler)
 
-		# 1.5) Set tenant context from obsolete locations (no authorization yet)
-		# TODO: Deprecated. Ignore tenant in path and query, always use request headers instead.
+		# 1) Set tenant context (no authorization yet)
+		# TODO: This should be eventually done by TenantService
 		if tenant_in_path:
 			handler = _set_tenant_context_from_url_path(handler)
 		else:
 			handler = _set_tenant_context_from_url_query(handler)
-
-		# 1) Set tenant context (no authorization yet)
-		# TODO: This should be eventually done by TenantService
-		if is_websocket:
-			handler = _set_tenant_context_from_sec_websocket_protocol_header(handler)
-		else:
-			handler = _set_tenant_context_from_x_tenant_header(handler)
 
 		route._handler = handler
 
@@ -693,68 +686,6 @@ def _pass_authz(handler):
 	return wrapper
 
 
-def _set_tenant_context_from_x_tenant_header(handler):
-	"""
-	Extract tenant from X-Tenant header and add it to context
-	"""
-	def get_tenant_from_header(request) -> str:
-		# Get tenant from X-Tenant header for HTTP requests
-		return request.headers.get("X-Tenant")
-
-	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
-		request = args[-1]
-		tenant = get_tenant_from_header(request)
-
-		if tenant is None:
-			response = await handler(*args, **kwargs)
-		else:
-			assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
-			tenant_ctx = Tenant.set(tenant)
-			try:
-				response = await handler(*args, **kwargs)
-			finally:
-				Tenant.reset(tenant_ctx)
-
-		return response
-
-	return wrapper
-
-
-def _set_tenant_context_from_sec_websocket_protocol_header(handler):
-	"""
-	Extract tenant from Sec-Websocket-Protocol header and add it to context
-	"""
-	def get_tenant_from_header(request) -> str:
-		# Get tenant from Sec-Websocket-Protocol header for websocket requests
-		protocols = request.headers.get("Sec-Websocket-Protocol", "")
-		for protocol in protocols.split(", "):
-			protocol = protocol.strip()
-			if protocol.startswith("tenant_"):
-				return protocol[7:]
-		else:
-			return None
-
-	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
-		request = args[-1]
-		tenant = get_tenant_from_header(request)
-
-		if tenant is None:
-			response = await handler(*args, **kwargs)
-		else:
-			assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
-			tenant_ctx = Tenant.set(tenant)
-			try:
-				response = await handler(*args, **kwargs)
-			finally:
-				Tenant.reset(tenant_ctx)
-
-		return response
-
-	return wrapper
-
-
 def _set_tenant_context_from_url_query(handler):
 	"""
 	Extract tenant from request query and add it to context
@@ -762,28 +693,14 @@ def _set_tenant_context_from_url_query(handler):
 	@functools.wraps(handler)
 	async def wrapper(*args, **kwargs):
 		request = args[-1]
-		header_tenant = request.headers.get("X-Tenant")
-		tenant = request.query.get("tenant")
+		tenant = request.query.get("tenant", None)
 
-		if tenant is None:
-			# No tenant in query
+		assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
+		tenant_ctx = Tenant.set(tenant)
+		try:
 			response = await handler(*args, **kwargs)
-		elif header_tenant is not None:
-			# Tenant from header must not be overwritten by a different tenant in query!
-			if tenant != header_tenant:
-				L.error("Tenant from URL query does not match tenant from header.", struct_data={
-					"header_tenant": header_tenant, "query_tenant": tenant})
-				raise AccessDeniedError()
-			# Tenant in query matches tenant in header
-			response = await handler(*args, **kwargs)
-		else:
-			# No tenant in header, only in query
-			assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
-			tenant_ctx = Tenant.set(tenant)
-			try:
-				response = await handler(*args, **kwargs)
-			finally:
-				Tenant.reset(tenant_ctx)
+		finally:
+			Tenant.reset(tenant_ctx)
 
 		return response
 
@@ -797,25 +714,14 @@ def _set_tenant_context_from_url_path(handler):
 	@functools.wraps(handler)
 	async def wrapper(*args, **kwargs):
 		request = args[-1]
-		header_tenant = request.headers.get("X-Tenant")
-		tenant = request.match_info.get("tenant")
+		tenant = request.match_info["tenant"]
 
-		if header_tenant is not None:
-			# Tenant from header must not be overwritten by a different tenant in path!
-			if tenant != header_tenant:
-				L.error("Tenant from URL path does not match tenant from header.", struct_data={
-					"header_tenant": header_tenant, "path_tenant": tenant})
-				raise AccessDeniedError()
-			# Tenant in path matches tenant in header
+		assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
+		tenant_ctx = Tenant.set(tenant)
+		try:
 			response = await handler(*args, **kwargs)
-		else:
-			# No tenant in header, only in path
-			assert len(tenant) < 128  # Limit tenant name length to 128 characters to maintain sanity
-			tenant_ctx = Tenant.set(tenant)
-			try:
-				response = await handler(*args, **kwargs)
-			finally:
-				Tenant.reset(tenant_ctx)
+		finally:
+			Tenant.reset(tenant_ctx)
 
 		return response
 


### PR DESCRIPTION
# Summary

- :warning: BREAKING :warning: Providing tenant in HTTP request headers (`X-Tenant` or `Sec-WebSocket-Protocol`) is no longer possible. Tenant-aware endpoints must **expect `tenant` parameter in URL path or query.**
- :warning: BREAKING :warning: `DiscoveryService.session(...)` does not accept `tenant` argument anymore and does not pass Tenant context variable to the request. You must now **include tenant in the discovery URL explicitly.**

Example:
```python
async with DiscoveryService.session() as session:

    # Tenant in path
    async with session.get(
        "http://ticket-app.instance_id.asab/{tenant}/tickets".format(tenant="bigcorporate")
    ) as resp:
        ...

    # Or tenant in query
    async with session.get(
        "http://ticket-app.service_id.asab/tickets?tenant={tenant}".format(tenant="bigcorporate")
    ) as resp:
        ...

```