### PR TITLE
Catch InfluxDB connection error

### DIFF
--- a/asab/metrics/influxdb.py
+++ b/asab/metrics/influxdb.py
@@ -140,11 +140,11 @@ class InfluxDBTarget(asab.Configurable):
 			response = conn.getresponse()
 			if response.status != 204:
 				L.warning("Failed to send metrics to InfluxDB.", struct_data={"url": self.BaseURL, "response.status": response.status, "response": response.read().decode("utf-8")})
-		except (ConnectionError, socket.gaierror):
-			L.error("Failed to connect to InfluxDB.", struct_data={"url": self.BaseURL})
-			return
 		except http.client.RemoteDisconnected:
 			L.error("Failed to send metrics to InfluxDB: Remote end closed connection without response.", struct_data={"url": self.BaseURL})
+			return
+		except (ConnectionError, socket.gaierror):
+			L.error("Failed to connect to InfluxDB.", struct_data={"url": self.BaseURL})
 			return
 		except Exception as err:
 			L.exception("Failed to send metrics to InfluxDB: {}".format(err), struct_data={"url": self.BaseURL})


### PR DESCRIPTION
1. When InfluxDB closes without response during synchronous upload, exception from `TaskService` is now catched and a single error is displayed.
2. Ensuring the connection is closed every time.

Solves:

```
18-Feb-2026 15:54:00.162266 WARNING asab.metrics.influxdb [sd url="[http://influxdb:8086](vscode-file://vscode-app/snap/code/224/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)" response.status="500" response="{"code":"internal error","message":"unexpected error writing points to database: timeout"}"] Sending metrics to InfluxDB failed.
18-Feb-2026 16:10:10.342383 ERROR asab.task Error 'Remote end closed connection without response' during task:
Traceback (most recent call last):
File "/usr/local/lib/python3.11/site-packages/asab/task.py", line 161, in main
await task
File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
result = self.fn(*self.args, **self.kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/asab/metrics/influxdb.py", line 147, in _worker_upload
response = conn.getresponse()
^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/http/client.py", line 1395, in getresponse
response.begin()
File "/usr/local/lib/python3.11/http/client.py", line 325, in begin
version, status, reason = self._read_status()
^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/http/client.py", line 294, in _read_status
raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of metrics uploads: now verifies HTTP response status and logs warnings for non-success responses, handles remote disconnects with explicit error logging, ensures connections are reliably closed and logs failures during cleanup, and consolidates response handling to reduce silent failures and provide clearer diagnostics when metric submissions fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->