### PR TITLE
Rename closures named "wrapper" to be more specific

### DIFF
--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -68,7 +68,7 @@ def noauth(handler):
 	handler.NoAuth = True
 
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def noauth_wrapper(*args, **kwargs):
 		return await handler(*args, **kwargs)
 
-	return wrapper
+	return noauth_wrapper

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -32,7 +32,7 @@ def require(*resources):
 	def decorator_require(handler):
 
 		@functools.wraps(handler)
-		async def wrapper(*args, **kwargs):
+		async def _require_wrapper(*args, **kwargs):
 			authz = Authz.get()
 			if authz is None:
 				raise AccessDeniedError()
@@ -41,7 +41,7 @@ def require(*resources):
 
 			return await handler(*args, **kwargs)
 
-		return wrapper
+		return _require_wrapper
 
 	return decorator_require
 
@@ -68,7 +68,7 @@ def noauth(handler):
 	handler.NoAuth = True
 
 	@functools.wraps(handler)
-	async def noauth_wrapper(*args, **kwargs):
+	async def _noauth_wrapper(*args, **kwargs):
 		return await handler(*args, **kwargs)
 
-	return noauth_wrapper
+	return _noauth_wrapper

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -29,10 +29,10 @@ def require(*resources):
 		return asab.web.rest.json_response(request, data)
 	```
 	"""
-	def decorator_require(handler):
+	def _require_resource_access_decorator(handler):
 
 		@functools.wraps(handler)
-		async def _require_wrapper(*args, **kwargs):
+		async def _require_resource_access_wrapper(*args, **kwargs):
 			authz = Authz.get()
 			if authz is None:
 				raise AccessDeniedError()
@@ -41,9 +41,9 @@ def require(*resources):
 
 			return await handler(*args, **kwargs)
 
-		return _require_wrapper
+		return _require_resource_access_wrapper
 
-	return decorator_require
+	return _require_resource_access_decorator
 
 
 def noauth(handler):

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -413,7 +413,7 @@ class AuthService(Service):
 		Extract the token claims into Authorization context so that they can be used for authorization checks.
 		"""
 		@functools.wraps(handler)
-		async def authorize_wrapper(*args, **kwargs):
+		async def _authorize_request_wrapper(*args, **kwargs):
 			request = args[-1]
 
 			bearer_token = await self.get_bearer_token_from_authorization_header(request)
@@ -430,7 +430,7 @@ class AuthService(Service):
 			finally:
 				Authz.reset(authz_ctx)
 
-		return authorize_wrapper
+		return _authorize_request_wrapper
 
 
 	async def set_up_auth_web_wrapper(self, aiohttp_app: aiohttp.web.Application):
@@ -645,10 +645,10 @@ def _pass_user_info(handler):
 	Add user info to the handler arguments
 	"""
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def _pass_user_info_wrapper(*args, **kwargs):
 		authz = Authz.get(None)
 		return await handler(*args, user_info=authz.user_info() if authz is not None else None, **kwargs)
-	return wrapper
+	return _pass_user_info_wrapper
 
 
 def _pass_resources(handler):
@@ -656,7 +656,7 @@ def _pass_resources(handler):
 	Add resources to the handler arguments
 	"""
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def _pass_resources_wrapper(*args, **kwargs):
 		authz = Authz.get(None)
 		return await handler(*args, resources=authz.authorized_resources() if authz is not None else None, **kwargs)
-	return wrapper
+	return _pass_resources_wrapper

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -554,8 +554,10 @@ class AuthService(Service):
 			# Ensure the wrappers are applied in the correct order
 			tenant_wrapper_idx = tenant_service.get_web_wrapper_position(web_container)
 			if tenant_wrapper_idx is not None and auth_wrapper_idx > tenant_wrapper_idx:
-				raise RuntimeError(
-					"TenantService.install(web_container) must be called before AuthService.install(web_container)")
+				L.error(
+					"TenantService.install(web_container) must be called before AuthService.install(web_container). "
+					"Otherwise authorization will not work properly."
+				)
 
 		if not auth_wrapper_installed:
 			L.warning(

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -413,7 +413,7 @@ class AuthService(Service):
 		Extract the token claims into Authorization context so that they can be used for authorization checks.
 		"""
 		@functools.wraps(handler)
-		async def wrapper(*args, **kwargs):
+		async def authorize_wrapper(*args, **kwargs):
 			request = args[-1]
 
 			bearer_token = await self.get_bearer_token_from_authorization_header(request)
@@ -430,7 +430,7 @@ class AuthService(Service):
 			finally:
 				Authz.reset(authz_ctx)
 
-		return wrapper
+		return authorize_wrapper
 
 
 	async def set_up_auth_web_wrapper(self, aiohttp_app: aiohttp.web.Application):

--- a/asab/web/tenant/decorator.py
+++ b/asab/web/tenant/decorator.py
@@ -14,7 +14,7 @@ def allow_no_tenant(handler):
 	handler.AllowNoTenant = True
 
 	@functools.wraps(handler)
-	async def allow_no_tenant_wrapper(*args, **kwargs):
+	async def _allow_no_tenant_wrapper(*args, **kwargs):
 		return await handler(*args, **kwargs)
 
-	return allow_no_tenant_wrapper
+	return _allow_no_tenant_wrapper

--- a/asab/web/tenant/decorator.py
+++ b/asab/web/tenant/decorator.py
@@ -14,7 +14,7 @@ def allow_no_tenant(handler):
 	handler.AllowNoTenant = True
 
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def allow_no_tenant_wrapper(*args, **kwargs):
 		return await handler(*args, **kwargs)
 
-	return wrapper
+	return allow_no_tenant_wrapper

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -55,14 +55,13 @@ class TenantService(Service):
 
 	async def initialize(self, app):
 		if len(self.Providers) == 0:
-			raise RuntimeError(
+			L.error(
 				"TenantService requires at least one provider. "
 				"Specify either `tenant_url` or `ids` in the [tenants] config section."
 			)
 
 		for provider in self.Providers:
 			await provider.initialize(app)
-		print(self.Tenants)
 
 
 	@property

--- a/asab/web/tenant/utils.py
+++ b/asab/web/tenant/utils.py
@@ -40,7 +40,7 @@ def _pass_tenant(tenant_service, handler):
 	Pass tenant from Tenant context variable to web handler as an argument.
 	"""
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def _pass_tenant_wrapper(*args, **kwargs):
 		tenant = Tenant.get()
 
 		if tenant is None:
@@ -54,7 +54,7 @@ def _pass_tenant(tenant_service, handler):
 			L.warning("Tenant not found.", struct_data={"tenant": tenant})
 			raise aiohttp.web.HTTPNotFound(reason="Tenant not found.")
 		return await handler(*args, tenant=tenant, **kwargs)
-	return wrapper
+	return _pass_tenant_wrapper
 
 
 def _set_tenant_context_from_url_query(tenant_service, handler):
@@ -62,7 +62,7 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 	Extract tenant from request query and add it to context
 	"""
 	@functools.wraps(handler)
-	async def tenant_context_from_url_query_wrapper(*args, **kwargs):
+	async def _tenant_context_from_url_query_wrapper(*args, **kwargs):
 		request = args[-1]
 		tenant = request.query.get("tenant")
 
@@ -85,7 +85,7 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 
 		return response
 
-	return tenant_context_from_url_query_wrapper
+	return _tenant_context_from_url_query_wrapper
 
 
 def _set_tenant_context_from_url_path(tenant_service, handler):
@@ -93,7 +93,7 @@ def _set_tenant_context_from_url_path(tenant_service, handler):
 	Extract tenant from request URL path and add it to context
 	"""
 	@functools.wraps(handler)
-	async def tenant_context_from_url_path_wrapper(*args, **kwargs):
+	async def _tenant_context_from_url_path_wrapper(*args, **kwargs):
 		request = args[-1]
 		tenant = request.match_info["tenant"]
 
@@ -109,7 +109,7 @@ def _set_tenant_context_from_url_path(tenant_service, handler):
 
 		return response
 
-	return tenant_context_from_url_path_wrapper
+	return _tenant_context_from_url_path_wrapper
 
 
 def _get_route_handler_args(route):

--- a/asab/web/tenant/utils.py
+++ b/asab/web/tenant/utils.py
@@ -68,6 +68,7 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 
 		if tenant is None:
 			if not (hasattr(handler, "AllowNoTenant") and handler.AllowNoTenant is True):
+				L.warning("URL contains no `tenant` parameter.")
 				raise aiohttp.web.HTTPNotFound(reason="Tenant not found.")
 			else:
 				# `None` is allowed: Tenant is optional at this endpoint.

--- a/asab/web/tenant/utils.py
+++ b/asab/web/tenant/utils.py
@@ -62,7 +62,7 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 	Extract tenant from request query and add it to context
 	"""
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def tenant_context_from_url_query_wrapper(*args, **kwargs):
 		request = args[-1]
 		tenant = request.query.get("tenant")
 
@@ -85,7 +85,7 @@ def _set_tenant_context_from_url_query(tenant_service, handler):
 
 		return response
 
-	return wrapper
+	return tenant_context_from_url_query_wrapper
 
 
 def _set_tenant_context_from_url_path(tenant_service, handler):
@@ -93,7 +93,7 @@ def _set_tenant_context_from_url_path(tenant_service, handler):
 	Extract tenant from request URL path and add it to context
 	"""
 	@functools.wraps(handler)
-	async def wrapper(*args, **kwargs):
+	async def tenant_context_from_url_path_wrapper(*args, **kwargs):
 		request = args[-1]
 		tenant = request.match_info["tenant"]
 
@@ -109,7 +109,7 @@ def _set_tenant_context_from_url_path(tenant_service, handler):
 
 		return response
 
-	return wrapper
+	return tenant_context_from_url_path_wrapper
 
 
 def _get_route_handler_args(route):


### PR DESCRIPTION
Improve traceback experience by replacing the generic name `wrapper` by more specific names.