### PR TITLE
Mongo storage: If the object is new (version is 1), set the _c date to now

### DIFF
--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -196,10 +196,10 @@ class MongoDBUpsertor(UpsertorABC):
 			if ret.get('_v') == 1 and '_c' not in ret:
 				# If the object is new (version is 1), set the creation datetime
 				await coll.update_one(
-					{ id_name: ret[id_name] },
-					{ '$set': { '_c': ret['_m'] } }
+					{id_name: ret[id_name]},
+					{'$set': {'_c': ret['_m']}}
 				)
-			
+
 			self.ObjId = ret[id_name]
 
 		if self.Storage.WebhookURIs is not None:

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -174,7 +174,6 @@ class MongoDBUpsertor(UpsertorABC):
 		if self.Version is not None:
 			filtr['_v'] = int(self.Version)
 
-		# First wave (adding stuff)
 		if len(addobj) > 0:
 			coll = self.Storage.Database[self.Collection]
 			try:
@@ -194,6 +193,13 @@ class MongoDBUpsertor(UpsertorABC):
 				# Object might have been changed in the meantime
 				raise KeyError("NOT-FOUND")
 
+			if ret.get('_v') == 1 and '_c' not in ret:
+				# If the object is new (version is 1), set the creation datetime
+				await coll.update_one(
+					{ id_name: ret[id_name] },
+					{ '$set': { '_c': ret['_m'] } }
+				)
+			
 			self.ObjId = ret[id_name]
 
 		if self.Storage.WebhookURIs is not None:


### PR DESCRIPTION
If the object was created using Mongo `asab.storage` upsertor without a version, the `_c` attribute was not filled.
This MR changes that and `_c` is set when the object is created without that.