### PR TITLE
Git Provider: removing redundant check

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -404,13 +404,6 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			)
 			return
 
-		if "origin" not in self.GitRepository.remotes:
-			L.error(
-				"Git repository not initialized: origin remote missing",
-				struct_data={"layer": self.Layer, "url": self.URLPath}
-			)
-			return
-
 		# If everything went fine, set the provider as ready
 		await self._set_ready()
 


### PR DESCRIPTION
#729 

the code is faulty in some versions in pygit and not vital

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Git repository initialization now succeeds for repositories without an "origin" remote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->