### PR TITLE
Add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
+        python -m pip install --upgrade pip
         pip install flake8
-        python setup.py install
+        pip install .
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install flake8
         python setup.py install
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full history, including all tags
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 import pathlib
 import re
 import subprocess
-
 from setuptools.command.build_py import build_py
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 here = pathlib.Path(__file__).parent
 txt = (here / 'asab' / '__init__.py').read_text('utf-8')
@@ -12,11 +10,19 @@ if (here / '.git').exists():
 	# This branch is happening during build from git version
 	module_dir = (here / 'asab')
 
-	version = subprocess.check_output(
-		['git', 'describe', '--abbrev=7', '--tags', '--dirty=-dirty', '--always'], cwd=module_dir)
-	version = version.decode('utf-8').strip()
-	if version[:1] == 'v':
+	try:
+		version = subprocess.check_output(
+			['git', 'describe', '--abbrev=7', '--tags', '--dirty=-dirty', '--always'],
+			cwd=module_dir,
+			encoding='utf-8',  # Ensure output is decoded correctly
+		).strip()
+	except subprocess.CalledProcessError:
+		raise RuntimeError("Git version retrieval failed")
+
+	if version.startswith('v'):
 		version = version[1:]
+
+	print("v1", version)
 
 	# PEP 440 requires that the PUBLIC version field does not contain hyphens or pluses.
 	# https://peps.python.org/pep-0440/#semantic-versioning
@@ -27,23 +33,29 @@ if (here / '.git').exists():
 	if match is not None:
 		version = "{}+{}".format(match[1], match[2])
 
-	build = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=module_dir)
-	build = build.decode('utf-8').strip()
+	print("v2", version)
+	try:
+		build = subprocess.check_output(
+			['git', 'rev-parse', 'HEAD'],
+			cwd=module_dir, encoding='utf-8'
+		).strip()
+	except subprocess.CalledProcessError:
+		raise RuntimeError("Git build hash retrieval failed")
 
 else:
-	# This is executed from packaged & distributed version
+	# This is executed for packaged & distributed versions
 	txt = (here / 'asab' / '__version__.py').read_text('utf-8')
 	version = re.findall(r"^__version__ = '([^']+)'\r?$", txt, re.M)[0]
 	build = re.findall(r"^__build__ = '([^']+)'\r?$", txt, re.M)[0]
 
 
-class custom_build_py(build_py):
-
+class CustomBuildPy(build_py):
 	def run(self):
 		super().run()
 
-		# This replace content of `__version__.py` in build folder
+		# Replace the content of `__version__.py` in the build folder with version info
 		version_file_name = pathlib.Path(self.build_lib, 'asab/__version__.py')
+		version_file_name.parent.mkdir(parents=True, exist_ok=True)
 		with open(version_file_name, 'w') as f:
 			f.write("__version__ = '{}'\n".format(version))
 			f.write("__build__ = '{}'\n".format(build))
@@ -53,8 +65,8 @@ class custom_build_py(build_py):
 setup(
 	name='asab',
 	version=version,
-	description='ASAB simplifies a development of async application servers',
-	long_description=open('README.rst').read(),
+	description='ASAB simplifies the development of async application servers',
+	long_description=(here / 'README.rst').read_text('utf-8'),
 	url='https://github.com/TeskaLabs/asab',
 	author='TeskaLabs Ltd',
 	author_email='info@teskalabs.com',
@@ -80,13 +92,13 @@ setup(
 		'PyYAML>=6.0,<7',
 	],
 	extras_require={
-		'git': 'pygit2<1.12',  # For Alpine 3.16 / Python 3.10, use pygit2>=1.9,<1.10
-		'encryption': 'cryptography',
-		'authz': 'jwcrypto==1.5.6',
-		'monitoring': "sentry-sdk==1.45.0"
+		'git': ['pygit2<1.12'],
+		'encryption': ['cryptography'],
+		'authz': ['jwcrypto==1.5.6'],
+		'monitoring': ['sentry-sdk==1.45.0']
 	},
 	cmdclass={
-		'build_py': custom_build_py,
+		'build_py': CustomBuildPy,
 	},
 	scripts=[
 		'asab-manifest.py'

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,6 @@ txt = (here / 'asab' / '__init__.py').read_text('utf-8')
 if (here / '.git').exists():
 	# This branch is happening during build from git version
 	module_dir = (here / 'asab')
-	print(">>>> module_dir", module_dir)
-
-	# Debug
-	try:
-		status = subprocess.check_output(
-			['git', 'status'],
-			cwd=module_dir,
-			encoding='utf-8',  # Ensure output is decoded correctly
-		).strip()
-	except subprocess.CalledProcessError:
-		raise RuntimeError("Git status retrieval failed")
-	print(">>>> status", status)
 
 	try:
 		version = subprocess.check_output(
@@ -29,12 +17,10 @@ if (here / '.git').exists():
 			encoding='utf-8',  # Ensure output is decoded correctly
 		).strip()
 	except subprocess.CalledProcessError:
-		raise RuntimeError("Git version retrieval failed")
+		raise RuntimeError('Git version retrieval failed')
 
 	if version.startswith('v'):
 		version = version[1:]
-
-	print(">>>> version", version)
 
 	# PEP 440 requires that the PUBLIC version field does not contain hyphens or pluses.
 	# https://peps.python.org/pep-0440/#semantic-versioning
@@ -43,18 +29,15 @@ if (here / '.git').exists():
 	# For example, "v22.06-rc6-291-g3021077-dirty" becomes "v22.06-rc6+291-g3021077-dirty".
 	match = re.match(r"^(.+)-([0-9]+-g[0-9a-f]{7}(?:-dirty)?)$", version)
 	if match is not None:
-		version = "{}+{}".format(match[1], match[2])
+		version = '{}+{}'.format(match[1], match[2])
 
-	print(">>>> version", version)
 	try:
 		build = subprocess.check_output(
 			['git', 'rev-parse', 'HEAD'],
 			cwd=module_dir, encoding='utf-8'
 		).strip()
 	except subprocess.CalledProcessError:
-		raise RuntimeError("Git build hash retrieval failed")
-
-	print(">>>> build", build)
+		raise RuntimeError('Git build hash retrieval failed')
 
 else:
 	# This is executed for packaged & distributed versions

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,18 @@ txt = (here / 'asab' / '__init__.py').read_text('utf-8')
 if (here / '.git').exists():
 	# This branch is happening during build from git version
 	module_dir = (here / 'asab')
+	print(">>>> module_dir", module_dir)
+
+	# Debug
+	try:
+		status = subprocess.check_output(
+			['git', 'status'],
+			cwd=module_dir,
+			encoding='utf-8',  # Ensure output is decoded correctly
+		).strip()
+	except subprocess.CalledProcessError:
+		raise RuntimeError("Git status retrieval failed")
+	print(">>>> status", status)
 
 	try:
 		version = subprocess.check_output(
@@ -22,7 +34,7 @@ if (here / '.git').exists():
 	if version.startswith('v'):
 		version = version[1:]
 
-	print("v1", version)
+	print(">>>> version", version)
 
 	# PEP 440 requires that the PUBLIC version field does not contain hyphens or pluses.
 	# https://peps.python.org/pep-0440/#semantic-versioning
@@ -33,7 +45,7 @@ if (here / '.git').exists():
 	if match is not None:
 		version = "{}+{}".format(match[1], match[2])
 
-	print("v2", version)
+	print(">>>> version", version)
 	try:
 		build = subprocess.check_output(
 			['git', 'rev-parse', 'HEAD'],
@@ -41,6 +53,8 @@ if (here / '.git').exists():
 		).strip()
 	except subprocess.CalledProcessError:
 		raise RuntimeError("Git build hash retrieval failed")
+
+	print(">>>> build", build)
 
 else:
 	# This is executed for packaged & distributed versions

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 import pathlib
 import re
 import subprocess
-
 from setuptools.command.build_py import build_py
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 here = pathlib.Path(__file__).parent
 txt = (here / 'asab' / '__init__.py').read_text('utf-8')
@@ -12,10 +10,16 @@ if (here / '.git').exists():
 	# This branch is happening during build from git version
 	module_dir = (here / 'asab')
 
-	version = subprocess.check_output(
-		['git', 'describe', '--abbrev=7', '--tags', '--dirty=-dirty', '--always'], cwd=module_dir)
-	version = version.decode('utf-8').strip()
-	if version[:1] == 'v':
+	try:
+		version = subprocess.check_output(
+			['git', 'describe', '--abbrev=7', '--tags', '--dirty=-dirty', '--always'],
+			cwd=module_dir,
+			encoding='utf-8',  # Ensure output is decoded correctly
+		).strip()
+	except subprocess.CalledProcessError:
+		raise RuntimeError("Git version retrieval failed")
+
+	if version.startswith('v'):
 		version = version[1:]
 
 	# PEP 440 requires that the PUBLIC version field does not contain hyphens or pluses.
@@ -27,34 +31,36 @@ if (here / '.git').exists():
 	if match is not None:
 		version = "{}+{}".format(match[1], match[2])
 
-	build = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=module_dir)
-	build = build.decode('utf-8').strip()
+	try:
+		build = subprocess.check_output(
+			['git', 'rev-parse', 'HEAD'],
+			cwd=module_dir, encoding='utf-8'
+		).strip()
+	except subprocess.CalledProcessError:
+		raise RuntimeError("Git build hash retrieval failed")
 
 else:
-	# This is executed from packaged & distributed version
+	# This is executed for packaged & distributed versions
 	txt = (here / 'asab' / '__version__.py').read_text('utf-8')
 	version = re.findall(r"^__version__ = '([^']+)'\r?$", txt, re.M)[0]
 	build = re.findall(r"^__build__ = '([^']+)'\r?$", txt, re.M)[0]
 
-
-class custom_build_py(build_py):
-
+class CustomBuildPy(build_py):
 	def run(self):
 		super().run()
 
-		# This replace content of `__version__.py` in build folder
+		# Replace the content of `__version__.py` in the build folder with version info
 		version_file_name = pathlib.Path(self.build_lib, 'asab/__version__.py')
+		version_file_name.parent.mkdir(parents=True, exist_ok=True)
 		with open(version_file_name, 'w') as f:
-			f.write("__version__ = '{}'\n".format(version))
-			f.write("__build__ = '{}'\n".format(build))
-			f.write("\n")
-
+			f.write(f"__version__ = '{version}'\n")
+			f.write(f"__build__ = '{build}'\n")
 
 setup(
 	name='asab',
 	version=version,
 	description='ASAB simplifies a development of async application servers',
-	long_description=open('README.rst').read(),
+	long_description=(here / 'README.rst').read_text('utf-8'),
 	url='https://github.com/TeskaLabs/asab',
 	author='TeskaLabs Ltd',
 	author_email='info@teskalabs.com',
@@ -66,6 +72,7 @@ setup(
 		'Programming Language :: Python :: 3.10',
 		'Programming Language :: Python :: 3.11',
 		'Programming Language :: Python :: 3.12',
+		'Programming Language :: Python :: 3.13',
 	],
 	keywords='asyncio',
 	packages=find_packages(exclude=['module_sample']),
@@ -79,13 +86,13 @@ setup(
 		'PyYAML>=6.0,<7',
 	],
 	extras_require={
-		'git': 'pygit2<1.12',  # For Alpine 3.16 / Python 3.10, use pygit2>=1.9,<1.10
-		'encryption': 'cryptography',
-		'authz': 'jwcrypto==1.5.6',
-		'monitoring': "sentry-sdk==1.45.0"
+		'git': ['pygit2<1.12'],
+		'encryption': ['cryptography'],
+		'authz': ['jwcrypto==1.5.6'],
+		'monitoring': ['sentry-sdk==1.45.0']
 	},
 	cmdclass={
-		'build_py': custom_build_py,
+		'build_py': CustomBuildPy,
 	},
 	scripts=[
 		'asab-manifest.py'


### PR DESCRIPTION
- Added support for Python 3.12 and 3.13
- CI/CD checkout is done with `fetch-depth: 0` to ensure git tags are available.
- Deprecated `python setup.py install` replaced with `pip install .`.
- custom_build_py should be a class.