### PR TITLE
Library: GitProvider - Don't stop the app even if the library is not ready

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -122,7 +122,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			pygit_message = str(err).replace('\"', '')
 			if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
 				# branch does not exist
-				L.critical(
+				L.exception(
 					"Branch does not exist.",
 					struct_data={
 						"url": self.URLPath,
@@ -130,13 +130,13 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 					}
 				)
 			else:
-				L.critical("Error when initializing git repository: {}".format(pygit_message))
+				L.exception("Error when initializing git repository: {}".format(pygit_message))
 
 		except pygit2.GitError as err:
 			pygit_message = str(err).replace('\"', '')
 			if "unexpected http status code: 404" in pygit_message:
 				# repository not found
-				L.critical(
+				L.exception(
 					"Git repository not found.",
 					struct_data={
 						"url": self.URLPath
@@ -144,7 +144,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			elif "remote authentication required but no callback set" in pygit_message:
 				# either repository not found or authentication failed
-				L.critical(
+				L.exception(
 					"Authentication failed when initializing git repository.\n"
 					"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
 					struct_data={
@@ -155,7 +155,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			elif 'cannot redirect from' in pygit_message:
 				# bad URL
-				L.critical(
+				L.exception(
 					"Git repository not found.",
 					struct_data={
 						"url": self.URLPath
@@ -163,14 +163,14 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			elif 'Temporary failure in name resolution' in pygit_message:
 				# Internet connection does
-				L.critical(
+				L.exception(
 					"Git repository not initialized: connection failed. Check your network connection.",
 					struct_data={
 						"url": self.URLPath
 					}
 				)
 			else:
-				L.critical("Git repository not initialized: {}".format(err))
+				L.exception("Git repository not initialized: {}".format(err))
 
 		except Exception as err:
 			L.exception(err)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -131,6 +131,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			else:
 				L.exception("Error when initializing git repository: {}".format(pygit_message))
+			return
 
 		except pygit2.GitError as err:
 			pygit_message = str(err).replace('\"', '')
@@ -171,9 +172,11 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			else:
 				L.exception("Git repository not initialized: {}".format(err))
+			return
 
 		except Exception as err:
 			L.exception(err)
+			return
 
 		assert hasattr(self.GitRepository, "remotes"), "Git repository not initialized."
 		assert self.GitRepository.remotes["origin"] is not None, "Git repository not initialized."

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -122,7 +122,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			pygit_message = str(err).replace('\"', '')
 			if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
 				# branch does not exist
-				L.exception(
+				L.critical(
 					"Branch does not exist.",
 					struct_data={
 						"url": self.URLPath,
@@ -130,14 +130,13 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 					}
 				)
 			else:
-				L.exception("Error when initializing git repository: {}".format(pygit_message))
-			self.App.stop()  # NOTE: raising Exception doesn't exit the app
+				L.critical("Error when initializing git repository: {}".format(pygit_message))
 
 		except pygit2.GitError as err:
 			pygit_message = str(err).replace('\"', '')
 			if "unexpected http status code: 404" in pygit_message:
 				# repository not found
-				L.exception(
+				L.critical(
 					"Git repository not found.",
 					struct_data={
 						"url": self.URLPath
@@ -145,7 +144,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			elif "remote authentication required but no callback set" in pygit_message:
 				# either repository not found or authentication failed
-				L.exception(
+				L.critical(
 					"Authentication failed when initializing git repository.\n"
 					"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
 					struct_data={
@@ -156,7 +155,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			elif 'cannot redirect from' in pygit_message:
 				# bad URL
-				L.exception(
+				L.critical(
 					"Git repository not found.",
 					struct_data={
 						"url": self.URLPath
@@ -164,15 +163,14 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 			elif 'Temporary failure in name resolution' in pygit_message:
 				# Internet connection does
-				L.exception(
+				L.critical(
 					"Git repository not initialized: connection failed. Check your network connection.",
 					struct_data={
 						"url": self.URLPath
 					}
 				)
 			else:
-				L.exception("Git repository not initialized: {}".format(err))
-			self.App.stop()
+				L.critical("Git repository not initialized: {}".format(err))
 
 		except Exception as err:
 			L.exception(err)


### PR DESCRIPTION
I don't want the whole app to crash even when the git repo is not initialized.

With my edits and failure of the repo initialization, the Library won't get ready. The functionality of the application will be significantly impaired. It probably won't be repairable from the UI as even remote control needs Library to change things. However, we can at least keep the apps up and provide info to the UI about what is wrong. When all containers keep restarting because of typo in the library config, it is scary. 