### PR TITLE
Small logging and docstring improvements in Library, ZooKeeper

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -417,24 +417,30 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				try:
 					await do_check_path(actual_path=path)
 				except Exception as e:
-					L.error("Failed to process library change for path {!r}: '{}'".format(path, e))
+					L.error(
+						"Failed to process library changes: '{}'".format(e),
+						struct_data={"path": path},
+					)
 
 			elif target == "tenant":
 				for tenant in await self._get_tenants():
 					try:
 						await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
 					except Exception as e:
-						L.error("Failed to process library change for path {!r} in tenant {!r}: '{}'".format(
-							path, tenant, e))
+						L.error(
+							"Failed to process library changes: '{}'".format(e),
+							struct_data={"path": path, "tenant": tenant},
+						)
 
 			elif isinstance(target, tuple) and len(target) == 2 and target[0] == "tenant":
 				tenant = target[1]
 				try:
 					await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
 				except Exception as e:
-					L.error("Failed to process library change for path {!r} in tenant {!r}: '{}'".format(
-						path, tenant, e))
-
+					L.error(
+						"Failed to process library changes: '{}'".format(e),
+						struct_data={"path": path, "tenant": tenant},
+					)
 			else:
 				raise ValueError("Unexpected target: {!r}".format((target, path)))
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -175,21 +175,18 @@ class LibraryService(Service):
 			L.log(LOG_NOTICE, "is NOT ready.", struct_data={'name': self.Name})
 			self.App.PubSub.publish("Library.not_ready!", self)
 
-	async def find(self, path: str) -> typing.Optional[typing.List[str]]:
+	async def find(self, path: str) -> typing.List[str]:
 		"""
-		Searches for files with a specific name within a library, using the provided path.
+		Search for files with a specific name within a library, using the provided path.
 
 		The method traverses the library directories, looking for files that match the given filename.
-		It returns a list of paths leading to these files, or `None` if no such files are found.
+		It returns a list of paths leading to these files, empty if no items are found.
 
 		Args:
-			path (str): The path specifying the filename and its location within the library.
-						The path should start with a forward slash and include the filename.
-						Example: '/library/Templates/.setup.yaml'
+			path (str): Location of the file in Library. It must start with a forward slash and include the filename. Example: '/Dashboards/Cisco/Overview.json'
 
 		Returns:
-			typing.Optional[typing.List[str]]: A list containing the paths to the found files,
-											`or an `empty list` if no files are found that match the filename.
+			typing.List[str]: A list of paths to the found files. If no files are found, the list will be empty.
 		"""
 		_validate_path_item(path)
 
@@ -198,7 +195,6 @@ class LibraryService(Service):
 			found_files = await library.find(path)
 			if found_files:
 				results.extend(found_files)
-
 		return results
 
 	async def read(self, path: str) -> typing.Optional[typing.IO]:

--- a/asab/pubsub.py
+++ b/asab/pubsub.py
@@ -102,7 +102,7 @@ class PubSub(object):
 		"""
 		callback_list = self.Subscribers.get(message_type)
 		if callback_list is None:
-			L.warning("Message type subscription '{}'' not found.".format(message_type))
+			L.warning("Message type subscription '{}' not found.".format(message_type))
 			return
 
 		remove_list = None
@@ -123,7 +123,7 @@ class PubSub(object):
 				break
 
 		else:
-			L.warning("Subscriber '{}'' not found for the message type '{}'.".format(message_type, callback))
+			L.warning("Subscriber '{}' not found for the message type '{}'.".format(message_type, callback))
 
 		if remove_list is not None:
 			for callback_ref in remove_list:

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -139,9 +139,9 @@ class ZooKeeperContainer(Configurable):
 		'''
 		if state == kazoo.protocol.states.KazooState.CONNECTED:
 			self.App.Loop.call_soon_threadsafe(self.ZooKeeper.Client.ensure_path, self.Path)
-			L.log(LOG_NOTICE, "Connected to ZooKeeper")
+			L.log(LOG_NOTICE, "Connected to ZooKeeper.")
 		else:
-			L.warning("ZooKeeper connection state changed", struct_data={"state": str(state)})
+			L.warning("ZooKeeper connection state changed.", struct_data={"state": str(state)})
 
 		self.App.PubSub.publish_threadsafe("ZooKeeperContainer.state/{}!".format(state), self)
 


### PR DESCRIPTION
- When library changes are not processed, path and tenant are in struct data now.
- Method `asab.library.LibraryService.find()` has corrected a misleading docstring - the function always returns a list.