### PR TITLE
Log exception when Library changes are not processed

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -438,7 +438,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				try:
 					await do_check_path(actual_path=path)
 				except Exception as e:
-					L.error(
+					L.exception(
 						"Failed to process library changes: '{}'".format(e),
 						struct_data={"path": path},
 					)
@@ -448,7 +448,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 					try:
 						await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
 					except Exception as e:
-						L.error(
+						L.exception(
 							"Failed to process library changes: '{}'".format(e),
 							struct_data={"path": path, "tenant": tenant},
 						)
@@ -458,7 +458,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				try:
 					await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
 				except Exception as e:
-					L.error(
+					L.exception(
 						"Failed to process library changes: '{}'".format(e),
 						struct_data={"path": path, "tenant": tenant},
 					)


### PR DESCRIPTION
Fixing "empty" exceptions when Library changes are not processed.

```
24-Apr-2025 09:49:46.419547 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.424906 ERROR asab.library.providers.zookeeper [sd path="/Site/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.433586 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.439348 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.447071 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.454790 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.463902 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.472890 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.483071 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.487361 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.490876 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.499262 ERROR asab.library.providers.zookeeper [sd path="/Site/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.515065 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.522812 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.534320 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
24-Apr-2025 09:49:46.546238 ERROR asab.library.providers.zookeeper [sd path="/EventLanes/"] Failed to process library changes: ''
```