### PR TITLE
Fix: Try to find SSH in the allowed types and try to authorize anyway

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -20,6 +20,22 @@ except ImportError:
 	L.critical("Please install pygit2 package to enable Git Library Provider. >>> pip install pygit2")
 	raise SystemExit("Application exiting... .")
 
+# Try to get the SSH key credential type constant - location varies by pygit2 version
+try:
+	GIT_CREDTYPE_SSH_KEY = pygit2.GIT_CREDTYPE_SSH_KEY
+except AttributeError:
+	try:
+		GIT_CREDTYPE_SSH_KEY = pygit2.credentials.GIT_CREDTYPE_SSH_KEY
+	except (AttributeError, ImportError):
+		try:
+			GIT_CREDTYPE_SSH_KEY = pygit2.GIT_CREDENTIAL_SSH_KEY
+		except AttributeError:
+			try:
+				GIT_CREDTYPE_SSH_KEY = pygit2.credentials.GIT_CREDENTIAL_SSH_KEY
+			except (AttributeError, ImportError):
+				# Fall back to the numeric value if constant not found
+				GIT_CREDTYPE_SSH_KEY = 2  # Standard value across libgit2 versions
+
 
 class GitLibraryProvider(FileSystemLibraryProvider):
 	"""
@@ -182,34 +198,37 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 					"allowed_types": allowed_types
 				})
 
-				# Check if SSH key authentication is allowed
-				if allowed_types & pygit2.credentials.GIT_CREDENTIAL_SSH_KEY:
-					# Expand paths
-					key_path = os.path.expanduser(self.SSHKeyPath)
-					pubkey_path = os.path.expanduser(self.SSHPubkeyPath)
+				# Warn if the allowed_types doesn't match what we expect
+				if not (allowed_types & GIT_CREDTYPE_SSH_KEY):
+					L.warning(
+						f"SSH credentials requested but allowed_types ({allowed_types}) "
+						f"doesn't include SSH_KEY flag ({GIT_CREDTYPE_SSH_KEY}). Attempting anyway."
+					)
 
-					# Check if key files exist
-					if not os.path.exists(key_path):
-						L.error(f"SSH private key not found: {key_path}")
-						return None
-					if not os.path.exists(pubkey_path):
-						L.warning(f"SSH public key not found: {pubkey_path}, trying without it")
-						pubkey_path = ""
+				# Expand paths
+				key_path = os.path.expanduser(self.SSHKeyPath)
+				pubkey_path = os.path.expanduser(self.SSHPubkeyPath)
 
-					L.debug(f"Using SSH key: {key_path}")
+				# Check if key files exist
+				if not os.path.exists(key_path):
+					L.error(f"SSH private key not found: {key_path}")
+					return None
+				if not os.path.exists(pubkey_path):
+					L.warning(f"SSH public key not found: {pubkey_path}, trying without it")
+					pubkey_path = ""
 
-					try:
-						return pygit2.Keypair(
-							username_from_url or self.User or "git",
-							pubkey_path,
-							key_path,
-							self.SSHPassphrase or ""
-						)
-					except Exception as e:
-						L.error(f"Failed to create SSH keypair: {e}")
-						return None
+				L.debug(f"Using SSH key: {key_path}")
 
-				return None
+				try:
+					return pygit2.Keypair(
+						username_from_url or self.User or "git",
+						pubkey_path,
+						key_path,
+						self.SSHPassphrase or ""
+					)
+				except Exception as e:
+					L.error(f"Failed to create SSH keypair: {e}")
+					return None
 
 			callbacks.credentials = credentials_cb
 


### PR DESCRIPTION
The error module 'pygit2.credentials' has no attribute 'GIT_CREDENTIAL_SSH_KEY' occurred because:

- Some pygit2 versions have it as pygit2.GIT_CREDTYPE_SSH_KEY
- Others have pygit2.credentials.GIT_CREDTYPE_SSH_KEY
- Some older versions use different names
- The constant location and naming changed across versions

# What is allowed_types?
The allowed_types parameter is a bitmask (bitfield) that libgit2 passes to the credentials callback. It tells you which authentication methods the server/repository accepts for this connection attempt.

- The possible flags include:
- GIT_CREDTYPE_USERPASS_PLAINTEXT (1) - Username/password
- GIT_CREDTYPE_SSH_KEY (2) - SSH key pair
- GIT_CREDTYPE_DEFAULT (4) - Default credentials
- GIT_CREDTYPE_SSH_CUSTOM (8) - Custom SSH handler
- GIT_CREDTYPE_SSH_INTERACTIVE (16) - Interactive SSH
- GIT_CREDTYPE_USERNAME (32) - Username only
- GIT_CREDTYPE_SSH_MEMORY (64) - SSH key from memory

## Why Might SSH Be Missing?
There are several legitimate scenarios:
1. First Connection Attempt
On the very first connection to a server, libgit2 might call the callback to ask "what credentials do you have available?" without yet knowing which methods the server supports. It might pass 0 or a generic flag.
2. Multiple Authentication Methods
Some servers support multiple auth methods (SSH + username/password). libgit2 might ask what you can provide, and you should return whatever you have.
3. Retry After Failure
If the first auth attempt fails, libgit2 might call back again with different allowed_types to try alternative methods.
4. Version/Constant Mismatch
If our GIT_CREDTYPE_SSH_KEY constant doesn't match what the library is actually using (due to version differences), the bitwise check would fail even though SSH is actually allowed.
Why We Try Anyway
Since the user explicitly configured an SSH URL like git+git@host:repo.git, we KNOW they want SSH authentication. The allowed_types check is informative but not authoritative for our use case:
The warning just helps with debugging if something unexpected is happening with the protocol negotiation or version compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH authentication resilience across different versions of the underlying Git library
  * Improved error handling and diagnostic logging for SSH key validation
  * SSH credential processing now continues gracefully when configuration flags are absent, with warnings logged for diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->