### PR TITLE
Library GIT provider: Custom CA certificate

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -105,11 +105,14 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			if pygit2.discover_repository(self.RepoPath) is None:
 				# For a new repository, clone the remote bit
 				os.makedirs(self.RepoPath, mode=0o700, exist_ok=True)
-				self.GitRepository = pygit2.clone_repository(
-					url=self.URL,
-					path=self.RepoPath,
-					checkout_branch=self.Branch
-				)
+				try:
+					self.GitRepository = pygit2.clone_repository(
+						url=self.URL,
+						path=self.RepoPath,
+						checkout_branch=self.Branch
+					)
+				except Exception as err:
+					L.exception("Error when cloning git repository: {}".format(err))
 			else:
 				# For existing repository, pull the latest changes
 				self.GitRepository = pygit2.Repository(self.RepoPath)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -62,6 +62,13 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 		self.GitRepository = None
 
+		# Set custom SSL certificate locations if specified
+		if any((Config.get("library:git", "cert_file", fallback=None), Config.get("library:git", "cert_dir", fallback=None))):
+			pygit2.settings.set_ssl_cert_locations(
+				cert_file=Config.get("library:git", "cert_file", fallback=None),
+				cert_dir=Config.get("library:git", "cert_dir", fallback=None)
+			)
+
 		from ...proactor import Module
 		self.App.add_module(Module)
 		self.ProactorService = self.App.get_service("asab.ProactorService")


### PR DESCRIPTION
I'm looking for a way to add custom trusted CA cert to library (self-hosted gitlab with local CA). 
I'd love to set the CA on the OS level. However, in alpine, it requires to add the cert to a dedicated directory AND run a command `update-ca-certificates`. That would require some "ohejbák" in every lmio Dockerfile. I could also change the original file with all trusted CA, but I find that a bit too much "prasárnička".

This is not an OS level, but it works with configuration only, without any need for sherpa/Dockerfile adjustments etc. 

The `cert_file` config option works fine. I cannot make `cert_dir` option work. It does not seem to work well with the directory.

Source: https://www.pygit2.org/settings.html#pygit2.Settings.ssl_cert_file