### PR TITLE
Fix RuntimeError in KeyProviders iteration

### DIFF
--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -68,7 +68,7 @@ class IdTokenAuthProvider(AuthProviderABC):
 		"""
 		Update the public keys from all key providers.
 		"""
-		for provider in self._KeyProviders:
+		for provider in list(self._KeyProviders):
 			await provider.reload_keys()
 		self.collect_keys()
 


### PR DESCRIPTION
Copy key providers before iteration to avoid "RuntimeError: Set changed size during iteration"