### PR TITLE
fix race condition - library can become not ready before the event.wait() returns

### DIFF
--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -169,18 +169,26 @@ class LibraryService(Service):
 		"""
 		Wait for the library to be ready.
 
+		After the ready edge event fires, re-checks `is_ready()`; if another task
+		moved the library back to not-ready before this coroutine resumed, raises
+		instead of waiting again.
+
 		Args:
 			timeout (int): The timeout in seconds. If not provided, the default timeout is used.
 
 		Raises:
-			LibraryNotReadyError: If the library is not ready within the timeout.
+			LibraryNotReadyError: If the library is not ready within the timeout, or if it is
+				not ready when this coroutine continues after the wait.
 		"""
 		if timeout is None:
 			timeout = self.LibraryReadyTimeout
+		if self.is_ready():
+			return
 		try:
 			await asyncio.wait_for(self.LibraryReadyEvent.wait(), timeout=timeout)
 		except asyncio.TimeoutError:
 			raise LibraryNotReadyError("Library is not ready yet.")
+		self._ensure_ready()
 
 	async def _set_ready(self, provider):
 		if len(self.Libraries) == 0:


### PR DESCRIPTION
Mithun showed me there is a race condition in the waiting mechanism. 
I believe it. It is just still quite difficult to me to understand it fully. Robot summarizes:


wait_for_library_ready() waited only on LibraryReadyEvent, which behaves like a doorbell: it signals that readiness happened at some point (set() on the not-ready → ready edge). open() / list() need the stronger guarantee: the library is ready right now — like checking through the peephole before you act.
Without a check after the await, another task could move the library back to not-ready between “the bell rang” and “this coroutine continues,” so callers could proceed on a stale observation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Library readiness detection now short-circuits when already ready and performs additional validation after readiness events fire, ensuring consistent behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->