### PR TITLE
Removing exclusion for HEAD calls (tenant assignments)

### DIFF
--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -160,10 +160,6 @@ class TenantService(Service):
 			if not inspect.iscoroutinefunction(route.handler):
 				continue
 
-			# Skip HEAD requests
-			if route.method == "HEAD":
-				continue
-
 			try:
 				set_handler_tenant(self, route)
 			except Exception as e:


### PR DESCRIPTION
@byewokko - please explain why that `if` is present.

It is causing problems when GET call is replaced by HEAD.

I propose to remove this if, unless there is a clear reason for that.
It causes monitoring (and likely more stuff) to broke.