### PR TITLE
Extend default mock authorization expiration to 1 year

### DIFF
--- a/asab/web/auth/providers/mock.py
+++ b/asab/web/auth/providers/mock.py
@@ -19,7 +19,7 @@ _MOCK_AUTH_CLAIMS_DEFAULT = {
 	# Token issued at (timestamp)
 	"iat": "now - 10s",
 	# Token expires at (timestamp)
-	"exp": "now + 1h",
+	"exp": "now + 1y",
 	# Audience
 	"aud": "my-app.asab",
 	# Subject (Unique user ID)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - None.
- Chores
  - Extended default expiration of mock authentication tokens from 1 hour to 1 year, enabling longer-lived sessions in mock environments.
  - Existing configuration and overrides continue to function; no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->