### PR TITLE
Remove race condition from service advertisement in asab.api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,17 @@
 # CHANGELOG
 
-## Relase Candidate
+## Release candidate
 
 ### Breaking Changes
-- XX
 
 ### Fix
-- XX
+- Remove race condition from service advertisement in asab.api (#694)
 
 ### Features
-- XX
 
 ### Refactoring
-- XX
 
 ---
+
 
 ## v25.25

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -10,6 +10,7 @@ from ..utils import running_in_container
 from .web_handler import APIWebHandler
 from .log import WebApiLoggingHandler
 from .doc import DocWebHandler
+from .discovery import DiscoveryService
 
 ##
 
@@ -66,6 +67,9 @@ class ApiService(Service):
 			self.ChangeLog = path
 		else:
 			self.ChangeLog = None
+
+		# Discovery service is essential to ASAB API service
+		self.DiscoveryService = None
 
 
 	def attention_required(self, att: dict, att_id=None):
@@ -185,6 +189,10 @@ class ApiService(Service):
 
 		# get zookeeper-service
 		self.ZkContainer = zoocontainer
+
+		# Use the container for service discovery
+		self.DiscoveryService = DiscoveryService(self.App, self.ZkContainer)
+
 		self._do_zookeeper_adv_data()
 
 

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -234,7 +234,12 @@ class ApiService(Service):
 			adv_data.update({"discovery": self.Discovery})
 
 		if self.WebContainer is not None:
-			adv_data['web'] = self.WebContainer.Addresses
+			web = self.WebContainer.Addresses
+			if web is not None:
+				adv_data['web'] = web
+			else:
+				# Web server is not ready yet, skip advertising - it will be advertised in a small moment, hopefully
+				return
 
 		self.ZkContainer.advertise(
 			data=adv_data,

--- a/asab/api/service.py
+++ b/asab/api/service.py
@@ -10,7 +10,6 @@ from ..utils import running_in_container
 from .web_handler import APIWebHandler
 from .log import WebApiLoggingHandler
 from .doc import DocWebHandler
-from .discovery import DiscoveryService
 
 ##
 
@@ -67,9 +66,6 @@ class ApiService(Service):
 			self.ChangeLog = path
 		else:
 			self.ChangeLog = None
-
-		# Service Discovery
-		self.DiscoveryService = None
 
 
 	def attention_required(self, att: dict, att_id=None):
@@ -189,19 +185,11 @@ class ApiService(Service):
 
 		# get zookeeper-service
 		self.ZkContainer = zoocontainer
-
-		# initialize service discovery
-		self.DiscoveryService = DiscoveryService(self.App, self.ZkContainer)
-
-		self.App.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zkcontainer_start)
 		self._do_zookeeper_adv_data()
 
 
 	def _do_zookeeper_adv_data(self):
 		if self.ZkContainer is None:
-			return
-
-		if not self.ZkContainer.is_connected():
 			return
 
 		adv_data = {
@@ -253,10 +241,6 @@ class ApiService(Service):
 			path="/run/{}.".format(self.App.__class__.__name__),
 		)
 
-
-	def _on_zkcontainer_start(self, message_type, container):
-		if container == self.ZkContainer:
-			self._do_zookeeper_adv_data()
 
 	def _on_webcontainer_start(self, message_type, container):
 		if container == self.WebContainer:

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -97,7 +97,7 @@ class ZooKeeperContainer(Configurable):
 			url_path = url_path[1:]
 
 		self.Path = url_path
-	
+
 		self.Advertisments = dict()
 		self.AdvertismentsLock = threading.Lock()
 

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -97,9 +97,9 @@ class ZooKeeperContainer(Configurable):
 			url_path = url_path[1:]
 
 		self.Path = url_path
-
-		self.AdvertismentsLock = threading.Lock()
+	
 		self.Advertisments = dict()
+		self.AdvertismentsLock = threading.Lock()
 
 		self.App.PubSub.subscribe("Application.tick/300!", self._on_tick300)
 		self.App.PubSub.subscribe("Application.tick/60!", self._on_tick60)
@@ -172,7 +172,6 @@ class ZooKeeperContainer(Configurable):
 	# Advertisement into Zookeeper
 
 	def advertise(self, data, path):
-		print(f"->>> Advertising {path} with data {data}")
 		if isinstance(data, dict):
 			data = json.dumps(data).encode("utf-8")
 		elif isinstance(data, str):
@@ -212,17 +211,15 @@ class ZooKeeperContainer(Configurable):
 							if stats.version != adv.version:
 								try:
 									stats = self.ZooKeeper.Client.set(adv.real_path, adv.data)
-									print(f"->>> Updated advertisement {adv.path} to version {stats.version}")
 									adv.version = stats.version
 								except kazoo.exceptions.NoNodeError:
 									adv.real_path = None
 
 					if adv.real_path is None:
 						adv.real_path, stats = self.ZooKeeper.Client.create(adv.path, adv.data, sequence=True, ephemeral=True, makepath=True, include_data=True)
-						print(f"->>> Created advertisement {adv.real_path} with version {stats.version} and data {adv.data}")
 						adv.version = stats.version
 
-				if any(adv.version == -1 for adv in self.Advertisments.values()):
+				if any((adv.version == -1) or (adv.real_path is None) for adv in self.Advertisments.values()) and self.ZooKeeper.Client.connected:
 					# Where was a change or a new advertisement, we need to try again
 					continue
 				else:


### PR DESCRIPTION
# Issue

When asab.web server is initialised slowly (ie due to the system load), there is a race condition that can lead to incorrect advertisement to Zookeeper / Discovery service.

It is manifested by `"web": null` property in `/asab/run` service entry in ZK, which makes the service not discoverable.

# Solution

- Advertisement is delayed until web container is ready.
- Handle quick changes in advertisements and delay the publishing of advertisements.