### PR TITLE
Fix Swagger UI at /doc

### DIFF
--- a/asab/api/doc_templates.py
+++ b/asab/api/doc_templates.py
@@ -91,10 +91,8 @@ SWAGGER_DOC_PAGE = """<!DOCTYPE html>
 		</style>
 	</head>
 	<body>
-		<script
-			id="api-reference"
-			data-url="{openapi_url}"></script>
-		<script src="https://unpkg.com/@scalar/api-reference"></script>
+		<script id="api-reference" data-url="{openapi_url}"></script>
+		<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
 	</body>
 </html>
 """


### PR DESCRIPTION
# Issue

Swagger UI at /doc does not load, the remote script throws _Uncaught SyntaxError: import declarations may only appear at top level of a module_.

# Fix

Swagger UI is loaded bundled from CDN instead of unpkg.