### PR TITLE
Library Git provider - Try to initialize repository periodically

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -399,7 +399,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 		if not hasattr(self.GitRepository, "remotes"):
 			L.error(
-				"Git repository not initialized: remotes attribute missing",
+				"Git repository not initialized: Git repository object is in an invalid state (missing remote configuration)",
 				struct_data={"layer": self.Layer, "url": self.URLPath}
 			)
 			return


### PR DESCRIPTION
- `asyncio.Lock` is used to prevent race conditions.
- When the repository is not initialized during provider init, retry is triggered once per minute
- Slightly improved logging messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async background repository sync with deferred initialization and a public startup-invocation to initialize repositories on demand.

* **Bug Fixes & Improvements**
  * More resilient startup and repo validation with safer clone vs pull behavior to avoid shutdowns.
  * Enhanced, structured diagnostics and clearer messages for URL/SSH/auth failures and host verification.
  * Conditional SSL handling and stronger concurrency controls for more reliable pull/clone operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->