### PR TITLE
Add transactions to MongoDB storage

### DIFF
--- a/asab/storage/exceptions.py
+++ b/asab/storage/exceptions.py
@@ -8,3 +8,10 @@ class DuplicateError(RuntimeError):
 		super().__init__(message)
 		self.ObjId = obj_id
 		self.KeyValue = key_value
+
+
+class AbortTransactionError(Exception):
+	'''
+	Raised by the user when the transaction is aborted.
+	'''
+	pass


### PR DESCRIPTION
Use a transaction:

```
async with storage.transaction():
	object_id = await u.execute()
```

Abort transaction:

```
async with storage.transaction() as tx:
	object_id = await u.execute()
	tx.abort()
```


Conditionally abort:

```
async with storage.transaction() as tx:
	object_id = await u.execute()
	if dry_run:
		tx.abort()
```
