### PR TITLE
Add explicit delete metric method.

### DIFF
--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -118,7 +118,7 @@ class MetricsService(Service):
 
 		return now
 
-	async def _on_flushing_event(self, event_type):
+	async def _on_flushing_event(self, event_type=None):
 		if len(self.Metrics) == 0:
 			return
 

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -90,10 +90,16 @@ class MetricsService(Service):
 		"""
 		This method deletes an existing metric from the service.
 		It has similar signature to other "delete" methods within technologies built by TeskaLabs.
+
+		It is up to the user to call flush when needed.
 		"""
 		metric_name, metric_tags = self.MetricToNameAndTags[metric_obj]
 		self.Storage.delete(metric_name, metric_tags)
 		self.Metrics.remove(metric_obj)
+
+
+	async def flush(self):
+		await self._on_flushing_event()
 
 
 	def clear(self):

--- a/asab/metrics/storage.py
+++ b/asab/metrics/storage.py
@@ -13,6 +13,21 @@ class Storage(object):
 		self.Metrics = []
 
 
+	def delete(self, metric_name: str, tags: dict):
+
+		for i in range(len(self.Metrics) - 1, -1, -1):
+
+			metric = self.Metrics[i]
+
+			if metric_name != metric['name']:
+				continue
+
+			if tags != metric["static_tags"]:
+				continue
+
+			del self.Metrics[i]
+
+
 	def add(self, metric_name: str, tags: dict, reset: bool, help: str, unit: str):
 
 		for i in range(len(self.Metrics) - 1, -1, -1):

--- a/test/test_metrics/baseclass.py
+++ b/test/test_metrics/baseclass.py
@@ -58,7 +58,7 @@ class MockMetricsService(MetricsService):
 		metric._initialize_storage(
 			self.Storage.add(metric_name, tags=metric.StaticTags.copy(), reset=reset, help=help, unit=unit)
 		)
-		self.Metrics.append(metric)
+		self.Metrics.add(metric)
 
 	def _flush_metrics(self):
 		now = MockApplication().time() + 30  # This is to distinguish creation time from flush time


### PR DESCRIPTION
This MR adds an explicit delete method for metrics, so that other services can call it when they dispose of objects associated with the metrics (like Correlator object with PredicateMetrics).