### PR TITLE
Swagger: Fix duplicate path parameters

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -89,7 +89,7 @@ class DocWebHandler(object):
 				continue
 
 			# Determine which routes are asab-based
-			if re.search("(asab|doc|oauth2-redirect.html)", self.get_route_path(route)):
+			if re.search("(asab|doc|oauth2-redirect.html|bspump)", self.get_route_path(route)):
 				asab_routes.append(self.parse_route_data(route))
 			else:
 				routes.append(self.parse_route_data(route))

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -139,7 +139,8 @@ class DocWebHandler(object):
 		if docstring_yaml is not None:
 			route_data.update(docstring_yaml)
 
-		for path_parameter in extract_path_parameters(route):
+		# Find all path parameters, add them if not specified in docstring.
+		for path_parameter in get_path_parameters(route):
 			if path_parameter.get("name") is not None:
 				if path_parameter["name"] not in [r["name"] for r in route_data["parameters"]]:
 					route_data["parameters"].append(path_parameter)
@@ -297,9 +298,9 @@ def get_docstring_description(docstring: typing.Optional[str]) -> str:
 	return description
 
 
-def extract_path_parameters(route) -> list:
+def get_path_parameters(route) -> list:
 	"""
-	Take a single route and return its parameters.
+	Return path parameters of a route.
 	"""
 	parameters: list = []
 	route_info = route.get_info()

--- a/asab/api/log.py
+++ b/asab/api/log.py
@@ -89,11 +89,50 @@ class WebApiLoggingHandler(logging.Handler):
 	@noauth
 	@allow_no_tenant
 	async def get_logs(self, request):
-		'''
+		"""
 		Get logs.
 		---
 		tags: ['asab.log']
-		'''
+
+		responses:
+			"200":
+				description: Logs.
+				content:
+					application/json:
+						schema:
+							type: array
+							items:
+								type: object
+								properties:
+									t:
+										type: string
+										description: Time when the log was emitted.
+										example: 2024-12-10T14:28:53.421079Z
+									C:
+										type: string
+										description: Class that produced the log.
+										example: myapp.myservice.service
+									M:
+										type: string
+										description: Log message.
+										example: Periodic check finished.
+									l:
+										type: int
+										example: 6
+										oneOf:
+										-	title: Alert
+											const: 1
+										-	title: Critical
+											const: 2
+										-	title: Error
+											const: 3
+										-	title: Warning
+											const: 4
+										-	title: Notice
+											const: 5
+										-	title: Info
+											const: 6
+		"""
 
 		return json_response(request, self.Buffer)
 

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -29,7 +29,7 @@ class APIWebHandler(object):
 	@allow_no_tenant
 	async def changelog(self, request):
 		"""
-		It returns a change log file.
+		Get changelog file.
 		---
 		tags: ['asab.api']
 		"""
@@ -47,23 +47,29 @@ class APIWebHandler(object):
 	@allow_no_tenant
 	async def manifest(self, request):
 		"""
-		It returns the manifest of the ASAB service.
+		Get manifest of the ASAB service.
 
-		THe manifest is a JSON object loaded from `MANIFEST.json` file.
+		The manifest is a JSON object loaded from `MANIFEST.json` file.
 		The manifest contains the creation (build) time and the version of the ASAB service.
 		The `MANIFEST.json` is produced during the creation of docker image by `asab-manifest.py` script.
 
-		Example of `MANIFEST.json`:
-
-		```
-		{
-			'created_at': 2022-03-21T15:49:37.14000,
-			'version' :v22.9-4
-		}
-		```
-
 		---
 		tags: ['asab.api']
+
+		responses:
+			"200":
+				description: Manifest of the application.
+				content:
+					application/json:
+						schema:
+							type: object
+							properties:
+								created_at:
+									type: str
+									example: 2024-12-10T15:49:37.14000
+								version:
+									type: str
+									example: v24.50.01
 		"""
 
 		if self.ApiService.Manifest is None:
@@ -76,21 +82,30 @@ class APIWebHandler(object):
 	@allow_no_tenant
 	async def environ(self, request):
 		"""
-		It returns a JSON response containing the contents of the environment variables.
+		Get environment variables.
 
-		Example:
-
-		```
-		{
-			"LANG": "en_GB.UTF-8",
-			"SHELL": "/bin/zsh",
-			"HOME": "/home/foobar",
-		}
-
-		```
+		Get JSON response containing the contents of the environment variables.
 
 		---
 		tags: ['asab.api']
+
+		responses:
+			"200":
+				description: Environment variables.
+				content:
+					application/json:
+						schema:
+							type: object
+							properties:
+								LANG:
+									type: str
+									example: "en_GB.UTF-8"
+								SHELL:
+									type: str
+									example: "/bin/zsh"
+								HOME:
+									type: str
+									example: "/home/foobar"
 		"""
 		return json_response(request, dict(os.environ))
 
@@ -99,9 +114,11 @@ class APIWebHandler(object):
 	@allow_no_tenant
 	async def config(self, request):
 		"""
-		It returns the JSON with the config of the ASAB service.
+		Get configuration of the service.
 
-		IMPORTANT: All passwords are erased.
+		Return configuration of the ASAB service in JSON format.
+
+		**IMPORTANT: All passwords are erased.**
 
 		Example:
 
@@ -122,6 +139,15 @@ class APIWebHandler(object):
 
 		---
 		tags: ['asab.api']
+
+		responses:
+			"200":
+				description: Configuration of the service.
+				content:
+					application/json:
+						schema:
+							type: object
+							example: {"general": {"config_file": "", "tick_period": "1", "uid": "", "gid": ""}, "asab:metrics": {"native_metrics": "true", "expiration": "60"}}
 		"""
 
 		# Copy the config and erase all passwords


### PR DESCRIPTION
- Path parameters taken from path are not added if they are described in route docstring.
- The first line of docstring is not duplicated in **name** and **description**.
- *asab* and *bspump* endpoints are at the bottom.
- Enhanced description for asab endpoints.

Example of path parameter taken from docstring:
![image](https://github.com/user-attachments/assets/61c95543-cfa1-4bb5-acc9-78c31387d375)

Example of path parameter taken only from path :
![image](https://github.com/user-attachments/assets/8ce6d637-ce38-4807-b58b-e69dcaee82f6)

Example of sorted tags in bspump application:
![image](https://github.com/user-attachments/assets/e218c0f3-6ca0-4edb-b52b-985edceaf901)

Examples of asab endpoints:
![image](https://github.com/user-attachments/assets/5dfb431f-3839-4a87-9d51-f8aad0aad9ab)

![image](https://github.com/user-attachments/assets/8af501c5-ba16-4e45-a77b-1aa7e0606e4e)
