### PR TITLE
ASAB API must require no tenant

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -11,6 +11,7 @@ import typing
 
 from .doc_templates import SWAGGER_OAUTH_PAGE, SWAGGER_DOC_PAGE
 from ..web.auth import noauth
+from ..web.tenant import allow_no_tenant
 
 
 ##
@@ -226,6 +227,7 @@ class DocWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	# This is the web request handler
 	async def doc(self, request):
 		"""
@@ -250,6 +252,7 @@ class DocWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def oauth2_redirect(self, request):
 		"""
 		Required for the authorization to work.
@@ -261,6 +264,7 @@ class DocWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def openapi(self, request):
 		"""
 		Download OpenAPI (version 3) API documentation (aka Swagger) in YAML.

--- a/asab/api/log.py
+++ b/asab/api/log.py
@@ -7,6 +7,7 @@ import aiohttp
 from ..web.rest.json import json_response
 from ..log import LOG_NOTICE
 from ..web.auth import noauth
+from ..web.tenant import allow_no_tenant
 
 ##
 
@@ -86,6 +87,7 @@ class WebApiLoggingHandler(logging.Handler):
 
 
 	@noauth
+	@allow_no_tenant
 	async def get_logs(self, request):
 		'''
 		Get logs.
@@ -97,6 +99,7 @@ class WebApiLoggingHandler(logging.Handler):
 
 
 	@noauth
+	@allow_no_tenant
 	async def ws(self, request):
 		'''
 		# Live feed of logs over websocket

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -5,6 +5,7 @@ import aiohttp.web
 from .. import Config
 from ..web.rest import json_response
 from ..web.auth import noauth
+from ..web.tenant import allow_no_tenant
 
 
 class APIWebHandler(object):
@@ -25,6 +26,7 @@ class APIWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def changelog(self, request):
 		"""
 		It returns a change log file.
@@ -42,6 +44,7 @@ class APIWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def manifest(self, request):
 		"""
 		It returns the manifest of the ASAB service.
@@ -70,6 +73,7 @@ class APIWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def environ(self, request):
 		"""
 		It returns a JSON response containing the contents of the environment variables.
@@ -92,6 +96,7 @@ class APIWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def config(self, request):
 		"""
 		It returns the JSON with the config of the ASAB service.

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -6,6 +6,7 @@ import datetime
 from .openmetric import metric_to_openmetric
 from ..web.rest import json_response
 from ..web.auth import noauth
+from ..web.tenant import allow_no_tenant
 
 
 class MetricWebHandler(object):
@@ -21,6 +22,7 @@ class MetricWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def metrics_json(self, request):
 		'''
 		Get metrics in a JSON.
@@ -32,6 +34,7 @@ class MetricWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def metrics(self, request):
 		'''
 		Produce the OpenMetrics output.
@@ -58,6 +61,7 @@ class MetricWebHandler(object):
 
 
 	@noauth
+	@allow_no_tenant
 	async def watch(self, request):
 		"""
 		Endpoint to list ASAB metrics in the command line.


### PR DESCRIPTION
# Fix
- `@allow_no_tenant` added to `/asab/v1/` handlers, since they are tenant-agnostic.