### PR TITLE
Feature/mongostorage transactions

### DIFF
--- a/asab/storage/dry_run.py
+++ b/asab/storage/dry_run.py
@@ -1,0 +1,22 @@
+import contextvars
+import functools
+
+
+DRY_RUN = contextvars.ContextVar("dry_run", default=False)
+
+
+def dry_run(handler_func):
+	@functools.wraps(handler_func)
+	async def async_wrapper(self_instance, request, *args, **kwargs):
+		is_dry_run_request = False
+		if hasattr(request, 'query') and callable(getattr(request.query, 'get', None)):
+			dry_run_param = request.query.get("dry_run", "false")
+			if isinstance(dry_run_param, str) and dry_run_param.lower() == "true":
+				is_dry_run_request = True
+
+		token = DRY_RUN.set(is_dry_run_request)
+		try:
+			return await handler_func(self_instance, request, *args, **kwargs)
+		finally:
+			DRY_RUN.reset(token)
+	return async_wrapper

--- a/asab/storage/exceptions.py
+++ b/asab/storage/exceptions.py
@@ -8,3 +8,12 @@ class DuplicateError(RuntimeError):
 		super().__init__(message)
 		self.ObjId = obj_id
 		self.KeyValue = key_value
+
+
+class DryRunAbort(Exception):
+	"""
+	Raised when a transaction is aborted due to a DRY_RUN context being true.
+	"""
+	def __init__(self, obj_id):
+		self.ObjID = obj_id
+		super().__init__(obj_id)

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -9,7 +9,7 @@ import bson
 import logging
 
 import asab
-from .exceptions import DuplicateError
+from .exceptions import DuplicateError, DryRunAbort
 from .service import StorageServiceABC
 from .upsertor import UpsertorABC
 from .dry_run import DRY_RUN
@@ -74,12 +74,6 @@ def transactional(method_to_decorate):
 					await session.abort_transaction()
 				raise
 	return wrapper
-
-
-class DryRunAbort(Exception):
-	def __init__(self, obj_id):
-		self.ObjID = obj_id
-		super().__init__(obj_id)
 
 
 class StorageService(StorageServiceABC):

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -32,10 +32,10 @@ asab.Config.add_defaults(
 
 def transactional(method_to_decorate):
 	"""
-    A decorator for asynchronous methods that wraps execution within a MongoDB transaction.
+	A decorator for asynchronous methods that wraps execution within a MongoDB transaction.
 
-    Ensures ACID properties for operations. Handles session management, transaction
-    start/commit/abort, and specific error conditions like `DryRunAbort` and `DuplicateError`.
+	Ensures ACID properties for operations. Handles session management, transaction
+	start/commit/abort, and specific error conditions like `DryRunAbort` and `DuplicateError`.
 	"""
 	@functools.wraps(method_to_decorate)
 	async def wrapper(*args, **kwargs):

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -11,6 +11,7 @@ import asab
 from .exceptions import DuplicateError
 from .service import StorageServiceABC
 from .upsertor import UpsertorABC
+from dry_run import DRY_RUN
 
 #
 
@@ -98,7 +99,7 @@ class StorageService(StorageServiceABC):
 
 		return self.Database[collection]
 
-
+	#dryrun here
 	async def delete(self, collection: str, obj_id):
 		coll = self.Database[collection]
 		ret = await coll.find_one_and_delete({'_id': obj_id})
@@ -233,7 +234,8 @@ class MongoDBUpsertor(UpsertorABC):
 		return bson.objectid.ObjectId()
 
 
-	async def transaction(self, session, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None, dry_run: bool = True):
+	async def transaction(self, session, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
+		dry_run = DRY_RUN.get("dry_run")
 		id_name = self.get_id_name()
 		addobj = {}
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -11,7 +11,7 @@ import asab
 from .exceptions import DuplicateError
 from .service import StorageServiceABC
 from .upsertor import UpsertorABC
-from dry_run import DRY_RUN
+from .dry_run import DRY_RUN
 
 #
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -31,6 +31,12 @@ asab.Config.add_defaults(
 
 
 def transactional(method_to_decorate):
+	"""
+    A decorator for asynchronous methods that wraps execution within a MongoDB transaction.
+
+    Ensures ACID properties for operations. Handles session management, transaction
+    start/commit/abort, and specific error conditions like `DryRunAbort` and `DuplicateError`.
+	"""
 	@functools.wraps(method_to_decorate)
 	async def wrapper(*args, **kwargs):
 		inst_self = args[0]

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -57,7 +57,7 @@ def transactional(method_to_decorate):
 				)
 				result = await method_to_decorate(inst_self, session, *decorated_method_args, **kwargs)
 
-				dry_run = DRY_RUN.get("dry_run")
+				dry_run = DRY_RUN.get()
 				if dry_run:
 					if session.in_transaction:
 						await session.abort_transaction()

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -1,6 +1,5 @@
 import datetime
 import typing
-import functools
 
 import motor.motor_asyncio
 import pymongo
@@ -28,6 +27,7 @@ asab.Config.add_defaults(
 		}
 	}
 )
+
 
 class MongoTransaction:
 	"""

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -29,6 +29,7 @@ asab.Config.add_defaults(
 	}
 )
 
+
 def transactional(method_to_decorate):
 	@functools.wraps(method_to_decorate)
 	async def wrapper(*args, **kwargs):
@@ -55,7 +56,7 @@ def transactional(method_to_decorate):
 					if session.in_transaction:
 						await session.abort_transaction()
 
-					
+
 					raise DryRunAbort(obj_id=obj_id)
 
 				if session.in_transaction:
@@ -275,7 +276,6 @@ class MongoDBUpsertor(UpsertorABC):
 
 	@transactional
 	async def execute(self, session, custom_data: typing.Optional[dict] = None, event_type: typing.Optional[str] = None):
-		dry_run = DRY_RUN.get("dry_run")
 		id_name = self.get_id_name()
 		addobj = {}
 

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -30,6 +30,16 @@ asab.Config.add_defaults(
 )
 
 class MongoTransaction:
+	"""
+	MongoDB transaction context manager.
+	Usage example (with upsertor):
+	client = upsertor.Storage.Client
+	async with asab.storage.mongodb.MongoTransaction(client=client, obj_id=pbid, target_accessor=upsertor) as transaction:
+			pbid = await upsertor.execute()
+	'client' is StorageService Client (a mongo motor AsyncIOMotorClientSession)
+	'obj_id' is MongoDB _id
+	'target_accessor' is either StorageService itself, or in this case instance of MongoDBUpsertor class
+	"""
 	def __init__(self, client, obj_id=None, target_accessor=None):
 		self.Client = client
 		self.ObjId = obj_id
@@ -331,10 +341,7 @@ class MongoDBUpsertor(UpsertorABC):
 		if len(addobj) > 0:
 			coll = self.Storage.Database[self.Collection]
 			try:
-
-				print("storage is", self.Storage._current_session)
 				if self.Storage._current_session:
-					print("executing in transaction from asab")
 					ret = await coll.find_one_and_update(
 						filtr,
 						update=addobj,

--- a/asab/storage/mongodb.py
+++ b/asab/storage/mongodb.py
@@ -70,7 +70,11 @@ def transactional(method_to_decorate):
 					await session.abort_transaction()
 				raise
 			except Exception as e:
-				L.exception("Unknown exception encountered while executing MongoDB transaction: {}".format(e))
+				L.exception(
+					"Unknown exception encountered while executing MongoDB transaction",
+					struct_data={
+						"reason": e,
+					})
 				if session.in_transaction:
 					await session.abort_transaction()
 				raise


### PR DESCRIPTION
- MongoDB storage service now enables :dry run" feature for Upsertor execute and StorageService delete.

- Upsertor execute and StorageService delete are now executed via transactions. 

This is a breaking change. While transactions are supported since MongoDB version 4 (https://severalnines.com/blog/transaction-considerations-mongodb-production/), it is breaking in the sense that transactions require a replica set (it may be a "single node" replica set).
