### PR TITLE
Make pull interval for libsreg configurable

### DIFF
--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -1,4 +1,4 @@
-import os
+import os.path
 import lzma
 import logging
 import hashlib
@@ -14,6 +14,7 @@ import aiohttp
 
 from .filesystem import FileSystemLibraryProvider
 from ..dirsync import synchronize_dirs
+from ...utils import convert_to_seconds
 
 #
 
@@ -28,26 +29,50 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 
 	It provides an option to specify more servers for more reliable content delivery.
 
-	Example of the configuration:
+	Configuration example:
 
 	```ini
 	[library]
 	providers=
-	...
-	libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library
-	...
+		...
+		libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library
+		...
 	```
 
+	Specify the library version in the URL fragment (after `#`):
+	```ini
+	[library]
+	providers=
+		...
+		libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library#v25.14.01
+		...
+	```
+
+	Specify the pull interval after `@pull:`:
+	```ini
+	[library]
+	providers=
+		...
+		libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library@pull:24h
+		...
+	```
 	"""
+
 
 	def __init__(self, library, path, layer):
 
+		if "@pull:" in path:
+			path, pull_interval = path.rsplit("@pull:", 1)
+			self.PullInterval = convert_to_seconds(pull_interval)
+		else:
+			self.PullInterval = 43200  # Default pull interval is 12 hours
+
 		url = urllib.parse.urlparse(path)
-		assert url.scheme.startswith('libsreg+')
+		assert url.scheme.startswith("libsreg+")
 
 		version = url.fragment
-		if version == '':
-			version = 'production'
+		if version == "":
+			version = "production"
 
 		archname = url.path[1:]
 
@@ -56,7 +81,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 			netloc=netloc,
 			archname=archname,
 			version=version,
-		) for netloc in url.netloc.split(',')]
+		) for netloc in url.netloc.split(",")]
 		assert len(self.URLs) > 0
 
 		# TODO: Read this for `[general]` config
@@ -66,7 +91,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 		self.RootPath = os.path.join(
 			tempdir,
 			"asab.library.libsreg",
-			hashlib.sha256(path.encode('utf-8')).hexdigest()
+			hashlib.sha256(path.encode("utf-8")).hexdigest()
 		)
 
 		self.RepoPath = os.path.join(
@@ -80,20 +105,14 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 		super().__init__(library, self.RepoPath, layer, set_ready=False)
 
 		self.PullLock = asyncio.Lock()
+		self.LastPull = self.App.time()
+		L.info("", struct_data={"path": self.RepoPath, "urls": self.URLs, "pull_interval": self.PullInterval})
 
 		# TODO: Subscription to changes in the library
 		self.SubscribedPaths = set()
 
 		self.App.TaskService.schedule(self._periodic_pull(None))
-
-		if version.startswith('v'):
-			# Fixed versions (ie v24.04) are much less likely to change, therefore we can check only every 12 hours
-			self.App.PubSub.subscribe("Application.tick/43200!", self._periodic_pull)
-		elif archname == 'teskalabs-versions-library':
-			# TODO: This is a temporary workaround for the teskalabs-versions-library. It has to be delivered continuously. However, it is not a good idea to check every minute. Better solution coming soon in LogMan.io.
-			self.App.PubSub.subscribe("Application.tick/43200!", self._periodic_pull)
-		else:
-			self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
+		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
 
 
 	async def _periodic_pull(self, event_name):
@@ -107,129 +126,136 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 		if self.PullLock.locked():
 			return
 
+		if self.App.time() - self.LastPull < self.PullInterval:
+			# Do not pull if the last pull was done less than PullInterval ago
+			return
+
 		async with self.PullLock:
-			headers = {}
+			await self._do_pull()
+			self.LastPull = self.App.time()
 
-			# Check for existing E-Tag
-			etag_fname = os.path.join(self.RootPath, "etag")
-			if os.path.exists(etag_fname):
+	async def _do_pull(self):
+		headers = {}
 
-				# Count number of files in self.RootPath recursively
-				file_count = sum([len(files) for _, _, files in os.walk(self.RootPath)])
+		# Check for existing E-Tag
+		etag_fname = os.path.join(self.RootPath, "etag")
+		if os.path.exists(etag_fname):
 
-				# If less than 5 files, we ignore the E-Tag and re-download everything
-				if file_count > 5:
-					with open(etag_fname, 'r') as f:
-						etag = f.read().strip()
-						headers['If-None-Match'] = etag
+			# Count number of files in self.RootPath recursively
+			file_count = sum([len(files) for _, _, files in os.walk(self.RootPath)])
 
-			# Prepare a list of URLs to try
-			# Randomize the order of the URLs (there might be more than one server to try)
-			# The list is trippled to increase the chance of getting the new version
-			# None is used as a separator between the URL sets - if the first URL set fails, we wait for 5 seconds before trying the next one
-			urllist = self.URLs.copy()
-			random.shuffle(urllist)
-			urllist = urllist + [None] + urllist + [None] + urllist
+			# If less than 5 files, we ignore the E-Tag and re-download everything
+			if file_count > 5:
+				with open(etag_fname, "r") as f:
+					etag = f.read().strip()
+					headers["If-None-Match"] = etag
 
-			for i in range(len(urllist)):
-				url = urllist[i]
+		# Prepare a list of URLs to try
+		# Randomize the order of the URLs (there might be more than one server to try)
+		# The list is trippled to increase the chance of getting the new version
+		# None is used as a separator between the URL sets - if the first URL set fails, we wait for 5 seconds before trying the next one
+		urllist = self.URLs.copy()
+		random.shuffle(urllist)
+		urllist = urllist + [None] + urllist + [None] + urllist
 
-				if url is None:
-					# Sleep for 5 seconds before trying the next URL set
-					await asyncio.sleep(5)
-					continue
+		for i in range(len(urllist)):
+			url = urllist[i]
 
-				L.debug("Periodic pull of libsreg library", struct_data={'url': url})
+			if url is None:
+				# Sleep for 5 seconds before trying the next URL set
+				await asyncio.sleep(5)
+				continue
 
-				last_try = i == len(urllist) - 1
+			L.debug("Periodic pull of libsreg library", struct_data={"url": url})
 
-				try:
-					# This is a hotfix at 02/06/2025
-					# Some SSL servers do not properly complete SSL shutdown process,
-					# in that case asyncio leaks SSL connections. If this parameter is set to True,
-					# aiohttp additionally aborts underlining transport after 2 seconds. It is off by default.
-					connector = aiohttp.TCPConnector(
-						enable_cleanup_closed=True,
-						force_close=True,  # Close underlying sockets after connection releasing
-					)
+			last_try = i == len(urllist) - 1
 
-					async with aiohttp.ClientSession(connector=connector, trust_env=self.TrustEnv) as session:
-						async with session.get(url, headers=headers) as response:
+			try:
+				# This is a hotfix at 02/06/2025
+				# Some SSL servers do not properly complete SSL shutdown process,
+				# in that case asyncio leaks SSL connections. If this parameter is set to True,
+				# aiohttp additionally aborts underlining transport after 2 seconds. It is off by default.
+				connector = aiohttp.TCPConnector(
+					enable_cleanup_closed=True,
+					force_close=True,  # Close underlying sockets after connection releasing
+				)
 
-							if response.status == 200:  # The request indicates a new version that we don't have yet
+				async with aiohttp.ClientSession(connector=connector, trust_env=self.TrustEnv) as session:
+					async with session.get(url, headers=headers) as response:
 
-								etag_incoming = response.headers.get('ETag')
+						if response.status == 200:  # The request indicates a new version that we don't have yet
 
-								# Download new version
-								dwnld_size = 0
-								newtarfname = os.path.join(self.RootPath, "new.tar.xz")
-								with open(newtarfname, 'wb') as ftmp:
-									while True:
-										chunk = await response.content.read(16 * 1024)
-										if not chunk:
-											break
-										ftmp.write(chunk)
-										dwnld_size += len(chunk)
+							etag_incoming = response.headers.get('ETag')
 
-								# Extract the contents to the temporary directory
-								temp_extract_dir = os.path.join(
-									self.RootPath,
-									"new"
-								)
+							# Download new version
+							dwnld_size = 0
+							newtarfname = os.path.join(self.RootPath, "new.tar.xz")
+							with open(newtarfname, 'wb') as ftmp:
+								while True:
+									chunk = await response.content.read(16 * 1024)
+									if not chunk:
+										break
+									ftmp.write(chunk)
+									dwnld_size += len(chunk)
 
-								# Remove temp_extract_dir if it exists (from the last, failed run)
-								if os.path.exists(temp_extract_dir):
-									shutil.rmtree(temp_extract_dir)
+							# Extract the contents to the temporary directory
+							temp_extract_dir = os.path.join(
+								self.RootPath,
+								"new"
+							)
 
-								# Extract the archive into the temp_extract_dir
-								try:
-									with tarfile.open(newtarfname, mode='r:xz') as tar:
-										tar.extractall(temp_extract_dir)
-								except lzma.LZMAError:
-									L.exception("LZMAError", struct_data={'size': dwnld_size})
-									continue
+							# Remove temp_extract_dir if it exists (from the last, failed run)
+							if os.path.exists(temp_extract_dir):
+								shutil.rmtree(temp_extract_dir)
 
-								# Synchronize the temp_extract_dir into the library
-								synchronize_dirs(self.RepoPath, temp_extract_dir)
-								if not self.IsReady:
-									await self._set_ready()
+							# Extract the archive into the temp_extract_dir
+							try:
+								with tarfile.open(newtarfname, mode='r:xz') as tar:
+									tar.extractall(temp_extract_dir)
+							except lzma.LZMAError:
+								L.exception("LZMAError", struct_data={'size': dwnld_size})
+								continue
 
-								if etag_incoming is not None:
-									with open(etag_fname, 'w') as f:
-										f.write(etag_incoming)
+							# Synchronize the temp_extract_dir into the library
+							synchronize_dirs(self.RepoPath, temp_extract_dir)
+							if not self.IsReady:
+								await self._set_ready()
 
-								# Remove temp_extract_dir
-								if os.path.exists(temp_extract_dir):
-									shutil.rmtree(temp_extract_dir)
+							if etag_incoming is not None:
+								with open(etag_fname, 'w') as f:
+									f.write(etag_incoming)
 
-								# Remove newtarfname
-								if os.path.exists(newtarfname):
-									os.remove(newtarfname)
+							# Remove temp_extract_dir
+							if os.path.exists(temp_extract_dir):
+								shutil.rmtree(temp_extract_dir)
 
-								return  # We are done, leaving the loop
+							# Remove newtarfname
+							if os.path.exists(newtarfname):
+								os.remove(newtarfname)
 
-							elif response.status == 304:
-								# The repository has not changed ...
-								if not self.IsReady:
-									await self._set_ready()
+							return  # We are done, leaving the loop
 
-								return  # We are done, leaving the loop
+						elif response.status == 304:
+							# The repository has not changed ...
+							if not self.IsReady:
+								await self._set_ready()
 
-							else:
-								if last_try:
-									L.error("Failed to download the library.", struct_data={"url": url, 'status': response.status})
+							return  # We are done, leaving the loop
 
-				except aiohttp.ClientError as e:
-					if last_try:
-						L.error("Failed to download the library (ClientError).", struct_data={"url": url, 'error': e, 'exception': e.__class__.__name__})
+						else:
+							if last_try:
+								L.error("Failed to download the library.", struct_data={"url": url, 'status': response.status})
 
-				except asyncio.TimeoutError as e:
-					if last_try:
-						L.error("Failed to download the library (TimeoutError).", struct_data={"url": url, 'error': e, 'exception': e.__class__.__name__})
+			except aiohttp.ClientError as e:
+				if last_try:
+					L.error("Failed to download the library (ClientError).", struct_data={"url": url, 'error': e, 'exception': e.__class__.__name__})
 
-				except Exception:
-					L.exception("Error when fetching the library content from a registry")
+			except asyncio.TimeoutError as e:
+				if last_try:
+					L.error("Failed to download the library (TimeoutError).", struct_data={"url": url, 'error': e, 'exception': e.__class__.__name__})
 
+			except Exception:
+				L.exception("Error when fetching the library content from a registry")
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		self.SubscribedPaths.add(path)


### PR DESCRIPTION
Instead of hard-coding pull interval based on library version, I suggest to use a configuration option for that.

```ini
[library]
providers=
...
libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library@pull:24h
libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library2@pull:10m
libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library3  # default is 12hours
...
```