### PR TITLE
Feature/es 8 compatibility

### DIFF
--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -387,31 +387,36 @@ class StorageService(StorageServiceABC):
 			}
 
 		elif _filter:
-			# Apply case-insensitive filtering if _filter is provided
 			body = {'query': {}}
 			body['query']['wildcard'] = {
 				'_keys': {
-					'value': f"*{_filter.lower()}*",  # Case-insensitive wildcard search
-					'case_insensitive': True  # Requires ES 7.10+
+					'value': f"*{_filter.lower()}*",
+					'case_insensitive': True
 				}
 			}
 
+		# Initialize sort list
 		if sorts:
 			body['sort'] = []
-
 			for field, desc in sorts:
 				order = 'desc' if desc else 'asc'
 				body['sort'].append({field: {"order": order}})
+			
+			# TIE-BREAKER: Always add _doc to the end of user-defined sorts 
+			# to ensure consistent ordering for deep pagination (search_after).
+			body['sort'].append({"_doc": "asc"})
 
 		else:
+			# DEFAULT SORT: Use _doc instead of _id to avoid Fielddata errors in ES 8/9.
+			# _doc is the most efficient sort and requires zero extra memory.
+			body['sort'] = [{"_doc": "asc"}]
 
-			# https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
-			body['sort'] = [{'_id': 'asc'}]  # Always need a consistent sort order for deep pagination
-
-		# Use "search_after" for deep pagination when "_from" exceeds 10,000
+		# Use "search_after" for deep pagination
 		if last_hit_sort:
 			body['search_after'] = last_hit_sort
 
+		# Note: If size + _from > 10,000, ES will throw an error. 
+		# In ASAB/search_after patterns, _from should ideally remain 0 while using last_hit_sort.
 		async with self.request("GET", "{}/_search?size={}&from={}&version=true".format(index, size, _from), json=body) as resp:
 
 			if resp.status != 200:

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -401,8 +401,8 @@ class StorageService(StorageServiceABC):
 			for field, desc in sorts:
 				order = 'desc' if desc else 'asc'
 				body['sort'].append({field: {"order": order}})
-			
-			# TIE-BREAKER: Always add _doc to the end of user-defined sorts 
+
+			# TIE-BREAKER: Always add _doc to the end of user-defined sorts
 			# to ensure consistent ordering for deep pagination (search_after).
 			body['sort'].append("_doc")
 
@@ -415,7 +415,7 @@ class StorageService(StorageServiceABC):
 		if last_hit_sort:
 			body['search_after'] = last_hit_sort
 
-		# Note: If size + _from > 10,000, ES will throw an error. 
+		# Note: If size + _from > 10,000, ES will throw an error.
 		# In ASAB/search_after patterns, _from should ideally remain 0 while using last_hit_sort.
 		async with self.request("GET", "{}/_search?size={}&from={}&version=true".format(index, size, _from), json=body) as resp:
 

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -407,7 +407,7 @@ class StorageService(StorageServiceABC):
 			body['sort'].append("_doc")
 
 		else:
-			# DEFAULT SORT: Use _doc instead of _id to avoid Fielddata errors in ES 8/9.
+			# DEFAULT SORT: Use _doc to avoid Fielddata errors in ES 8/9.
 			# _doc is the most efficient sort and requires zero extra memory.
 			body['sort'] = ["_doc"]
 

--- a/asab/storage/elasticsearch.py
+++ b/asab/storage/elasticsearch.py
@@ -390,7 +390,7 @@ class StorageService(StorageServiceABC):
 			body = {'query': {}}
 			body['query']['wildcard'] = {
 				'_keys': {
-					'value': f"*{_filter.lower()}*",
+					'value': "*{}*".format(_filter.lower()),
 					'case_insensitive': True
 				}
 			}
@@ -404,12 +404,12 @@ class StorageService(StorageServiceABC):
 			
 			# TIE-BREAKER: Always add _doc to the end of user-defined sorts 
 			# to ensure consistent ordering for deep pagination (search_after).
-			body['sort'].append({"_doc": "asc"})
+			body['sort'].append("_doc")
 
 		else:
 			# DEFAULT SORT: Use _doc instead of _id to avoid Fielddata errors in ES 8/9.
 			# _doc is the most efficient sort and requires zero extra memory.
-			body['sort'] = [{"_doc": "asc"}]
+			body['sort'] = ["_doc"]
 
 		# Use "search_after" for deep pagination
 		if last_hit_sort:


### PR DESCRIPTION
This is a small change, encountered while trying to run the storage service with ES 8x and above. The fix not only provides compatibility with the ES 8x and above, but should also optimize the method performace, while having no impact when using the ES storage service with ES 7x and above (maybe even 6x, not tested).
The issue was:
"Attempting to sort, aggregate, or access the _id field in a way that requires it to be loaded into memory. In 7.x this was allowed, but in 8.x it is blocked to prevent memory exhaustion (OOM) on large clusters."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination stability and ordering consistency for large result sets with enhanced tie-breaker sorting logic.
  * Enhanced search filtering with improved case-insensitive wildcard query handling.

* **Performance**
  * Optimized default sorting behavior to improve retrieval performance and prevent Elasticsearch fielddata-related performance issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->