### PR TITLE
Protect ASAB API

### DIFF
--- a/asab/api/log.py
+++ b/asab/api/log.py
@@ -5,6 +5,7 @@ import datetime
 import aiohttp
 
 from ..web.rest.json import json_response
+from ..web.auth import require
 from ..log import LOG_NOTICE
 from ..web.auth import noauth
 from ..web.tenant import allow_no_tenant
@@ -12,6 +13,7 @@ from ..web.tenant import allow_no_tenant
 ##
 
 L = logging.getLogger(__name__)
+LOG_ACCESS_RESOURCE_ID = "asab:service:access"
 
 ##
 
@@ -86,7 +88,7 @@ class WebApiLoggingHandler(logging.Handler):
 			asyncio.ensure_future(self._send_ws(log_entry))
 
 
-	@noauth
+	@require(LOG_ACCESS_RESOURCE_ID)
 	@allow_no_tenant
 	async def get_logs(self, request):
 		"""
@@ -137,7 +139,7 @@ class WebApiLoggingHandler(logging.Handler):
 		return json_response(request, self.Buffer)
 
 
-	@noauth
+	@require(LOG_ACCESS_RESOURCE_ID)
 	@allow_no_tenant
 	async def ws(self, request):
 		'''

--- a/asab/api/log.py
+++ b/asab/api/log.py
@@ -5,9 +5,8 @@ import datetime
 import aiohttp
 
 from ..web.rest.json import json_response
-from ..web.auth import require
 from ..log import LOG_NOTICE
-from ..web.auth import noauth
+from ..web.auth import require
 from ..web.tenant import allow_no_tenant
 
 ##

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -15,8 +15,8 @@ class APIWebHandler(object):
 		self.ApiService = api_svc
 
 		# Add routes
-		webapp.router.add_get("/asab/v1/environ", self.environ)
-		webapp.router.add_get("/asab/v1/config", self.config)
+		# webapp.router.add_get("/asab/v1/environ", self.environ)  # Disabled for security reasons
+		# webapp.router.add_get("/asab/v1/config", self.config)  # Disabled for security reasons
 
 		webapp.router.add_get("/asab/v1/logs", log_handler.get_logs)
 		webapp.router.add_get("/asab/v1/logws", log_handler.ws)

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -4,7 +4,7 @@ import aiohttp.web
 
 from .. import Config
 from ..web.rest import json_response
-from ..web.auth import noauth
+from ..web.auth import noauth, require_superuser
 from ..web.tenant import allow_no_tenant
 
 
@@ -78,7 +78,7 @@ class APIWebHandler(object):
 		return json_response(request, self.ApiService.Manifest)
 
 
-	@noauth
+	@require_superuser
 	@allow_no_tenant
 	async def environ(self, request):
 		"""
@@ -110,7 +110,7 @@ class APIWebHandler(object):
 		return json_response(request, dict(os.environ))
 
 
-	@noauth
+	@require_superuser
 	@allow_no_tenant
 	async def config(self, request):
 		"""

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -16,6 +16,7 @@ class MetricWebHandler(object):
 		self.App = self.MetricsService.App
 
 		# Add routes
+		# TODO: Add access control (asab:service:access). Test with Prometheus first.
 		webapp.router.add_get("/asab/v1/metrics", self.metrics)
 		webapp.router.add_get("/asab/v1/watch_metrics", self.watch)
 		webapp.router.add_get("/asab/v1/metrics.json", self.metrics_json)

--- a/asab/web/auth/__init__.py
+++ b/asab/web/auth/__init__.py
@@ -1,4 +1,4 @@
-from .decorator import require, noauth
+from .decorator import require, require_superuser, noauth
 from .service import AuthService
 from .authorization import Authorization
 
@@ -6,5 +6,6 @@ __all__ = (
 	"AuthService",
 	"Authorization",
 	"require",
+	"require_superuser",
 	"noauth",
 )

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -46,6 +46,33 @@ def require(*resources):
 	return _require_resource_access_decorator
 
 
+def require_superuser(handler):
+	"""
+	Require that the request have authorized access to the superuser resource.
+	Requests without superuser access result in AccessDeniedError and consequently in an HTTP 403 response.
+
+	Examples:
+
+	```python
+	@asab.web.auth.require_superuser
+	async def get_confidential_info(self, request):
+		data = await self.service.get_confidential_info()
+		return asab.web.rest.json_response(request, data)
+	```
+	"""
+	@functools.wraps(handler)
+	async def _require_superuser_access_wrapper(*args, **kwargs):
+		authz = Authz.get()
+		if authz is None:
+			raise AccessDeniedError()
+
+		authz.require_superuser_access()
+
+		return await handler(*args, **kwargs)
+
+	return _require_superuser_access_wrapper
+
+
 def noauth(handler):
 	"""
 	Exempt the decorated handler from authentication and authorization.


### PR DESCRIPTION
- Implemented `@asab.web.auth.require_superuser` decorator.
- Some ASAB API endpoints now require authorization, while the sensitive ones have been disabled completely.

## ASAB API
### Core
- `/asab/v1/api/config` has been **disabled**.
- `/asab/v1/api/environ` has been **disabled**.
- `/asab/v1/api/manifest` is open.
- `/asab/v1/api/changelog` is open.

### Logs
- `/asab/v1/api/log` requires `asab:service:access` authorization.
- `/asab/v1/api/logws` requires `asab:service:access` authorization.

### OpenAPI and Swagger docs
- `/doc` is open.
- `/asab/v1/openapi` is open.
- `/oauth2-redirect.html` is open.

### Metrics
- `/asab/v1/api/metrics` is open*.
- `/asab/v1/api/watch_metrics` is open*.
- `/asab/v1/api/metrics.json` is open*.

*Metrics should be eventually protected (`asab:service:access`) but that would block Prometheus at the moment. I leave them open until client credentials grant is implemented in Seacat Auth.
