### PR TITLE
Zookeeper Provider for Tenants

### DIFF
--- a/asab/web/tenant/providers/__init__.py
+++ b/asab/web/tenant/providers/__init__.py
@@ -1,7 +1,9 @@
 from .static import StaticTenantProvider
 from .web import WebTenantProvider
+from .zookeeper import ZookeeperTenantProvider
 
 __all__ = [
 	"StaticTenantProvider",
 	"WebTenantProvider",
+	"ZookeeperTenantProvider"
 ]

--- a/asab/web/tenant/providers/zookeeper.py
+++ b/asab/web/tenant/providers/zookeeper.py
@@ -1,0 +1,70 @@
+import typing
+import logging
+
+from .abc import TenantProviderABC
+from ....zookeeper import ZooKeeperContainer
+
+
+L = logging.getLogger(__name__)
+
+
+class ZookeeperTenantProvider(TenantProviderABC):
+	def __init__(self, app, tenant_service, config):
+		super().__init__(app, tenant_service, config)
+		self.Tenants: typing.Set[str] = set()
+
+		# Initialize ZooKeeper Client
+		self.ZooKeeperService = self.App.get_service("asab.ZooKeeperService")
+		self.ZKPath = self.Config.get("zk_path")
+		self.ZookeeperContainer = ZooKeeperContainer(
+			self.ZooKeeperService,
+			config_section_name="zookeeper",
+			z_path=self.ZKPath
+		)
+		self.ZookeeperClient = self.ZookeeperContainer.ZooKeeper
+
+
+	async def get_tenants(self) -> typing.Set[str]:
+		return self.Tenants
+
+
+	async def is_tenant_known(self, tenant: str) -> bool:
+		return tenant in self.Tenants
+
+
+	async def update(self):
+		try:
+			zk_node_exists = await self.ZookeeperClient.exists(self.ZKPath)
+
+			if zk_node_exists:
+				external_tenants = await self.ZookeeperClient.get_children(self.ZKPath)
+				self._set_ready(True)  # Provider was checked => True
+
+			elif zk_node_exists is None:
+				L.warning(
+					"Failed to load tenants: zk node doesn't exist",
+					struct_data={"path": self.ZKPath}
+				)
+				self._set_ready(True)  # Provider was checked (no data in ZK) => True
+				return
+
+		except Exception as e:
+			self._set_ready(False)  # Failed to check the provider
+			L.exception(
+				"Failed to load tenants",
+				struct_data={
+					"class": e.__class__.__name__.__str__(),
+					"reason": str(e),
+					"path": self.ZKPath
+				}
+			)
+			return
+
+		new_tenants = set(external_tenants)
+		if self.Tenants != new_tenants:
+			L.debug("Tenants from Zookeeper updated", struct_data={"path": self.ZKPath})
+			self.Tenants = new_tenants
+			self.App.PubSub.publish("Tenants.change!")
+
+		if not self._IsReady:
+			self._set_ready(True)

--- a/asab/web/tenant/providers/zookeeper.py
+++ b/asab/web/tenant/providers/zookeeper.py
@@ -40,10 +40,8 @@ class ZookeeperTenantProvider(TenantProviderABC):
 				external_tenants = await self.ZookeeperClient.get_children(self.ZKPath)
 
 			elif zk_node_exists is None:
-				self.Tenants = set()  # Reset data from last iteration
-				self._set_ready(True)  # Provider was checked (no data in ZK) => True
+				external_tenants = set()  # To reset data from last iteration
 				L.debug("Found no tenants data: zk node doesn't exist", struct_data={"path": self.ZKPath})
-				return
 
 		except Exception as e:
 			self._set_ready(False)  # Failed to check the provider
@@ -64,4 +62,4 @@ class ZookeeperTenantProvider(TenantProviderABC):
 			self.App.PubSub.publish("Tenants.change!")
 
 		if not self._IsReady:
-			self._set_ready(True)  # Provider was checked => True
+			self._set_ready(True)  # Provider was checked (including no data in ZK) => True

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -76,6 +76,10 @@ class TenantService(Service):
 			from .providers import WebTenantProvider
 			self.Providers.append(WebTenantProvider(self.App, self, Config["tenants"]))
 
+		if Config.get("zookeeper", "servers", fallback=None):
+			from .providers import ZookeeperTenantProvider
+			self.Providers.append(ZookeeperTenantProvider(self.App, self, Config["tenants"]))
+
 
 	async def _every_five_minutes(self, message_type=None):
 		await self.update_tenants()

--- a/asab/web/tenant/service.py
+++ b/asab/web/tenant/service.py
@@ -76,7 +76,7 @@ class TenantService(Service):
 			from .providers import WebTenantProvider
 			self.Providers.append(WebTenantProvider(self.App, self, Config["tenants"]))
 
-		if Config.get("zookeeper", "servers", fallback=None):
+		if Config.get("tenants", "zk_path", fallback=None):
 			from .providers import ZookeeperTenantProvider
 			self.Providers.append(ZookeeperTenantProvider(self.App, self, Config["tenants"]))
 


### PR DESCRIPTION
Adds Zookeeper as the 3rd provider for `asab.TenantService`.
Returns Tenant IDs loaded from a dedicated ZK node.
Merge after this PR is ready and merged: https://github.com/TeskaLabs/asab/pull/652

This change will require:
- usual configuration in `[zookeeper]` section and
- an additional (new) configuration in `[tenants]` section:

```
[zookeeper]
servers=zookeeper-1:2181

[tenants]
zk_path=XXXXX
```