### PR TITLE
Fix the interaction of auth and tenant modules

### DIFF
--- a/asab/config.py
+++ b/asab/config.py
@@ -114,6 +114,14 @@ class ConfigParser(configparser.ConfigParser):
 			"run_at_startup": "no",
 		},
 
+		"tenants": {
+			# Whitespace/comma-separated list of tenant IDs
+			"ids": "",
+
+			# Web URL that provides a JSON array of tenant ID strings
+			"tenant_url": "",
+		},
+
 		"auth": {
 			# URL location containing the authorization server's public JWK keys
 			# (often found at "/.well-known/jwks.json")
@@ -127,7 +135,7 @@ class ConfigParser(configparser.ConfigParser):
 			# - custom mock user info can supplied in a JSON file.
 			# "enabled": "yes",
 			"mock_user_info_path": "/conf/mock-userinfo.json",
-		}
+		},
 	}
 
 	if 'ASAB_ZOOKEEPER_SERVERS' in os.environ:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -226,6 +226,7 @@ class AuthService(Service):
 
 		tenant_wrapper_idx = tenant_service.get_web_wrapper_position(web_container)
 		if tenant_wrapper_idx is not None:
+			# Tenant wrapper is present - Auth wrapper must be applied before it
 			web_container.WebApp.on_startup.insert(tenant_wrapper_idx, self.set_up_auth_web_wrapper)
 		else:
 			web_container.WebApp.on_startup.append(self.set_up_auth_web_wrapper)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -554,8 +554,10 @@ class AuthService(Service):
 			# Ensure the wrappers are applied in the correct order
 			tenant_wrapper_idx = tenant_service.get_web_wrapper_position(web_container)
 			if tenant_wrapper_idx is not None and auth_wrapper_idx > tenant_wrapper_idx:
-				raise RuntimeError(
-					"TenantService.install(web_container) must be called before AuthService.install(web_container)")
+				L.error(
+					"TenantService.install(web_container) must be called before AuthService.install(web_container). "
+					"Otherwise authorization will not work properly."
+				)
 
 		if not auth_wrapper_installed:
 			L.warning(

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -211,13 +211,13 @@ class AuthService(Service):
 		# Check that the middleware has not been installed yet
 		if self.set_up_auth_web_wrapper in web_container.WebApp.on_startup:
 			if len(web_service.Containers) == 1:
-				raise Exception(
+				raise RuntimeError(
 					"WebContainer has authorization middleware installed already. "
 					"You don't need to call `AuthService.install()` in applications with a single WebContainer; "
 					"it is called automatically at init time."
 				)
 			else:
-				raise Exception("WebContainer has authorization middleware installed already.")
+				raise RuntimeError("WebContainer has authorization middleware installed already.")
 
 		tenant_service = self.App.get_service("asab.TenantService")
 		if tenant_service is None:
@@ -554,7 +554,7 @@ class AuthService(Service):
 			# Ensure the wrappers are applied in the correct order
 			tenant_wrapper_idx = tenant_service.get_web_wrapper_position(web_container)
 			if tenant_wrapper_idx is not None and auth_wrapper_idx > tenant_wrapper_idx:
-				raise Exception(
+				raise RuntimeError(
 					"TenantService.install(web_container) must be called before AuthService.install(web_container)")
 
 		if not auth_wrapper_installed:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -581,7 +581,7 @@ class AuthService(Service):
 		web_container = web_service.WebContainer
 
 		self.install(web_container)
-		L.info("WebContainer authorization installed automatically.")
+		L.debug("WebContainer authorization wrapper will be installed automatically.")
 
 
 def _get_id_token_claims(bearer_token: str, auth_server_public_key):

--- a/asab/web/tenant/providers/static.py
+++ b/asab/web/tenant/providers/static.py
@@ -29,7 +29,7 @@ class StaticTenantProvider(TenantProviderABC):
 			self.Tenants.add(tenant_id)
 
 		if len(self.Tenants) > 0:
-			L.info("Static tenants loaded from config.")
+			L.debug("Static tenants loaded from config.")
 			self.App.PubSub.publish("Tenants.change!")
 
 	def get_tenants(self) -> typing.Set[str]:

--- a/asab/web/tenant/providers/static.py
+++ b/asab/web/tenant/providers/static.py
@@ -1,7 +1,10 @@
 import re
 import typing
+import logging
 
 from .abc import TenantProviderABC
+
+L = logging.getLogger(__name__)
 
 
 class StaticTenantProvider(TenantProviderABC):
@@ -26,6 +29,7 @@ class StaticTenantProvider(TenantProviderABC):
 			self.Tenants.add(tenant_id)
 
 		if len(self.Tenants) > 0:
+			L.info("Static tenants loaded from config.")
 			self.App.PubSub.publish("Tenants.change!")
 
 	def get_tenants(self) -> typing.Set[str]:

--- a/asab/web/tenant/providers/web.py
+++ b/asab/web/tenant/providers/web.py
@@ -46,6 +46,6 @@ class WebTenantProvider(TenantProviderABC):
 
 		new_tenants = set(external_tenants)
 		if self.Tenants != new_tenants:
-			L.info("Tenants from URL updated.", struct_data={"url": self.TenantUrl})
+			L.debug("Tenants from URL updated.", struct_data={"url": self.TenantUrl})
 			self.Tenants = new_tenants
 			self.App.PubSub.publish("Tenants.change!")

--- a/asab/web/tenant/providers/web.py
+++ b/asab/web/tenant/providers/web.py
@@ -46,5 +46,6 @@ class WebTenantProvider(TenantProviderABC):
 
 		new_tenants = set(external_tenants)
 		if self.Tenants != new_tenants:
+			L.info("Tenants from URL updated.", struct_data={"url": self.TenantUrl})
 			self.Tenants = new_tenants
 			self.App.PubSub.publish("Tenants.change!")

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -54,6 +54,12 @@ class TenantService(Service):
 
 
 	async def initialize(self, app):
+		if len(self.Providers) == 0:
+			raise RuntimeError(
+				"TenantService requires at least one provider. "
+				"Specify either `tenant_url` or `ids` in the [tenants] config section."
+			)
+
 		for provider in self.Providers:
 			await provider.initialize(app)
 		print(self.Tenants)

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -159,7 +159,7 @@ class TenantService(Service):
 		web_container = web_service.WebContainer
 
 		self.install(web_container)
-		L.info("WebContainer tenant context wrapper will be installed automatically.")
+		L.debug("WebContainer tenant wrapper will be installed automatically.")
 
 
 	async def _set_up_tenant_web_wrapper(self, aiohttp_app: aiohttp.web.Application):

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -15,17 +15,6 @@ L = logging.getLogger(__name__)
 #
 
 
-Config.add_defaults({
-	"tenants": {
-		# List of tenant IDs, entries can be separated by comma or newline
-		"ids": "",
-
-		# URL that provides a JSON array of tenant IDs
-		"tenant_url": "",
-	}
-})
-
-
 class TenantService(Service):
 	"""
 	Provides set of known tenants and tenant extraction for web requests.
@@ -67,6 +56,7 @@ class TenantService(Service):
 	async def initialize(self, app):
 		for provider in self.Providers:
 			await provider.initialize(app)
+		print(self.Tenants)
 
 
 	@property

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -55,14 +55,13 @@ class TenantService(Service):
 
 	async def initialize(self, app):
 		if len(self.Providers) == 0:
-			raise RuntimeError(
+			raise L.error(
 				"TenantService requires at least one provider. "
 				"Specify either `tenant_url` or `ids` in the [tenants] config section."
 			)
 
 		for provider in self.Providers:
 			await provider.initialize(app)
-		print(self.Tenants)
 
 
 	@property

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -55,7 +55,7 @@ class TenantService(Service):
 
 	async def initialize(self, app):
 		if len(self.Providers) == 0:
-			raise L.error(
+			L.error(
 				"TenantService requires at least one provider. "
 				"Specify either `tenant_url` or `ids` in the [tenants] config section."
 			)

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -136,6 +136,22 @@ class TenantService(Service):
 		web_container.WebApp.on_startup.append(self._set_up_tenant_web_wrapper)
 
 
+	def get_web_wrapper_position(self, web_container) -> typing.Optional[int]:
+		"""
+		Check if tenant web wrapper is installed in container and where.
+
+		Args:
+			web_container: Web container to inspect.
+
+		Returns:
+			typing.Optional[int]: The index at which the wrapper is located, or `None` if it is not installed.
+		"""
+		try:
+			return web_container.WebApp.on_startup.index(self._set_up_tenant_web_wrapper)
+		except ValueError:
+			return None
+
+
 	def _try_auto_install(self):
 		"""
 		If there is exactly one web container, install tenant middleware on it.

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -101,6 +101,9 @@ class TenantService(Service):
 		"""
 		if tenant is None:
 			return False
+		if len(self.Providers) == 0:
+			L.warning("No tenant provider registered.")
+			return False
 		for provider in self.Providers:
 			if provider.is_tenant_known(tenant):
 				return True

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -36,7 +36,7 @@ class TenantService(Service):
 
 		auth_svc = self.App.get_service("asab.AuthService")
 		if auth_svc is not None:
-			raise Exception("Please initialize TenantService BEFORE AuthService.")
+			raise RuntimeError("Please initialize TenantService before AuthService.")
 
 		self._prepare_providers()
 		if auto_install_web_wrapper:
@@ -121,13 +121,13 @@ class TenantService(Service):
 		for middleware in web_container.WebApp.on_startup:
 			if middleware == self._set_up_tenant_web_wrapper:
 				if len(web_service.Containers) == 1:
-					raise Exception(
+					raise RuntimeError(
 						"WebContainer has tenant middleware installed already. "
 						"You don't need to call `TenantService.install()` in applications with a single WebContainer; "
 						"it is called automatically at init time."
 					)
 				else:
-					raise Exception("WebContainer has tenant middleware installed already.")
+					raise RuntimeError("WebContainer has tenant middleware installed already.")
 
 		web_container.WebApp.on_startup.append(self._set_up_tenant_web_wrapper)
 
@@ -175,6 +175,6 @@ class TenantService(Service):
 			try:
 				set_handler_tenant(self, route)
 			except Exception as e:
-				raise Exception(
+				raise RuntimeError(
 					"Failed to initialize tenant context for handler {!r}.".format(route.handler.__qualname__)
 				) from e

--- a/asab/web/tenant/utils.py
+++ b/asab/web/tenant/utils.py
@@ -68,6 +68,7 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 
 		if tenant is None:
 			if not (hasattr(handler, "AllowNoTenant") and handler.AllowNoTenant is True):
+				L.warning("URL contains no `tenant` parameter.")
 				raise aiohttp.web.HTTPNotFound(reason="Tenant not found.")
 			else:
 				# `None` is allowed: Tenant is optional at this endpoint.

--- a/asab/web/tenant/utils.py
+++ b/asab/web/tenant/utils.py
@@ -37,7 +37,7 @@ def set_handler_tenant(tenant_service, route: aiohttp.web.AbstractRoute):
 
 def _pass_tenant(tenant_service, handler):
 	"""
-	Add tenant to the handler arguments
+	Pass tenant from Tenant context variable to web handler as an argument.
 	"""
 	@functools.wraps(handler)
 	async def wrapper(*args, **kwargs):
@@ -46,6 +46,9 @@ def _pass_tenant(tenant_service, handler):
 		if tenant is None:
 			if not (hasattr(handler, "AllowNoTenant") and handler.AllowNoTenant is True):
 				raise aiohttp.web.HTTPNotFound(reason="Tenant not found.")
+			else:
+				# `None` is allowed: Tenant is optional at this endpoint.
+				pass
 
 		elif not tenant_service.is_tenant_known(tenant):
 			L.warning("Tenant not found.", struct_data={"tenant": tenant})
@@ -66,6 +69,9 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 		if tenant is None:
 			if not (hasattr(handler, "AllowNoTenant") and handler.AllowNoTenant is True):
 				raise aiohttp.web.HTTPNotFound(reason="Tenant not found.")
+			else:
+				# `None` is allowed: Tenant is optional at this endpoint.
+				pass
 
 		elif not tenant_service.is_tenant_known(tenant):
 			L.warning("Tenant not found.", struct_data={"tenant": tenant})

--- a/examples/web-auth.py
+++ b/examples/web-auth.py
@@ -14,6 +14,12 @@ if "web" not in asab.Config:
 		"listen": "8080"
 	}
 
+if "tenants" not in asab.Config:
+	asab.Config["tenants"] = {
+		# Define known tenants
+		"ids": "default brothers-workspace big-corporation"
+	}
+
 if "auth" not in asab.Config:
 	asab.Config["auth"] = {
 		# Enable all authentication and authorization, or switch into MOCK mode.
@@ -30,7 +36,7 @@ if "auth" not in asab.Config:
 
 		# URL of the authorization server's JWK public keys, used for ID token verification.
 		# This option is ignored in mock mode or when authorization is disabled.
-		"public_keys_url": "http://localhost:3081/.well-known/jwks.json",
+		# "public_keys_url": "http://localhost:3081/.well-known/jwks.json",
 	}
 
 


### PR DESCRIPTION
# Changes
- Restore the functionality of `@allow_no_tenant` decorator.
- Fix auth and tenant web wrapper order checks.
- Tenant service requires at least one tenant provider to be configured (a list of tenant ids, URL with tenant ids, or both). If there is no provider at the async stage of initialization, tenant service logs an error:
```
04-Dec-2024 14:42:50.849680 ERROR asab.web.tenant.service TenantService requires at least one provider. 
  Specify either `tenant_url` or `ids` in the [tenants] config section.
```

# Refactoring
- Tenant service config defaults moved to `asab.config`.