### PR TITLE
Remove enure ready for read disabled

### DIFF
--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -383,7 +383,6 @@ class LibraryService(Service):
 		return items
 
 	async def _read_disabled(self, publish_changes=False):
-		self._ensure_ready()
 
 		old_disabled = self.Disabled.copy()
 		old_disabled_paths = list(self.DisabledPaths)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the disabled library configuration so it can be processed earlier during startup.
  * Ensures values from /.disabled.yaml are applied promptly, leading to more consistent recognition of disabled libraries and paths across restarts.
  * Reduces spurious “service not ready” errors related to disabled-state detection during initialization.
  * No changes to user-facing APIs or settings; behavior should appear more stable and predictable when managing disabled libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->