### PR TITLE
Library: Make layers consistently string-typed.

### DIFF
--- a/asab/library/item.py
+++ b/asab/library/item.py
@@ -10,14 +10,12 @@ class LibraryItem:
     Attributes:
         name (str): The absolute path of the Item. It can be directly fed into `LibraryService.read(...)`.
         type (str): Can be either `dir` if the Item is a directory or `item` if Item is of any other type.
-            layers (list[int | str]): Identifiers of layers in which this item was found.
-        Values are provider-defined and treated as opaque identifiers.
-        Examples: 0, 1, "0:global", "0:tenant", "0:personal".
+        layers (list[str]): Identifiers of layers in which this item was found.
+        Examples only as strings, e.g. "0", "1", "0:global", "0:tenant", "0:personal".
         providers (list): List of `LibraryProvider` objects containing this Item.
         disabled (bool): `True` if the Item is disabled, `False` otherwise. If the Item is disabled, `LibraryService.read(...)` will return `None`.
         favorite (bool): True if the Item is marked as a favorite.
         override (int): If `True`, this item is marked as an override for the providers with the same Item name.
-        target (str): Specifies the target context, e.g., "tenant" or "global". Defaults to "global".
     """
     name: str
     type: str

--- a/asab/library/item.py
+++ b/asab/library/item.py
@@ -10,7 +10,9 @@ class LibraryItem:
     Attributes:
         name (str): The absolute path of the Item. It can be directly fed into `LibraryService.read(...)`.
         type (str): Can be either `dir` if the Item is a directory or `item` if Item is of any other type.
-        layer (int): The number of highest layer in which this Item is found. The higher the number, the lower the layer is.
+            layers (list[int | str]): Identifiers of layers in which this item was found.
+        Values are provider-defined and treated as opaque identifiers.
+        Examples: 0, 1, "0:global", "0:tenant", "0:personal".
         providers (list): List of `LibraryProvider` objects containing this Item.
         disabled (bool): `True` if the Item is disabled, `False` otherwise. If the Item is disabled, `LibraryService.read(...)` will return `None`.
         favorite (bool): True if the Item is marked as a favorite.
@@ -19,7 +21,7 @@ class LibraryItem:
     """
     name: str
     type: str
-    layers: typing.List[int]  # Now stores multiple layers in ascending order
+    layers: typing.List[typing.Union[int, str]]
     providers: list
     disabled: bool = False
     favorite: bool = False

--- a/asab/library/item.py
+++ b/asab/library/item.py
@@ -21,7 +21,7 @@ class LibraryItem:
     """
     name: str
     type: str
-    layers: typing.List[typing.Union[int, str]]
+    layers: typing.List[str]
     providers: list
     disabled: bool = False
     favorite: bool = False

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -151,7 +151,7 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 			items.append(LibraryItem(
 				name=i.name,
 				type=i.type,
-				layers=[self.Layer],
+				layers=[str(self.Layer)],
 				providers=[self],
 				size=i.size if isinstance(i, AzureItem) else 0  # Include size
 			))

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -120,7 +120,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			items.append(LibraryItem(
 				name=fname,
 				type=ftype,
-				layers=[self.Layer],
+				layers=[str(self.Layer)],
 				providers=[self],
 				size=size  # Include size attribute
 			))

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -154,7 +154,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			item = LibraryItem(
 				name=path[len(self.BasePath):],  # Store relative path
 				type="item",  # or "dir" if applicable
-				layers=[self.Layer],
+				layers=[str(self.Layer)],
 				providers=[self],
 			)
 			results.append(item)

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -642,7 +642,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				results.append(
 					LibraryItem(
 						name=(
-								"/" + full_path[len(root):].lstrip("/")
+							"/" + full_path[len(root):].lstrip("/")
 						),
 						type="item",
 						layers=[self.Layer if self.Layer != 0 else "0:{}".format(target)],

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -592,6 +592,14 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return tenants
 
 	async def find(self, filename: str) -> list:
+		"""
+		Recursively search for files ending with a specific name in ZooKeeper nodes, starting from the base path.
+
+		:param filename: The filename to search for (e.g., '.setup.yaml')
+		:return: A list of LibraryItem objects for files ending with the specified name,
+				or an empty list if no matching files were found.
+		"""
+
 		results = []
 
 		tenant_id = self._current_tenant_id()

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -658,4 +658,5 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 						filename,
 						results,
 						target=target,
+						root=root,
 					)

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -625,11 +625,11 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				filename,
 				results,
 				target=target,
+				root=root,
 			)
-
 		return results
 
-	async def _recursive_find(self, path, filename, results, *, target):
+	async def _recursive_find(self, path, filename, results, *, target, root):
 		children = await self.Zookeeper.get_children(path) or []
 		for child in children:
 			# ---- hard stop: never cross scopes ----
@@ -641,12 +641,15 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			if full_path.endswith(filename):
 				results.append(
 					LibraryItem(
-						name=full_path[len(self.BasePath):],
+						name=(
+								"/" + full_path[len(root):].lstrip("/")
+						),
 						type="item",
 						layers=[self.Layer if self.Layer != 0 else "0:{}".format(target)],
 						providers=[self],
 					)
 				)
+
 			else:
 				# recurse only into directories
 				if "." not in child or child.endswith((".io", ".d")):

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -649,7 +649,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				)
 			else:
 				# recurse only into directories
-				if "." not in child:
+				if "." not in child or child.endswith((".io", ".d")):
 					await self._recursive_find(
 						full_path,
 						filename,

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -639,7 +639,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 					LibraryItem(
 						name=full_path[len(self.BasePath):],
 						type="item",
-						layers=[self.Layer if self.Layer != 0 else f"0:{target}"],
+						layers=[self.Layer if self.Layer != 0 else "0:{}".format(target)],
 						providers=[self],
 					)
 				)

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -622,11 +622,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return results
 
 	async def _recursive_find(self, path, filename, results, *, target):
-		try:
-			children = await self.Zookeeper.get_children(path)
-		except kazoo.exceptions.NoNodeError:
-			return
-
+		children = await self.Zookeeper.get_children(path) or []
 		for child in children:
 			# ---- hard stop: never cross scopes ----
 			if child in {".tenants", ".personal"}:

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -423,7 +423,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				else:
 					layer_label = "0:{}".format(target)
 			else:
-				layer_label = self.Layer
+				layer_label = str(self.Layer)
 
 			items.append(LibraryItem(
 				name=fname,
@@ -645,7 +645,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 							"/" + full_path[len(root):].lstrip("/")
 						),
 						type="item",
-						layers=[self.Layer if self.Layer != 0 else "0:{}".format(target)],
+						layers=[str(self.Layer) if self.Layer != 0 else "0:{}".format(target)],
 						providers=[self],
 					)
 				)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -373,7 +373,7 @@ class LibraryService(Service):
 				item.disabled = self.check_disabled(item.name)
 				item.favorite = self.check_favorite(item.name)
 				# Use the layers as provided by the provider; if empty, fall back to outer_layer.
-				provider_layers = item.layers if item.layers else [outer_layer]
+				provider_layers = item.layers if item.layers else [str(outer_layer)]
 
 				if item.name in unique_items:
 					existing_item = unique_items[item.name]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now runs per-root (personal, tenant, global), respects per-root context and propagates target through traversal.
  * Library items use multi-type layer identifiers (strings), and include new override and optional size fields; the previous single-target field was removed.

* **Bug Fixes**
  * Enforces scope boundaries during traversal, restricts recursion to valid directories, and safely accumulates results across roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->