### PR TITLE
Fixes

### DIFF
--- a/asab/api/discovery.py
+++ b/asab/api/discovery.py
@@ -36,6 +36,8 @@ class DiscoveryService(Service):
 			self.InternalAuth = InternalAuth(app, zkc)
 
 		self._advertised_cache = dict()
+		self._advertised_raw = dict()
+
 		self._cache_lock = asyncio.Lock()
 		self._ready_event = asyncio.Event()
 
@@ -118,6 +120,11 @@ class DiscoveryService(Service):
 		return copy.deepcopy(self._advertised_cache)
 
 
+	async def discover_raw(self) -> typing.Dict[str, typing.Dict[str, typing.Set[typing.Tuple]]]:
+		await asyncio.wait_for(self._ready_event.wait(), 600)
+		return copy.deepcopy(self._advertised_raw)
+
+
 	async def get_advertised_instances(self) -> typing.List[typing.Dict]:
 		"""
 		This method is here for backward compatibility. Use `discover()` method instead.
@@ -126,7 +133,7 @@ class DiscoveryService(Service):
 		"""
 		# TODO: an obsolete log for this method
 		advertised = []
-		async for item, item_data in self._iter_zk_items():
+		for item, item_data in await self._iter_zk_items():
 			item_data['ephemeral_id'] = item
 			advertised.append(item_data)
 
@@ -164,6 +171,7 @@ class DiscoveryService(Service):
 			# Only one rescan / cache update at a time
 			return
 
+
 		async with self._cache_lock:
 
 			advertised = {
@@ -171,58 +179,64 @@ class DiscoveryService(Service):
 				"service_id": {},
 			}
 
-			iterator = self._iter_zk_items()
-			if iterator is None:
-				return  # reason logged from the _iter_zk_items method
+			advertised_raw = {}
 
-			async for item, item_data in iterator:
-				instance_id = item_data.get("instance_id")
-				service_id = item_data.get("service_id")
-				discovery: typing.Dict[str, list] = item_data.get("discovery", {})
+			try:
+				for item, item_data in await self._iter_zk_items():
 
-				if instance_id is not None:
-					discovery["instance_id"] = [instance_id]
+					advertised_raw[item] = item_data
 
-				if instance_id is not None:
-					discovery["service_id"] = [service_id]
+					instance_id = item_data.get("instance_id")
+					service_id = item_data.get("service_id")
+					discovery: typing.Dict[str, list] = item_data.get("discovery", {})
 
-				host = item_data.get("host")
-				if host is None:
-					continue
+					if instance_id is not None:
+						discovery["instance_id"] = [instance_id]
 
-				web = item_data.get("web")
-				if web is None:
-					continue
+					if service_id is not None:
+						discovery["service_id"] = [service_id]
 
-				for i in web:
-
-					try:
-						ip = i[0]
-						port = i[1]
-					except KeyError:
-						L.error("Unexpected format of 'web' section in advertised data: '{}'".format(web))
-						return
-
-					if ip == "0.0.0.0":
-						family = socket.AF_INET
-					elif ip == "::":
-						family = socket.AF_INET6
-					else:
+					host = item_data.get("host")
+					if host is None:
 						continue
 
-					if discovery is not None:
-						for id_type, ids in discovery.items():
-							if advertised.get(id_type) is None:
-								advertised[id_type] = {}
+					web = item_data.get("web")
+					if web is None:
+						continue
 
-							for identifier in ids:
-								if identifier is not None:
-									if advertised[id_type].get(identifier) is None:
-										advertised[id_type][identifier] = {(host, port, family)}
-									else:
-										advertised[id_type][identifier].add((host, port, family))
+					for i in web:
+
+						try:
+							ip = i[0]
+							port = i[1]
+						except KeyError:
+							L.error("Unexpected format of 'web' section in advertised data: '{}'".format(web))
+							continue
+
+						if ip == "0.0.0.0":
+							family = socket.AF_INET
+						elif ip == "::":
+							family = socket.AF_INET6
+						else:
+							continue
+
+						if discovery is not None:
+							for id_type, ids in discovery.items():
+								if advertised.get(id_type) is None:
+									advertised[id_type] = {}
+
+								for identifier in ids:
+									if identifier is not None:
+										if advertised[id_type].get(identifier) is None:
+											advertised[id_type][identifier] = {(host, port, family)}
+										else:
+											advertised[id_type][identifier].add((host, port, family))
+			except Exception:
+				L.exception("Error when scanning advertised instances")
+				return
 
 			self._advertised_cache = advertised
+			self._advertised_raw = advertised_raw
 			self._ready_event.set()
 
 
@@ -230,40 +244,40 @@ class DiscoveryService(Service):
 		base_path = self.ZooKeeperContainer.Path + "/run"
 
 		def get_items():
+			result = []
 			try:
 				# Create the base path if it does not exist
 				if not self.ZooKeeperContainer.ZooKeeper.Client.exists(base_path):
 					self.ZooKeeperContainer.ZooKeeper.Client.create(base_path, b'', makepath=True)
 
-				return self.ZooKeeperContainer.ZooKeeper.Client.get_children(base_path, watch=self._on_change_threadsafe)
+				items = self.ZooKeeperContainer.ZooKeeper.Client.get_children(base_path, watch=self._on_change_threadsafe)
+
 			except (kazoo.exceptions.SessionExpiredError, kazoo.exceptions.ConnectionLoss):
 				L.warning("Connection to ZooKeeper lost. Discovery Service could not fetch up-to-date state of the cluster services.")
 				return None
 
-			except kazoo.exceptions.KazooException:
+			except Exception:
+				L.exception("Error when getting advertised instances")
 				return None
 
-		def get_data(item):
-			try:
-				data, stat = self.ZooKeeperContainer.ZooKeeper.Client.get((base_path + '/' + item), watch=self._on_change_threadsafe)
-				return data
-			except (kazoo.exceptions.SessionExpiredError, kazoo.exceptions.ConnectionLoss):
-				L.warning("Connection to ZooKeeper lost. Discovery Service could not fetch up-to-date state of the cluster services.")
-				return None
+			for item in items:
+				try:
+					data, stat = self.ZooKeeperContainer.ZooKeeper.Client.get(base_path + '/' + item, watch=self._on_change_threadsafe)
+					result.append((item, json.loads(data)))
+				except (kazoo.exceptions.SessionExpiredError, kazoo.exceptions.ConnectionLoss):
+					L.warning("Connection to ZooKeeper lost. Discovery Service could not fetch up-to-date state of the cluster services.")
+					return None
+				except kazoo.exceptions.NoNodeError:
+					continue
 
-			except kazoo.exceptions.KazooException:
-				# There's a race condition -> if ZK node is deleted between get_items and get_data calls, NoNodeError is raised. Let's just ignore it. The ZK node is already deleted.
-				return None
+			return result
 
-		items = await self.ProactorService.execute(get_items)
-		if items is None:
-			return
+		result = await self.ProactorService.execute(get_items)
+		if result is None:
+			return []
 
-		for item in items:
-			item_data = await self.ProactorService.execute(get_data, item)
-			if item_data is None:
-				continue
-			yield item, json.loads(item_data)
+		return result
+
 
 	def _on_change_threadsafe(self, watched_event):
 		# Runs on a thread, returns the process back to the main thread

--- a/asab/application.py
+++ b/asab/application.py
@@ -480,6 +480,7 @@ class Application(metaclass=Singleton):
 		Args:
 			exit_code (int, optional): Exit code of the finalized process.
 		"""
+
 		if exit_code is not None:
 			self.set_exit_code(exit_code)
 

--- a/asab/task.py
+++ b/asab/task.py
@@ -160,7 +160,10 @@ class TaskService(asab.Service):
 					try:
 						await task
 					except Exception as e:
-						L.exception("Error '{}' during task:".format(e))
+						msg = str(e)
+						if len(msg) == 0:
+							msg = e.__class__.__name__
+						L.exception("Error '{}' during task:".format(msg))
 					self.App.PubSub.publish("TaskService.task_done!", task)
 
 

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -141,7 +141,11 @@ class ZooKeeperContainer(Configurable):
 			self.App.Loop.call_soon_threadsafe(self.ZooKeeper.Client.ensure_path, self.Path)
 			L.log(LOG_NOTICE, "Connected to ZooKeeper.")
 		else:
-			L.warning("ZooKeeper connection state changed.", struct_data={"state": str(state)})
+			if self.ZooKeeper.Stopped and state == kazoo.protocol.states.KazooState.LOST:
+				# This is normal
+				pass
+			else:
+				L.warning("ZooKeeper connection state changed.", struct_data={"state": str(state)})
 
 		self.App.PubSub.publish_threadsafe("ZooKeeperContainer.state/{}!".format(state), self)
 

--- a/asab/zookeeper/wrapper.py
+++ b/asab/zookeeper/wrapper.py
@@ -26,13 +26,17 @@ class KazooWrapper(object):
 		)
 
 		self.Client.add_listener(zkcnt._listener)
+		self.Stopped = False
 
 
 	async def _stop(self):
-		ret = await self.ProactorService.execute(
-			self.Client.stop,
-		)
-		return ret
+		def do():
+			self.Stopped = True
+			ret = self.Client.stop()
+			self.Client.close()
+			return ret
+
+		return await self.ProactorService.execute(do)
 
 
 	# read-only calls

--- a/examples/proactor.py
+++ b/examples/proactor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import asab
+import asyncio
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__()
+
+		# Make sure that the proactor service exists
+		from asab.proactor import Module
+		self.add_module(Module)
+		self.ProactorService = self.get_service("asab.ProactorService")
+
+		self.PubSub.subscribe("Application.tick!", self.on_tick)
+
+		self.Count = 0
+
+	def on_tick(self, event_name):
+		print("Count", self.Count)
+
+	async def main(self):
+		i = 0
+		while True:
+			self.ProactorService.schedule(self.task1)
+			self.ProactorService.schedule(self.task2)
+			self.ProactorService.schedule(self.task3)
+
+			i += 1
+			if i > 1000:
+				await asyncio.sleep(0.001)
+				i = 0
+
+	def task1(self):
+		self.Count += 1
+
+	def task2(self):
+		self.Count += 3
+
+	def task3(self):
+		self.Count += 5
+
+
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION
This fixes:

- How zookeeper do the cleanup of the failed connection
- how some exceptions are reported in Task service
- Significant improvement in Discovery service - it consumes way lower number of proactor threads

Proactor threads are limited resource - I learnt it during a work on receiver.
So we need to be nice to ProactorService and rather do more work in one thread call (in opposite to calling multitude of smaller proactor threads)