### PR TITLE
Make [logging:file] rotate_every option case insensitive

### DIFF
--- a/asab/log.py
+++ b/asab/log.py
@@ -85,20 +85,20 @@ class Logging(object):
 
 				rotate_every = Config.get("logging:file", "rotate_every")
 				if rotate_every != '':
-					rotate_every = re.match(r"^([0-9]+)([dMHs])$", rotate_every)
+					rotate_every = re.match(r"^([0-9]+)([dDmMhHsS])$", rotate_every)
 					if rotate_every is not None:
 						i, u = rotate_every.groups()
 						i = int(i)
 						if i <= 0:
 							self.RootLogger.error("Invalid 'rotate_every' configuration value.")
 						else:
-							if u == 'H':
+							if u == 'H' or u == 'h':
 								i = i * 60 * 60
-							elif u == 'M':
+							elif u == 'm' or u == 'M':
 								i = i * 60
-							elif u == 'd':
+							elif u == 'd' or u == 'D':
 								i = i * 60 * 60 * 24
-							elif u == 's':
+							elif u == 's' or u == 'S':
 								pass
 
 							# PubSub is not ready at this moment, we need to create timer in a future


### PR DESCRIPTION
Making configuration option case insensitive, similarly to how `asab.config.getseconds()` works.

Right now, this is invalid configuration:

```ini
[logging:file]
rotate_every=12h
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Logging rotation configuration now accepts both lowercase and uppercase time units (d/h/m/s), preventing errors when lowercase values are used.
  * Improves usability by making the rotation interval input more flexible and less error-prone.
  * Existing configurations continue to work without changes; no action required by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->