### PR TITLE
Add session_id and connected node to ZK connection log

### DIFF
--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -143,8 +143,12 @@ class ZooKeeperContainer(Configurable):
 		conn = self.ZooKeeper.Client._connection
 		sock = conn._socket if conn else None
 		if sock is not None:
-			peername = sock.getpeername()
-			connected_node = "{}:{}".format(peername[0], peername[1])
+			try:
+				peername = sock.getpeername()
+				connected_node = "{}:{}".format(peername[0], peername[1])
+			except OSError:
+				# Socket is not connected or has been closed
+				pass
 
 		if state == kazoo.protocol.states.KazooState.CONNECTED:
 			self.ProactorService.schedule_threadsafe(self._on_connected_at_proactor_thread)

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -137,7 +137,7 @@ class ZooKeeperContainer(Configurable):
 		'''
 		session_id = None
 		client_id = getattr(self.ZooKeeper.Client, 'client_id', None)
-		if client_id:
+		if client_id is not None:
 			try:
 				raw_session_id = client_id[0]
 				if raw_session_id is not None:

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -135,12 +135,12 @@ class ZooKeeperContainer(Configurable):
 		* ZooKeeperContainer.state/LOST!
 		* ZooKeeperContainer.state/SUSPENDED!
 		'''
-		session_id = getattr(self.Client, '_session_id', None)
+		session_id = getattr(self.ZooKeeper.Client, '_session_id', None)
 		if session_id is not None:
 			session_id = hex(session_id)
 
 		connected_node = None
-		conn = self.Client._connection
+		conn = self.ZooKeeper.Client._connection
 		sock = conn._socket if conn else None
 		if sock is not None:
 			peername = sock.getpeername()

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -135,9 +135,16 @@ class ZooKeeperContainer(Configurable):
 		* ZooKeeperContainer.state/LOST!
 		* ZooKeeperContainer.state/SUSPENDED!
 		'''
-		session_id = getattr(self.ZooKeeper.Client, '_session_id', None)
-		if session_id is not None:
-			session_id = hex(session_id)
+		session_id = None
+		client_id = getattr(self.ZooKeeper.Client, 'client_id', None)
+		if client_id:
+			try:
+				raw_session_id = client_id[0]
+				if raw_session_id is not None:
+					session_id = hex(raw_session_id)
+			except (TypeError, IndexError, ValueError):
+				# Unexpected client_id format; leave session_id as None
+				pass
 
 		connected_node = None
 		conn = self.ZooKeeper.Client._connection


### PR DESCRIPTION
Added session_id and connected node of the current ZK client session to the log.

`python3 examples/zookeeper.py`:

```
22-Jan-2026 11:58:12.120608 NOTICE asab.application is ready.
22-Jan-2026 11:58:42.233386 NOTICE asab.zookeeper.container [sd node="10.17.171.89:2181" session_id="0x100468227810001"] Connected to ZooKeeper
22-Jan-2026 11:59:37.073745 WARNING kazoo.client Connection dropped: socket connection broken
22-Jan-2026 11:59:37.074410 WARNING kazoo.client Transition to CONNECTING
22-Jan-2026 11:59:37.074743 WARNING asab.zookeeper.container [sd state="SUSPENDED" node="10.17.171.89:2181" session_id="0x100468227810001"] ZooKeeper connection state changed. Zookeeper calls are now blocking!
22-Jan-2026 11:59:37.327655 WARNING kazoo.client Connection dropped: socket connection error: Connection refused
22-Jan-2026 11:59:37.368808 NOTICE asab.zookeeper.container [sd node="10.17.168.156:2181" session_id="0x100468227810001"] Connected to ZooKeeper
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Connection-state logging now includes richer structured diagnostic context (hex-encoded session ID and remote node information) for CONNECTED, LOST, and other transitions to improve observability and troubleshooting; no runtime behavior or control flow changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->