### PR TITLE
MCP auth

### DIFF
--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -1,4 +1,40 @@
 import aiohttp.web
+import typing
+
+
+class _WWWAuthenticateMixin:
+	def update_www_authenticate(
+		self,
+		*,
+		realm: str | None = None,
+		scope: typing.List[str] | None = None,
+		error: str | None = None,
+		error_description: str | None = None,
+		error_uri: str | None = None,
+		resource_metadata: str | None = None,
+	):
+		if not hasattr(self, "WwwAuthenticate"):
+			self.WWWAuthenticate = {}
+		if realm is not None:
+			self.WWWAuthenticate["realm"] = realm
+		if scope is not None:
+			self.WWWAuthenticate["scope"] = scope
+		if error is not None:
+			self.WWWAuthenticate["error"] = error
+		if error_description is not None:
+			self.WWWAuthenticate["error_description"] = error_description
+		if error_uri is not None:
+			self.WWWAuthenticate["error_uri"] = error_uri
+		if resource_metadata is not None:
+			self.WWWAuthenticate["resource_metadata"] = resource_metadata
+
+		# Update the header
+		if hasattr(self, "headers"):
+			self.headers[aiohttp.hdrs.WWW_AUTHENTICATE] = "Bearer " + ", ".join(
+				"{}=\"{}\"".format(k, (" ".join(v) if k == "scope" else v))
+				for k, v in self.WWWAuthenticate.items()
+				if v is not None
+			)
 
 
 class ValidationError(Exception):
@@ -9,20 +45,76 @@ class ValidationError(Exception):
 	pass
 
 
-class NotAuthenticatedError(aiohttp.web.HTTPUnauthorized):
+class NotAuthenticatedError(_WWWAuthenticateMixin, aiohttp.web.HTTPUnauthorized):
 	"""
 	Request could not be authenticated
 	"""
-	def __init__(self):
-		# TODO: Optionally include "error", "realm" etc. (https://www.rfc-editor.org/rfc/rfc6750#section-3)
-		super().__init__(headers={"WWW-Authenticate": "Bearer scope=openid"})
+	def __init__(
+		self,
+		*args,
+		realm: str | None = "asab",
+		scope: typing.List[str] | None = None,
+		error: str | None = "invalid_token",
+		error_description: str | None = None,
+		error_uri: str | None = None,
+		resource_metadata: str | None = None,
+		**kwargs
+	):
+		"""
+		Args:
+			*args:
+			realm: Defines the protection space within the server being accessed (RFC2617)
+			scope: The scope required to access the resource (RFC6750)
+			error: ASCII error code (RFC6750)
+			error_description: Human-readable UTF-8 encoded text providing additional error information (RFC6750)
+			resource_metadata: The URL of the protected resource metadata (RFC9728)
+			**kwargs:
+		"""
+		super().__init__()
+		self.WWWAuthenticate = {}
+		self.update_www_authenticate(
+			realm=realm,
+			scope=scope,
+			error=error,
+			error_description=error_description,
+			resource_metadata=resource_metadata
+		)
 
 
-class AccessDeniedError(aiohttp.web.HTTPForbidden):
+class AccessDeniedError(_WWWAuthenticateMixin, aiohttp.web.HTTPForbidden):
 	"""
 	Authenticated subject does not have the rights to access requested resource
 	"""
-	pass
+	def __init__(
+		self,
+		*args,
+		realm: str | None = "asab",
+		scope: typing.List[str] | None = None,
+		error: str | None = "insufficient_scope",
+		error_description: str | None = None,
+		error_uri: str | None = None,
+		resource_metadata: str | None = None,
+		**kwargs
+	):
+		"""
+		Args:
+			*args:
+			realm: Defines the protection space within the server being accessed (RFC2617)
+			scope: The scope required to access the resource (RFC6750)
+			error: ASCII error code (RFC6750)
+			error_description: Human-readable UTF-8 encoded text providing additional error information (RFC6750)
+			resource_metadata: The URL of the protected resource metadata (RFC9728)
+			**kwargs:
+		"""
+		super().__init__()
+		self.WWWAuthenticate = {}
+		self.update_www_authenticate(
+			realm=realm,
+			scope=scope,
+			error=error,
+			error_description=error_description,
+			resource_metadata=resource_metadata
+		)
 
 
 class Conflict(Exception):
@@ -79,7 +171,7 @@ class LibraryNotReadyError(LibraryError):
 			if item is not None:
 				data = item.read()
 	except LibraryNotReadyError:
-		print("Library is not ready yet.")
+			print("Library is not ready yet.")
 	"""
 	def __init__(self, message="Library is not ready yet.", *args, **kwargs):
 		super().__init__(message, *args, **kwargs)

--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -6,12 +6,12 @@ class _WWWAuthenticateMixin:
 	def update_www_authenticate(
 		self,
 		*,
-		realm: str | None = None,
-		scope: typing.List[str] | None = None,
-		error: str | None = None,
-		error_description: str | None = None,
-		error_uri: str | None = None,
-		resource_metadata: str | None = None,
+		realm: typing.Optional[str] = None,
+		scope: typing.Optional[typing.List[str]] = None,
+		error: typing.Optional[str] = None,
+		error_description: typing.Optional[str] = None,
+		error_uri: typing.Optional[str] = None,
+		resource_metadata: typing.Optional[str] = None,
 	):
 		if not hasattr(self, "WwwAuthenticate"):
 			self.WWWAuthenticate = {}
@@ -52,12 +52,12 @@ class NotAuthenticatedError(_WWWAuthenticateMixin, aiohttp.web.HTTPUnauthorized)
 	def __init__(
 		self,
 		*args,
-		realm: str | None = "asab",
-		scope: typing.List[str] | None = None,
-		error: str | None = "invalid_token",
-		error_description: str | None = None,
-		error_uri: str | None = None,
-		resource_metadata: str | None = None,
+		realm: typing.Optional[str] = "asab",
+		scope: typing.Optional[typing.List[str]] = None,
+		error: typing.Optional[str] = "invalid_token",
+		error_description: typing.Optional[str] = None,
+		error_uri: typing.Optional[str] = None,
+		resource_metadata: typing.Optional[str] = None,
 		**kwargs
 	):
 		"""
@@ -88,12 +88,12 @@ class AccessDeniedError(_WWWAuthenticateMixin, aiohttp.web.HTTPForbidden):
 	def __init__(
 		self,
 		*args,
-		realm: str | None = "asab",
-		scope: typing.List[str] | None = None,
-		error: str | None = "insufficient_scope",
-		error_description: str | None = None,
-		error_uri: str | None = None,
-		resource_metadata: str | None = None,
+		realm: typing.Optional[str] = "asab",
+		scope: typing.Optional[typing.List[str]] = None,
+		error: typing.Optional[str] = "insufficient_scope",
+		error_description: typing.Optional[str] = None,
+		error_uri: typing.Optional[str] = None,
+		resource_metadata: typing.Optional[str] = None,
 		**kwargs
 	):
 		"""

--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -171,7 +171,7 @@ class LibraryNotReadyError(LibraryError):
 			if item is not None:
 				data = item.read()
 	except LibraryNotReadyError:
-			print("Library is not ready yet.")
+		print("Library is not ready yet.")
 	"""
 	def __init__(self, message="Library is not ready yet.", *args, **kwargs):
 		super().__init__(message, *args, **kwargs)

--- a/asab/mcp/service.py
+++ b/asab/mcp/service.py
@@ -29,8 +29,6 @@ class MCPService(asab.Service):
 
 		self.RPCServer = aiohttp_rpc.JsonRpcServer(middlewares=[logging_middleware])
 		web.add_post(r'/{tenant}/mcp', self._handle_http_request)
-		web.add_get(r'/.well-known/oauth-protected-resource/{resource:.*}', self._resource_metadata)
-		asab.web.tenant.NO_TENANT_ROUTES.add('/.well-known/oauth-protected-resource/{resource}')
 
 		self.RPCServer.add_method(aiohttp_rpc.JsonRpcMethod(self._rpc_mcp_initialize, name="initialize"))
 		self.RPCServer.add_method(aiohttp_rpc.JsonRpcMethod(self._rpc_notifications_initialized, name="notifications/initialized"))
@@ -76,29 +74,6 @@ class MCPService(asab.Service):
 	async def _handle_http_request(self, request):
 		# TODO: Handle tenant and authorization
 		return await self.RPCServer.handle_http_request(request)
-
-
-	@asab.web.auth.noauth
-	async def _resource_metadata(self, request):
-		"""
-		Handles OAuth 2.1 Resource Metadata requests.
-
-		https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-location
-		"""
-		resource_id = request.match_info["resource"]
-		response = {
-			"resource": resource_id,
-		}
-		# TODO: Check resource existence and authorization
-		# TODO: Resource must contain tenant ID
-		# resource = self.get_resource_metadata(resource_id)
-		# if "name" in resource:
-		# 	response["resource_name"] = resource["name"]
-
-		auth_svc = self.App.get_service("asab.AuthService")
-		if auth_svc is not None:
-			response["authorization_servers"] = auth_svc.get_auth_servers()
-		return asab.web.rest.json_response(request, response)
 
 
 	async def _rpc_mcp_initialize(self, capabilities=None, clientInfo=None, *args, **kwargs):

--- a/asab/mcp/service.py
+++ b/asab/mcp/service.py
@@ -2,8 +2,6 @@ import logging
 import dataclasses
 
 import asab
-import asab.web.rest
-import asab.web.tenant
 
 import aiohttp_rpc
 

--- a/asab/mcp/service.py
+++ b/asab/mcp/service.py
@@ -2,6 +2,8 @@ import logging
 import dataclasses
 
 import asab
+import asab.web.rest
+import asab.web.tenant
 
 import aiohttp_rpc
 
@@ -27,6 +29,8 @@ class MCPService(asab.Service):
 
 		self.RPCServer = aiohttp_rpc.JsonRpcServer(middlewares=[logging_middleware])
 		web.add_post(r'/{tenant}/mcp', self._handle_http_request)
+		web.add_get(r'/.well-known/oauth-protected-resource/{resource:.*}', self._resource_metadata)
+		asab.web.tenant.NO_TENANT_ROUTES.add('/.well-known/oauth-protected-resource/{resource}')
 
 		self.RPCServer.add_method(aiohttp_rpc.JsonRpcMethod(self._rpc_mcp_initialize, name="initialize"))
 		self.RPCServer.add_method(aiohttp_rpc.JsonRpcMethod(self._rpc_notifications_initialized, name="notifications/initialized"))
@@ -72,6 +76,29 @@ class MCPService(asab.Service):
 	async def _handle_http_request(self, request):
 		# TODO: Handle tenant and authorization
 		return await self.RPCServer.handle_http_request(request)
+
+
+	@asab.web.auth.noauth
+	async def _resource_metadata(self, request):
+		"""
+		Handles OAuth 2.1 Resource Metadata requests.
+
+		https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-location
+		"""
+		resource_id = request.match_info["resource"]
+		response = {
+			"resource": resource_id,
+		}
+		# TODO: Check resource existence and authorization
+		# TODO: Resource must contain tenant ID
+		# resource = self.get_resource_metadata(resource_id)
+		# if "name" in resource:
+		# 	response["resource_name"] = resource["name"]
+
+		auth_svc = self.App.get_service("asab.AuthService")
+		if auth_svc is not None:
+			response["authorization_servers"] = auth_svc.get_auth_servers()
+		return asab.web.rest.json_response(request, response)
 
 
 	async def _rpc_mcp_initialize(self, capabilities=None, clientInfo=None, *args, **kwargs):

--- a/asab/web/auth/authorization.py
+++ b/asab/web/auth/authorization.py
@@ -191,7 +191,7 @@ class Authorization:
 		if not self.has_superuser_access():
 			L.warning("Superuser authorization required.", struct_data={
 				"cid": self.CredentialsId})
-			raise AccessDeniedError(scope=[SUPERUSER_RESOURCE_ID])
+			raise AccessDeniedError()
 
 
 	def require_resource_access(self, *resources: str):
@@ -214,7 +214,7 @@ class Authorization:
 		if not self.has_resource_access(*resources):
 			L.warning("Resource authorization required.", struct_data={
 				"resource": resources, "cid": self.CredentialsId})
-			scope = set(resources)
+			scope = set()
 			_add_tenant_scope(scope)
 			raise AccessDeniedError(scope=scope)
 

--- a/asab/web/auth/authorization.py
+++ b/asab/web/auth/authorization.py
@@ -191,7 +191,7 @@ class Authorization:
 		if not self.has_superuser_access():
 			L.warning("Superuser authorization required.", struct_data={
 				"cid": self.CredentialsId})
-			raise AccessDeniedError()
+			raise AccessDeniedError(scope=[SUPERUSER_RESOURCE_ID])
 
 
 	def require_resource_access(self, *resources: str):
@@ -214,7 +214,7 @@ class Authorization:
 		if not self.has_resource_access(*resources):
 			L.warning("Resource authorization required.", struct_data={
 				"resource": resources, "cid": self.CredentialsId})
-			raise AccessDeniedError()
+			raise AccessDeniedError(scope=list(resources))
 
 
 	def require_tenant_access(self, tenant=None):
@@ -253,7 +253,7 @@ class Authorization:
 		if not has_tenant_access(self._Resources, tenant):
 			L.warning("Tenant authorization required.", struct_data={
 				"tenant": tenant, "cid": self.CredentialsId})
-			raise AccessDeniedError()
+			raise AccessDeniedError(scope=["tenant:{}".format(tenant)])
 
 
 	def user_info(self) -> typing.Dict[str, typing.Any]:

--- a/asab/web/auth/authorization.py
+++ b/asab/web/auth/authorization.py
@@ -214,7 +214,9 @@ class Authorization:
 		if not self.has_resource_access(*resources):
 			L.warning("Resource authorization required.", struct_data={
 				"resource": resources, "cid": self.CredentialsId})
-			raise AccessDeniedError(scope=list(resources))
+			scope = set(resources)
+			_add_tenant_scope(scope)
+			raise AccessDeniedError(scope=scope)
 
 
 	def require_tenant_access(self, tenant=None):
@@ -253,7 +255,9 @@ class Authorization:
 		if not has_tenant_access(self._Resources, tenant):
 			L.warning("Tenant authorization required.", struct_data={
 				"tenant": tenant, "cid": self.CredentialsId})
-			raise AccessDeniedError(scope=["tenant:{}".format(tenant)])
+			scope = set()
+			_add_tenant_scope(scope)
+			raise AccessDeniedError(scope=scope)
 
 
 	def user_info(self) -> typing.Dict[str, typing.Any]:
@@ -395,3 +399,15 @@ def _authorized_resources(resources_claim: typing.Mapping, tenant: typing.Union[
 		raise ValueError("Invalid tenant name: {}".format(tenant))
 
 	return set(resources_claim.get(tenant if tenant is not None else "*", []))
+
+
+def _add_tenant_scope(scope: typing.Set[str]):
+	"""
+	Add tenant scope to the provided scope set if tenant is present in context.
+
+	Args:
+		scope (typing.Set[str]): Set of scope strings to add tenant scope to.
+	"""
+	tenant = Tenant.get(None)
+	if tenant is not None:
+		scope.add("tenant:{}".format(tenant))

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -66,5 +66,3 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 
 		self.Authorizations[access_token] = authz
 		return authz
-
-

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -3,6 +3,7 @@ import logging
 import aiohttp.web
 import jwcrypto.jwt
 import jwcrypto.jwk
+import asab
 
 from .abc import AuthProviderABC
 from .key_providers import PublicKeyProviderABC

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -1,7 +1,6 @@
 import functools
 import inspect
 import logging
-import re
 import typing
 
 import aiohttp
@@ -148,20 +147,6 @@ class AuthService(Service):
 			raise error
 
 		raise NotAuthenticatedError()
-
-
-	def get_auth_servers(self) -> typing.List[str]:
-		"""
-		Get the list of authorization servers trusted by the AuthService.
-
-		Returns:
-			List of authorization server URLs.
-		"""
-		# TODO: Temporary redundant config - Use providers to get the auth servers
-		auth_servers = Config.get("auth", "servers", fallback="").strip()
-		if not auth_servers:
-			return []
-		return re.split(r"\s+", auth_servers, flags=re.MULTILINE)
 
 
 	def _set_up_providers(self):

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -133,15 +133,20 @@ class AuthService(Service):
 		Raises:
 			NotAuthenticatedError: When no provider is able to authorize the request
 		"""
+		error = None
 		for provider in self.Providers:
 			try:
 				return await provider.authorize(request)
-			except NotAuthenticatedError:
+			except NotAuthenticatedError as e:
 				# Provider was unable to authenticate request
 				# L.debug("Authorization failed.", struct_data={"auth_provider": provider.Type})
-				pass
+				error = e
 
 		L.warning("Cannot authenticate request: No valid authorization provider found.")
+		if error:
+			# Re-raise the last error, preserve the original error response headers
+			raise error
+
 		raise NotAuthenticatedError()
 
 

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import logging
+import re
 import typing
 
 import aiohttp
@@ -142,6 +143,20 @@ class AuthService(Service):
 
 		L.warning("Cannot authenticate request: No valid authorization provider found.")
 		raise NotAuthenticatedError()
+
+
+	def get_auth_servers(self) -> typing.List[str]:
+		"""
+		Get the list of authorization servers trusted by the AuthService.
+
+		Returns:
+			List of authorization server URLs.
+		"""
+		# TODO: Temporary redundant config - Use providers to get the auth servers
+		auth_servers = Config.get("auth", "servers", fallback="").strip()
+		if not auth_servers:
+			return []
+		return re.split(r"\s+", auth_servers, flags=re.MULTILINE)
 
 
 	def _set_up_providers(self):


### PR DESCRIPTION
# Summary
- Extended `NotAuthenticatedError` (401) and `AccessDeniedError` (403) to include `WWW-Authenticate` header with `resource_metadata`.
- This requires `resource_metadata_url` to be specified in the config:

```ini
[auth]
resource_metadata_url=https://auth.teskalabs.com/.well-known/oauth-protected-resource
...
```

# Compatibility
- Relies on https://github.com/TeskaLabs/seacat-auth/pull/541 to work properly
