### PR TITLE
Introduce item and directory subscriptions for library providers

### DIFF
--- a/asab/__init__.py
+++ b/asab/__init__.py
@@ -11,6 +11,10 @@ For detailed documentation and examples, please refer to the ASAB documentation 
 
 import logging
 
+from ._teskalabs_kazoo import prefer_teskalabs_kazoo
+
+prefer_teskalabs_kazoo()
+
 from .abc.module import Module
 from .abc.service import Service
 from .abc.singleton import Singleton

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -64,3 +64,8 @@ class LibraryProviderABC(object):
 			path: Absolute path to subscribe (starting with "/")
 		"""
 		raise NotImplementedError("{}.subscribe()".format(self.__class__.__name__))
+
+	@staticmethod
+	def _is_item_subscription(path: str) -> bool:
+		name = path.rstrip("/").rsplit("/", 1)[-1]
+		return "." in name and not name.endswith((".io", ".d"))

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -48,7 +48,7 @@ class LibraryProviderABC(object):
 
 	async def subscribe(self, path: str, target: typing.Union[str, tuple, None] = None):
 		"""
-		Take a path and subscribe to changes in this directory.
+		Take a path and subscribe to changes in this directory or item.
 		When change occurs, publish PubSub signal "Library.change!"
 
 		Note:
@@ -56,7 +56,7 @@ class LibraryProviderABC(object):
 		These might vary in lag between change if the library and its propagation.
 
 		Mind following when implementing this method:
-		- user can subscribe only on existing directory. -> Check whether subscribed path is a directory,
+		- user can subscribe only on an existing directory or item -> Check the subscribed path
 			specifically in the provider
 		- subscribing to nonexisting directory or file should lead to silent error
 

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -384,7 +384,23 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		"""
-		Subscribe to filesystem changes under `path`.
+		Translate a logical library subscription into one or more filesystem watches.
+
+		Directories are expanded recursively into watched directory boundaries,
+		while items are implemented by watching their parent directory and later
+		filtering low-level events by child filename.
+
+		Examples:
+			``subscribe("/Schemas/")``
+				Recursively watches ``<BasePath>/Schemas`` and its existing
+				subdirectories. Any later change under that subtree publishes
+				``/Schemas/``.
+
+			``subscribe("/Correlations/Microsoft/Windows/Account Created.yaml")``
+				Watches the parent directory
+				``<BasePath>/Correlations/Microsoft/Windows`` and publishes the
+				item path only when the low-level event name is
+				``"Account Created.yaml"``.
 		"""
 		if self.FD is None:
 			L.warning("Cannot subscribe to changes in the filesystem layer of the library: '{}'".format(self.BasePath))
@@ -403,6 +419,17 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _iter_subscription_paths(self, path, target: typing.Union[str, tuple, None]):
+		"""
+		Resolve a logical subscription path into concrete filesystem paths.
+
+		The returned paths are scope-specific filesystem locations under the
+		global, tenant, or personal library trees.
+
+		Examples:
+			``("/Schemas/", "global")`` -> ``["<BasePath>/Schemas"]``
+			``("/Schemas/", ("tenant", "acme"))`` ->
+				``["<BasePath>/.tenants/acme/Schemas"]``
+		"""
 		if target in {None, "global"}:
 			return [self.build_path(path, tenant_specific=False)]
 
@@ -441,6 +468,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _build_directory_subscription(self, publish_path, actual_path):
+		"""Create a descriptor for a directory-style logical subscription."""
 		return {
 			"kind": "dir",
 			"publish_path": publish_path,
@@ -450,6 +478,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _build_item_subscription(self, publish_path, actual_path):
+		"""Create a descriptor for an item-style logical subscription."""
 		return {
 			"kind": "item",
 			"publish_path": publish_path,
@@ -459,6 +488,18 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _subscribe_item(self, subscription):
+		"""
+		Attach an item subscription to its parent directory watch.
+
+		Inotify delivers child-name events relative to watched directories, so
+		exact item semantics are recovered later by comparing the event name with
+		the descriptor's ``item_name``.
+
+		Example:
+			For ``/Correlations/Microsoft/Windows/Account Created.yaml`` the
+			provider watches ``.../Windows`` and later checks whether the decoded
+			inotify child name equals ``"Account Created.yaml"``.
+		"""
 		parent_path = os.path.dirname(subscription["key"][2])
 		wd = self._ensure_watch(parent_path)
 		if wd is None:
@@ -467,6 +508,18 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _subscribe_recursive(self, subscription, watched_path):
+		"""
+		Ensure a directory subscription covers ``watched_path`` and all descendants.
+
+		Filesystem recursion is not native to inotify, so the provider expands the
+		current directory tree in user space by registering one watch per existing
+		subdirectory.
+
+		Example:
+			A subscription for ``/Schemas/`` results in watches for
+			``.../Schemas``, ``.../Schemas/nested``, ``.../Schemas/nested/deeper``,
+			and so on for the current subtree snapshot.
+		"""
 		wd = self._ensure_watch(watched_path)
 		if wd is None:
 			return
@@ -485,6 +538,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _ensure_watch(self, watched_path):
+		"""Create or reuse the inotify watch for one concrete directory path."""
 		wd = self.WatchedPaths.get(watched_path)
 		if wd is not None:
 			return wd
@@ -502,6 +556,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _attach_subscription(self, wd, subscription):
+		"""Attach a logical subscription descriptor to one watched directory."""
 		subscriptions = self.WDSubscriptions.setdefault(wd, [])
 		if any(existing["key"] == subscription["key"] for existing in subscriptions):
 			return
@@ -516,6 +571,13 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _on_inotify_read(self):
+		"""
+		Read and decode one batch of packed ``inotify_event`` records.
+
+		A single ``os.read`` call may return many concatenated records, so the
+		buffer is walked record by record and each decoded event is handed to the
+		provider-level event interpreter.
+		"""
 		data = os.read(self.FD, 64 * 1024)
 
 		pos = 0
@@ -529,10 +591,24 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	def _handle_inotify_event(self, wd, mask, name):
+		"""
+		Interpret one decoded inotify event against attached subscription descriptors.
+
+		Newly created or moved-in directories are expanded into fresh recursive
+		watches so directory subscriptions keep covering the subtree as it grows.
+
+		Example:
+			If a watched ``.../Schemas`` directory reports a new child directory
+			named ``nested``, the provider adds recursive watches under
+			``.../Schemas/nested`` before aggregating the logical change
+			publication.
+		"""
 		watched_path = self.WDs.get(wd)
 		subscriptions = list(self.WDSubscriptions.get(wd, ()))
 
 		if mask & IN_ISDIR == IN_ISDIR and ((mask & IN_CREATE == IN_CREATE) or (mask & IN_MOVED_TO == IN_MOVED_TO)):
+			# Extend recursive coverage when a new directory appears under an
+			# already subscribed directory subtree.
 			child_path = os.path.join(watched_path, name) if watched_path is not None else None
 			if child_path is not None:
 				for subscription in subscriptions:
@@ -551,6 +627,17 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 
 	async def _on_aggr_timer(self):
+		"""
+		Collapse low-level inotify bursts into deduplicated logical publications.
+
+		This keeps filesystem notification multiplicity from leaking into the
+		``Library.change!`` contract.
+
+		Example:
+			Several low-level write-related events for
+			``Account Created.yaml`` collapse into one logical publication of
+			``/Correlations/Microsoft/Windows/Account Created.yaml``.
+		"""
 		to_advertise = set()
 		for subscriptions, name in self.AggrEvents:
 			for subscription in subscriptions:

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -168,11 +168,6 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			os.path.splitext(path)[1]) > 0, "File path must end with an extension (e.g. /library/Templates/item.json)"
 		assert '//' not in path, "File path cannot contain double slashes (//)"
 
-	@staticmethod
-	def _is_item_subscription(path: str) -> bool:
-		name = path.rstrip("/").rsplit("/", 1)[-1]
-		return "." in name and not name.endswith((".io", ".d"))
-
 	def build_path(self, path, tenant_specific=False, tenant=None):
 		"""
 		Build an absolute filesystem path under this provider base path.
@@ -617,3 +612,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		if self.FD is not None:
 			self.App.Loop.remove_reader(self.FD)
 			os.close(self.FD)
+		self.AggrEvents.clear()
+		self.WDs.clear()
+		self.WDSubscriptions.clear()
+		self.WatchedPaths.clear()

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -81,7 +81,9 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		self.DisabledFilePath = os.path.join(self.BasePath, '.disabled.yaml')
 
 		self.AggrEvents = []
-		self.WDs = {}  # wd -> (subscribed_path, child_path)
+		self.WDs = {}  # wd -> watched directory path
+		self.WDSubscriptions = {}  # wd -> list of subscriptions attached to the watched directory
+		self.WatchedPaths = {}  # watched directory path -> wd
 
 	def _current_tenant_id(self):
 		try:
@@ -165,6 +167,11 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		assert len(
 			os.path.splitext(path)[1]) > 0, "File path must end with an extension (e.g. /library/Templates/item.json)"
 		assert '//' not in path, "File path cannot contain double slashes (//)"
+
+	@staticmethod
+	def _is_item_subscription(path: str) -> bool:
+		name = path.rstrip("/").rsplit("/", 1)[-1]
+		return "." in name and not name.endswith((".io", ".d"))
 
 	def build_path(self, path, tenant_specific=False, tenant=None):
 		"""
@@ -383,36 +390,134 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		"""
 		Subscribe to filesystem changes under `path`.
-
-		Note:
-			`target` is accepted for API compatibility; current filesystem implementation
-			watches the resolved path without target-specific scoping.
 		"""
-		if not os.path.isdir(self.BasePath + path):
-			return
 		if self.FD is None:
 			L.warning("Cannot subscribe to changes in the filesystem layer of the library: '{}'".format(self.BasePath))
 			return
-		self._subscribe_recursive(path, path)
+
+		for actual_path in self._iter_subscription_paths(path, target):
+			if os.path.isdir(actual_path):
+				self._subscribe_recursive(
+					subscription=self._build_directory_subscription(path, actual_path),
+					watched_path=actual_path,
+				)
+			elif os.path.isfile(actual_path):
+				self._subscribe_item(
+					subscription=self._build_item_subscription(path, actual_path),
+				)
 
 
-	def _subscribe_recursive(self, subscribed_path, path_to_be_listed):
-		binary = (self.BasePath + path_to_be_listed).encode()
-		wd = inotify_add_watch(self.FD, binary, IN_ALL_EVENTS)
-		if wd == -1:
-			L.error("Error in inotify_add_watch")
+	def _iter_subscription_paths(self, path, target: typing.Union[str, tuple, None]):
+		if target in {None, "global"}:
+			return [self.build_path(path, tenant_specific=False)]
+
+		if target == "tenant":
+			return [self.build_path(path, tenant_specific=True, tenant=tenant) for tenant in self._get_tenants()]
+
+		if isinstance(target, tuple) and len(target) == 2 and target[0] == "tenant":
+			return [self.build_path(path, tenant_specific=True, tenant=target[1])]
+
+		if target == "personal":
+			tenant_id = self._current_tenant_id()
+			cred_id = self._current_credentials_id()
+			personal_path = self._personal_path(path, tenant_id, cred_id)
+			return [personal_path] if personal_path is not None else []
+
+		if isinstance(target, tuple) and len(target) == 2 and target[0] == "personal":
+			tenant_id = self._current_tenant_id()
+			personal_path = self._personal_path(path, tenant_id, target[1])
+			return [personal_path] if personal_path is not None else []
+
+		raise ValueError("Unexpected target: {!r}".format(target))
+
+
+	def _get_tenants(self) -> typing.List[str]:
+		root = os.path.join(self.BasePath, ".tenants")
+		if not os.path.isdir(root):
+			return []
+
+		tenants = []
+		for tenant in os.listdir(root):
+			tenant_path = os.path.join(root, tenant)
+			if tenant.startswith(".") or not os.path.isdir(tenant_path):
+				continue
+			tenants.append(tenant)
+		return tenants
+
+
+	def _build_directory_subscription(self, publish_path, actual_path):
+		return {
+			"kind": "dir",
+			"publish_path": publish_path,
+			"item_name": None,
+			"key": ("dir", publish_path, actual_path),
+		}
+
+
+	def _build_item_subscription(self, publish_path, actual_path):
+		return {
+			"kind": "item",
+			"publish_path": publish_path,
+			"item_name": os.path.basename(actual_path),
+			"key": ("item", publish_path, actual_path),
+		}
+
+
+	def _subscribe_item(self, subscription):
+		parent_path = os.path.dirname(subscription["key"][2])
+		wd = self._ensure_watch(parent_path)
+		if wd is None:
 			return
-		self.WDs[wd] = (subscribed_path, path_to_be_listed)
+		self._attach_subscription(wd, subscription)
+
+
+	def _subscribe_recursive(self, subscription, watched_path):
+		wd = self._ensure_watch(watched_path)
+		if wd is None:
+			return
+		self._attach_subscription(wd, subscription)
 
 		try:
-			items = self._list(path_to_be_listed)
-		except KeyError:
+			entries = list(os.scandir(watched_path))
+		except FileNotFoundError:
 			# subscribing to non-existing directory is silent
 			return
 
-		for item in items:
-			if item.type == "dir":
-				self._subscribe_recursive(subscribed_path, item.name)
+		for entry in entries:
+			if entry.name.startswith(".") or not entry.is_dir(follow_symlinks=False):
+				continue
+			self._subscribe_recursive(subscription, entry.path)
+
+
+	def _ensure_watch(self, watched_path):
+		wd = self.WatchedPaths.get(watched_path)
+		if wd is not None:
+			return wd
+
+		binary = watched_path.encode()
+		wd = inotify_add_watch(self.FD, binary, IN_ALL_EVENTS)
+		if wd == -1:
+			L.error("Error in inotify_add_watch")
+			return None
+
+		self.WatchedPaths[watched_path] = wd
+		self.WDs[wd] = watched_path
+		self.WDSubscriptions.setdefault(wd, [])
+		return wd
+
+
+	def _attach_subscription(self, wd, subscription):
+		subscriptions = self.WDSubscriptions.setdefault(wd, [])
+		if any(existing["key"] == subscription["key"] for existing in subscriptions):
+			return
+		subscriptions.append(subscription)
+
+
+	def _remove_watch(self, wd):
+		watched_path = self.WDs.pop(wd, None)
+		self.WDSubscriptions.pop(wd, None)
+		if watched_path is not None:
+			self.WatchedPaths.pop(watched_path, None)
 
 
 	def _on_inotify_read(self):
@@ -423,33 +528,41 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			wd, mask, cookie, namesize = struct.unpack_from(EVENT_FMT, data, pos)
 			pos += EVENT_SIZE + namesize
 			name = (data[pos - namesize: pos].split(b'\x00', 1)[0]).decode()
-
-			if mask & IN_ISDIR == IN_ISDIR and ((mask & IN_CREATE == IN_CREATE) or (mask & IN_MOVED_TO == IN_MOVED_TO)):
-				subscribed_path, child_path = self.WDs[wd]
-				self._subscribe_recursive(subscribed_path, "/".join([child_path, name]))
-
-			if mask & IN_IGNORED == IN_IGNORED:
-				# cleanup
-				del self.WDs[wd]
-				continue
-
-			name = (data[pos - namesize: pos].split(b'\x00', 1)[0]).decode()
-
-			full_path = os.path.join(self.BasePath, name)
-			if os.path.normpath(full_path) == os.path.normpath(self.DisabledFilePath):
-				self.App.TaskService.schedule(self.Library._read_disabled(publish_changes=True))
+			self._handle_inotify_event(wd, mask, name)
 
 		self.AggrTimer.restart(0.2)
 
 
+	def _handle_inotify_event(self, wd, mask, name):
+		watched_path = self.WDs.get(wd)
+		subscriptions = list(self.WDSubscriptions.get(wd, ()))
+
+		if mask & IN_ISDIR == IN_ISDIR and ((mask & IN_CREATE == IN_CREATE) or (mask & IN_MOVED_TO == IN_MOVED_TO)):
+			child_path = os.path.join(watched_path, name) if watched_path is not None else None
+			if child_path is not None:
+				for subscription in subscriptions:
+					if subscription["kind"] != "dir":
+						continue
+					self._subscribe_recursive(subscription, child_path)
+
+		self.AggrEvents.append((subscriptions, name))
+
+		full_path = os.path.join(watched_path, name) if watched_path is not None and len(name) > 0 else watched_path
+		if full_path is not None and os.path.normpath(full_path) == os.path.normpath(self.DisabledFilePath):
+			self.App.TaskService.schedule(self.Library._read_disabled(publish_changes=True))
+
+		if mask & IN_IGNORED == IN_IGNORED:
+			self._remove_watch(wd)
+
+
 	async def _on_aggr_timer(self):
 		to_advertise = set()
-		for wd, mask, cookie, name in self.AggrEvents:
-			# When wathed directory is being removed, more than one inotify events are being produced.
-			# When IN_IGNORED event occurs, respective wd is removed from self.WDs,
-			# but some other events (like IN_DELETE_SELF) get to this point, without having its reference in self.WDs.
-			subscribed_path, _ = self.WDs.get(wd, (None, None))
-			to_advertise.add(subscribed_path)
+		for subscriptions, name in self.AggrEvents:
+			for subscription in subscriptions:
+				if subscription["kind"] == "dir":
+					to_advertise.add(subscription["publish_path"])
+				elif name == subscription["item_name"]:
+					to_advertise.add(subscription["publish_path"])
 		self.AggrEvents.clear()
 
 		for path in to_advertise:

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -1,5 +1,4 @@
 import io
-import hashlib
 import typing
 import logging
 import functools
@@ -7,6 +6,7 @@ import os.path
 import urllib.parse
 
 import kazoo.exceptions
+import kazoo.protocol.states
 import kazoo.recipe.watchers
 
 from .abc import LibraryProviderABC
@@ -168,30 +168,33 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		self.FullPath += self.BasePath
 
-		self.VersionNodePath = self.build_path('/.version.yaml')
-		self.Version = None  # Will be read when a library become ready
-		self.VersionWatch = None
-
 		self.DisabledNodePath = self.build_path('/.disabled.yaml')
 		self.DisabledWatch = None
 
 		self.App.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_connected)
 		self.App.PubSub.subscribe("ZooKeeperContainer.state/LOST!", self._on_zk_lost)
 		self.App.PubSub.subscribe("ZooKeeperContainer.state/SUSPENDED!", self._on_zk_lost)
-		self.App.PubSub.subscribe("Application.tick/60!", self._get_version_counter)
 
-		# This is a contingency check for changes for subscribed folders in library even without version counter change.
-		self.App.PubSub.subscribe("Application.tick/600!", self._on_library_changed)
-
-		self.Subscriptions: typing.Iterable[str] = set()
-		self.NodeDigests: typing.Dict[str, bytes] = {}
+		self.Subscriptions: typing.Set[typing.Tuple[typing.Union[str, tuple, None], str]] = set()
+		self.SubscriptionActualPaths: typing.Dict[typing.Tuple[typing.Union[str, tuple, None], str], typing.List[str]] = {}
+		self.SubscriptionDescriptors: typing.Dict[
+			typing.Tuple[typing.Union[str, tuple, None], str],
+			typing.List[typing.Dict[str, typing.Any]],
+		] = {}
+		self.WatchSubscriptions: typing.Dict[str, typing.List[typing.Dict[str, typing.Any]]] = {}
+		self.PersistentWatches: typing.Set[str] = set()
 
 
 	async def finalize(self, app):
 		"""
 		The `finalize` function is called when the application is shutting down
 		"""
+		await self._remove_subscription_watches()
 		self.DisabledWatch = None
+		self.PersistentWatches = set()
+		self.WatchSubscriptions = {}
+		self.SubscriptionActualPaths = {}
+		self.SubscriptionDescriptors = {}
 		zksvc = self.App.get_service("asab.ZooKeeperService")
 		await zksvc.remove(self.ZookeeperContainer)
 
@@ -205,14 +208,6 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		L.info("is connected.", struct_data={'path': self.FullPath})
 
-		def on_version_changed(version, event):
-			self.App.Loop.call_soon_threadsafe(self._check_version_counter, version)
-
-		def install_watcher():
-			return kazoo.recipe.watchers.DataWatch(self.Zookeeper.Client, self.VersionNodePath, on_version_changed)
-
-		self.VersionWatch = await self.Zookeeper.ProactorService.execute(install_watcher)
-
 		def on_disabled_changed(data, stat):
 			# Whenever .disabled.yaml changes, reload disables
 			self.App.TaskService.schedule(self.Library._read_disabled(publish_changes=True))
@@ -222,6 +217,9 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		self.DisabledWatch = await self.Zookeeper.ProactorService.execute(install_disabled_watcher)
 
+		if len(self.WatchSubscriptions) > 0:
+			await self._restore_subscription_watches()
+
 		await self._set_ready()
 
 
@@ -229,37 +227,9 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		if zkcontainer != self.ZookeeperContainer:
 			return
 
+		self.DisabledWatch = None
+		self.PersistentWatches = set()
 		await self._set_ready(ready=False)
-
-
-	async def _get_version_counter(self, event_name=None):
-		if self.Zookeeper is None:
-			return
-
-		version = await self.Zookeeper.get_data(self.VersionNodePath)
-		self._check_version_counter(version)
-
-
-	def _check_version_counter(self, version):
-		# If version is `None` aka `/.version.yaml` doesn't exists, then assume version -1
-		if version is not None:
-			try:
-				version = int(version)
-			except ValueError:
-				version = 1
-		else:
-			version = 1
-
-		if self.Version is None:
-			# Initial grab of the version
-			self.Version = version
-			return
-
-		if self.Version == version:
-			# The version has not changed
-			return
-
-		self.App.TaskService.schedule(self._on_library_changed())
 
 	# inside class ZooKeeperLibraryProvider
 
@@ -278,6 +248,41 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			return getattr(authz, "CredentialsId", None)
 		except LookupError:
 			return None
+
+	@staticmethod
+	def _is_item_subscription(path: str) -> bool:
+		name = path.rstrip("/").rsplit("/", 1)[-1]
+		return "." in name and not name.endswith((".io", ".d"))
+
+	@staticmethod
+	def _normalize_subscription_path(path: str) -> str:
+		assert path[:1] == '/'
+		if path != '/':
+			path = path.rstrip('/')
+			if path == '':
+				return '/'
+		return path
+
+	def _zk_node_path(self, path: str) -> str:
+		path = self._normalize_subscription_path(path)
+		if self.BasePath == '':
+			return path
+		if path == '/':
+			return self.BasePath
+		return "{}{}".format(self.BasePath, path)
+
+	def _persistent_recursive_watch_mode(self):
+		add_watch_mode = getattr(kazoo.protocol.states, "AddWatchMode", None)
+		mode = getattr(add_watch_mode, "PERSISTENT_RECURSIVE", None) if add_watch_mode is not None else None
+		if mode is None or not hasattr(self.Zookeeper.Client, "add_watch"):
+			raise RuntimeError(
+				"ZooKeeper subscriptions require vendored kazoo with persistent recursive watch support."
+			)
+		return mode
+
+	def _watcher_type_any(self):
+		watcher_type = getattr(kazoo.protocol.states, "WatcherType", None)
+		return getattr(watcher_type, "ANY", None) if watcher_type is not None else None
 
 	def _personal_node_path(self, path: str, tenant_id: typing.Optional[str], cred_id: typing.Optional[str]) -> typing.Optional[str]:
 		"""
@@ -458,111 +463,186 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return node_path
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
-		self.Subscriptions.add((target, path))
+		if not hasattr(self, "SubscriptionDescriptors"):
+			self.SubscriptionDescriptors = {}
+		if not hasattr(self, "WatchSubscriptions"):
+			self.WatchSubscriptions = {}
+		if not hasattr(self, "PersistentWatches"):
+			self.PersistentWatches = set()
+		if not hasattr(self, "SubscriptionActualPaths"):
+			self.SubscriptionActualPaths = {}
 
+		self._persistent_recursive_watch_mode()
+
+		key = (target, path)
+		self.Subscriptions.add(key)
+		if key in self.SubscriptionDescriptors:
+			return
+
+		actual_paths = [
+			self._normalize_subscription_path(actual_path)
+			for actual_path in await self._iter_subscription_paths(path, target)
+		]
+
+		descriptors = []
+		for actual_path in actual_paths:
+			if not await self._subscription_path_exists(actual_path):
+				continue
+
+			descriptor = self._build_subscription_descriptor(target, path, actual_path)
+			descriptors.append(descriptor)
+			self._attach_watch_subscription(descriptor)
+			await self._ensure_subscription_watch(descriptor["zk_path"])
+
+		self.SubscriptionDescriptors[key] = descriptors
+		self.SubscriptionActualPaths[key] = [descriptor["actual_path"] for descriptor in descriptors]
+
+	async def _get_subscription_actual_paths(self, path, target: typing.Union[str, tuple, None]):
+		if not hasattr(self, "SubscriptionActualPaths"):
+			self.SubscriptionActualPaths = {}
+
+		key = (target, path)
+		actual_paths = list(self.SubscriptionActualPaths.get(key, []))
+		if not actual_paths:
+			actual_paths = [
+				self._normalize_subscription_path(actual_path)
+				for actual_path in await self._iter_subscription_paths(path, target)
+			]
+			self.SubscriptionActualPaths[key] = list(actual_paths)
+		return actual_paths
+
+	async def _iter_subscription_paths(self, path, target: typing.Union[str, tuple, None]):
 		if target in {None, "global"}:
-			self.NodeDigests[path] = await self._get_directory_hash(path)
+			return [path]
 
-		elif target == "tenant":
-			for tenant in await self._get_tenants():
-				actual_path = "/.tenants/{}{}".format(tenant, path)
-				self.NodeDigests[actual_path] = await self._get_directory_hash(actual_path)
+		if target == "tenant":
+			return ["/.tenants/{}{}".format(tenant, path) for tenant in await self._get_tenants()]
 
-		elif isinstance(target, tuple) and len(target) == 2 and target[0] == "tenant":
-			_, tenant = target
-			actual_path = "/.tenants/{}{}".format(tenant, path)
-			self.NodeDigests[actual_path] = await self._get_directory_hash(actual_path)
+		if isinstance(target, tuple) and len(target) == 2 and target[0] == "tenant":
+			return ["/.tenants/{}{}".format(target[1], path)]
 
-		elif target == "personal":
-			# current tenant + current credentials
-			try:
-				tenant_id = Tenant.get()
-			except LookupError:
-				tenant_id = None
-			try:
-				authz = Authz.get()
-				cred_id = getattr(authz, "CredentialsId", None)
-			except LookupError:
-				cred_id = None
+		if target == "personal":
+			tenant_id = self._current_tenant_id()
+			cred_id = self._current_credentials_id()
 			if tenant_id and cred_id:
-				actual_path = "/.personal/{}/{}{}".format(tenant_id, cred_id, path)
-				self.NodeDigests[actual_path] = await self._get_directory_hash(actual_path)
-		else:
-			raise ValueError("Unexpected target: {!r}".format(target))
+				return ["/.personal/{}/{}{}".format(tenant_id, cred_id, path)]
+			return []
 
-	async def _get_directory_hash(self, path):
-		path = self.BasePath + path
+		if isinstance(target, tuple) and len(target) == 2 and target[0] == "personal":
+			tenant_id = self._current_tenant_id()
+			if tenant_id and target[1]:
+				return ["/.personal/{}/{}{}".format(tenant_id, target[1], path)]
+			return []
 
-		def recursive_traversal(path, digest):
-			if not self.Zookeeper.Client.exists(path):
+		raise ValueError("Unexpected target: {!r}".format(target))
+
+	async def _subscription_path_exists(self, actual_path: str) -> bool:
+		return (await self.Zookeeper.exists(self._zk_node_path(actual_path))) is not None
+
+	def _build_subscription_descriptor(self, target, publish_path: str, actual_path: str) -> typing.Dict[str, typing.Any]:
+		actual_path = self._normalize_subscription_path(actual_path)
+		return {
+			"key": (target, publish_path, actual_path),
+			"kind": "item" if self._is_item_subscription(publish_path) else "dir",
+			"publish_path": publish_path,
+			"actual_path": actual_path,
+			"zk_path": self._zk_node_path(actual_path),
+		}
+
+	def _attach_watch_subscription(self, descriptor: typing.Dict[str, typing.Any]) -> None:
+		subscriptions = self.WatchSubscriptions.setdefault(descriptor["zk_path"], [])
+		if any(existing["key"] == descriptor["key"] for existing in subscriptions):
+			return
+		subscriptions.append(descriptor)
+
+	async def _detach_subscription_descriptors(self, key) -> None:
+		for descriptor in self.SubscriptionDescriptors.pop(key, []):
+			subscriptions = [
+				existing for existing in self.WatchSubscriptions.get(descriptor["zk_path"], [])
+				if existing["key"] != descriptor["key"]
+			]
+			if len(subscriptions) > 0:
+				self.WatchSubscriptions[descriptor["zk_path"]] = subscriptions
+			else:
+				self.WatchSubscriptions.pop(descriptor["zk_path"], None)
+				await self._remove_subscription_watch(descriptor["zk_path"])
+
+		self.SubscriptionActualPaths.pop(key, None)
+
+	async def _ensure_subscription_watch(self, zk_path: str) -> None:
+		if zk_path in self.PersistentWatches:
+			return
+
+		mode = self._persistent_recursive_watch_mode()
+
+		def on_watch_event(event, watch_path=zk_path):
+			if event is None or getattr(event, "path", None) is None:
+				return
+			self.App.TaskService.schedule_threadsafe(
+				self._handle_watch_event(watch_path, event)
+			)
+
+		def install_watch():
+			return self.Zookeeper.Client.add_watch(zk_path, on_watch_event, mode)
+
+		try:
+			await self.Zookeeper.ProactorService.execute(install_watch)
+		except kazoo.exceptions.NoNodeError:
+			return
+
+		self.PersistentWatches.add(zk_path)
+
+	async def _remove_subscription_watch(self, zk_path: str) -> None:
+		if zk_path not in self.PersistentWatches:
+			return
+
+		self.PersistentWatches.discard(zk_path)
+		watcher_type_any = self._watcher_type_any()
+		remove_all_watches = getattr(self.Zookeeper.Client, "remove_all_watches", None)
+		if watcher_type_any is None or remove_all_watches is None:
+			return
+
+		def remove_watch():
+			try:
+				remove_all_watches(zk_path, watcher_type_any)
+			except (kazoo.exceptions.NoNodeError, kazoo.exceptions.NoWatcherError):
 				return
 
-			children = self.Zookeeper.Client.get_children(path)
-			for child in children:
-				if path != "/":
-					child_path = "{}/{}".format(path, child)
-				else:
-					child_path = "/{}".format(child)
-				zstat = self.Zookeeper.Client.exists(child_path)
-				digest.update("{}\n{}\n".format(child_path, zstat.version).encode('utf-8'))
-				recursive_traversal(child_path, digest)
+		try:
+			await self.Zookeeper.ProactorService.execute(remove_watch)
+		except kazoo.exceptions.ConnectionClosedError:
+			return
 
-		digest = hashlib.sha1()
-		await self.Zookeeper.ProactorService.execute(recursive_traversal, path, digest)
-		return digest.digest()
+	async def _remove_subscription_watches(self) -> None:
+		for zk_path in list(self.PersistentWatches):
+			await self._remove_subscription_watch(zk_path)
 
-	async def _on_library_changed(self, event_name=None):
-		for (target, path) in list(self.Subscriptions):
+	async def _restore_subscription_watches(self) -> None:
+		self._persistent_recursive_watch_mode()
+		for zk_path in list(self.WatchSubscriptions.keys()):
+			await self._ensure_subscription_watch(zk_path)
 
-			async def do_check_path(actual_path):
-				try:
-					newdigest = await self._get_directory_hash(actual_path)
-				except kazoo.exceptions.NoNodeError:
-					newdigest = None
-				if newdigest != self.NodeDigests.get(actual_path):
-					self.NodeDigests[actual_path] = newdigest
-					self.App.PubSub.publish("Library.change!", self, path)
+	def _subscription_matches_event(self, descriptor: typing.Dict[str, typing.Any], event_path: str) -> bool:
+		subscription_path = descriptor["zk_path"]
+		if descriptor["kind"] == "item":
+			return event_path == subscription_path
+		if subscription_path == '/':
+			return event_path.startswith('/')
+		return event_path == subscription_path or event_path.startswith(subscription_path + "/")
 
-			if target in {None, "global"}:
-				try:
-					await do_check_path(actual_path=path)
-				except Exception as e:
-					L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path})
+	async def _handle_watch_event(self, zk_path: str, event) -> None:
+		event_path = getattr(event, "path", None)
+		if event_path is None:
+			return
 
-			elif target == "tenant":
-				for tenant in await self._get_tenants():
-					try:
-						await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
-					except Exception as e:
-						L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path, "tenant": tenant})
+		event_path = self._normalize_subscription_path(event_path)
+		to_publish = set()
+		for descriptor in list(self.WatchSubscriptions.get(zk_path, ())):
+			if self._subscription_matches_event(descriptor, event_path):
+				to_publish.add(descriptor["publish_path"])
 
-			elif isinstance(target, tuple) and len(target) == 2 and target[0] == "tenant":
-				tenant = target[1]
-				try:
-					await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
-				except Exception as e:
-					L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path, "tenant": tenant})
-
-			elif target == "personal":
-				try:
-					tenant_id = Tenant.get()
-				except LookupError:
-					tenant_id = None
-				try:
-					authz = Authz.get()
-					cred_id = getattr(authz, "CredentialsId", None)
-				except LookupError:
-					cred_id = None
-				if tenant_id and cred_id:
-					try:
-						await do_check_path(actual_path="/.personal/{}/{}{}".format(tenant_id, cred_id, path))
-					except Exception as e:
-						L.exception(
-							"Failed to process library changes: '{}'".format(e),
-							struct_data={"path": path, "tenant": tenant_id, "credentials_id": cred_id},
-						)
-			else:
-				raise ValueError("Unexpected target: {!r}".format((target, path)))
+		for publish_path in to_publish:
+			self.App.PubSub.publish("Library.change!", self, publish_path)
 
 	async def _get_personals(self) -> typing.List[str]:
 		"""

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -282,8 +282,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		watcher_type = getattr(kazoo.protocol.states, "WatcherType", None)
 		return getattr(watcher_type, "ANY", None) if watcher_type is not None else None
 
-	def _personal_node_path(self, path: str, tenant_id: typing.Optional[str], cred_id: typing.Optional[str]) -> \
-	typing.Optional[str]:
+	def _personal_node_path(self, path: str, tenant_id: typing.Optional[str], cred_id: typing.Optional[str]) -> typing.Optional[str]:
 		"""
 		Returns '/.personal/{tenant}/{cred}{path}' or None if tenant/cred are missing.
 		"""

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -463,6 +463,23 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return node_path
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
+		"""
+		Translate a logical library subscription into ZooKeeper watch state.
+
+		The logical request may expand into multiple concrete scoped paths. Each
+		existing concrete path is converted into a descriptor, attached to a watch
+		root, and backed by a persistent recursive ZooKeeper watch.
+
+		Examples:
+			``subscribe("/Schemas/", "global")``
+				Builds a directory descriptor for ``/library/Schemas`` and installs
+				a persistent recursive watch rooted there.
+
+			``subscribe("/Schemas/", "tenant")``
+				Expands into one concrete path per tenant, builds one descriptor per
+				path, and installs one persistent recursive watch per resulting
+				``zk_path``.
+		"""
 		if not hasattr(self, "SubscriptionDescriptors"):
 			self.SubscriptionDescriptors = {}
 		if not hasattr(self, "WatchSubscriptions"):
@@ -498,6 +515,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		self.SubscriptionActualPaths[key] = [descriptor["actual_path"] for descriptor in descriptors]
 
 	async def _get_subscription_actual_paths(self, path, target: typing.Union[str, tuple, None]):
+		"""Return cached or freshly expanded concrete subscription paths."""
 		if not hasattr(self, "SubscriptionActualPaths"):
 			self.SubscriptionActualPaths = {}
 
@@ -512,6 +530,19 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return actual_paths
 
 	async def _iter_subscription_paths(self, path, target: typing.Union[str, tuple, None]):
+		"""
+		Resolve a logical subscription path into one or more scoped ZooKeeper paths.
+
+		Global paths stay unchanged, tenant paths expand under ``/.tenants``, and
+		personal paths expand under ``/.personal`` using the current context.
+
+		Examples:
+			``("/Schemas/", "global")`` -> ``["/Schemas/"]``
+			``("/Schemas/", ("tenant", "acme"))`` ->
+				``["/.tenants/acme/Schemas/"]``
+			``("/Schemas/", ("personal", "cred-1"))`` with tenant context ``acme``
+				-> ``["/.personal/acme/cred-1/Schemas/"]``
+		"""
 		if target in {None, "global"}:
 			return [path]
 
@@ -537,10 +568,19 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		raise ValueError("Unexpected target: {!r}".format(target))
 
 	async def _subscription_path_exists(self, actual_path: str) -> bool:
+		"""Check whether the concrete ZooKeeper path exists before watching it."""
 		return (await self.Zookeeper.exists(self._zk_node_path(actual_path))) is not None
 
 	def _build_subscription_descriptor(self, target, publish_path: str, actual_path: str) -> typing.Dict[
 		str, typing.Any]:
+		"""
+		Build the semantic record that bridges watch callbacks back to logical paths.
+
+		Example:
+			A logical ``/Schemas/`` subscription may become:
+			``{"kind": "dir", "publish_path": "/Schemas/", "actual_path":
+			"/.tenants/acme/Schemas", "zk_path": "/library/.tenants/acme/Schemas"}``
+		"""
 		actual_path = self._normalize_subscription_path(actual_path)
 		return {
 			"key": (target, publish_path, actual_path),
@@ -551,12 +591,14 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		}
 
 	def _attach_watch_subscription(self, descriptor: typing.Dict[str, typing.Any]) -> None:
+		"""Index one descriptor under its concrete watch root."""
 		subscriptions = self.WatchSubscriptions.setdefault(descriptor["zk_path"], [])
 		if any(existing["key"] == descriptor["key"] for existing in subscriptions):
 			return
 		subscriptions.append(descriptor)
 
 	async def _detach_subscription_descriptors(self, key) -> None:
+		"""Remove all descriptors associated with one logical subscription key."""
 		for descriptor in self.SubscriptionDescriptors.pop(key, []):
 			subscriptions = [
 				existing for existing in self.WatchSubscriptions.get(descriptor["zk_path"], [])
@@ -571,6 +613,18 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		self.SubscriptionActualPaths.pop(key, None)
 
 	async def _ensure_subscription_watch(self, zk_path: str) -> None:
+		"""
+		Install the persistent recursive watch for one concrete ZooKeeper root.
+
+		The callback only schedules ASAB's own event handler; semantic filtering
+		remains in the provider rather than in the raw Kazoo callback.
+
+		Example:
+			A directory subscription for ``/Schemas/`` installs a watch on
+			``/library/Schemas``. A later event for
+			``/library/Schemas/nested/deeper/account-created.schema.json`` is
+			delivered through that same persistent recursive watch.
+		"""
 		if zk_path in self.PersistentWatches:
 			return
 
@@ -579,6 +633,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		def on_watch_event(event, watch_path=zk_path):
 			if event is None or getattr(event, "path", None) is None:
 				return
+			# Keep the Kazoo callback thin and hand semantic work back to ASAB's
+			# task service.
 			self.App.TaskService.schedule_threadsafe(
 				self._handle_watch_event(watch_path, event)
 			)
@@ -594,6 +650,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		self.PersistentWatches.add(zk_path)
 
 	async def _remove_subscription_watch(self, zk_path: str) -> None:
+		"""Remove the persistent watch for one concrete ZooKeeper root."""
 		if zk_path not in self.PersistentWatches:
 			return
 
@@ -615,15 +672,30 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			return
 
 	async def _remove_subscription_watches(self) -> None:
+		"""Remove every active persistent watch managed by this provider."""
 		for zk_path in list(self.PersistentWatches):
 			await self._remove_subscription_watch(zk_path)
 
 	async def _restore_subscription_watches(self) -> None:
+		"""Reinstall all watch roots after reconnecting to ZooKeeper."""
 		self._persistent_recursive_watch_mode()
 		for zk_path in list(self.WatchSubscriptions.keys()):
 			await self._ensure_subscription_watch(zk_path)
 
 	def _subscription_matches_event(self, descriptor: typing.Dict[str, typing.Any], event_path: str) -> bool:
+		"""
+		Apply the provider's semantic predicate for one descriptor.
+
+		Item subscriptions require exact path equality; directory subscriptions
+		require the event path to stay within the watched subtree.
+
+		Examples:
+			Item:
+				``event_path == "/library/.../Account Created.yaml"``
+
+			Directory:
+				``event_path.startswith("/library/Schemas/")``
+		"""
 		subscription_path = descriptor["zk_path"]
 		if descriptor["kind"] == "item":
 			return event_path == subscription_path
@@ -632,6 +704,18 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return event_path == subscription_path or event_path.startswith(subscription_path + "/")
 
 	async def _handle_watch_event(self, zk_path: str, event) -> None:
+		"""
+		Interpret one ZooKeeper callback against descriptors attached to ``zk_path``.
+
+		Matching logical publish paths are buffered so repeated backend callbacks
+		can be deduplicated before ``Library.change!`` is published.
+
+		Example:
+			An event for ``/library/.tenants/acme/Schemas/account-created.schema.json``
+			matches the directory descriptor rooted at
+			``/library/.tenants/acme/Schemas`` and buffers the logical publish path
+			``/Schemas/``.
+		"""
 		event_path = getattr(event, "path", None)
 		if event_path is None:
 			return
@@ -649,6 +733,13 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		self.AggrTimer.restart(0.2)
 
 	async def _on_aggr_timer(self) -> None:
+		"""
+		Publish the deduplicated logical paths accumulated from ZooKeeper callbacks.
+
+		Example:
+			Several callback events under the same watched ``/Schemas`` subtree
+			collapse into one logical publication of ``/Schemas/``.
+		"""
 		to_publish = set(self.AggrEvents)
 		self.AggrEvents.clear()
 

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -18,11 +18,11 @@ from ...contextvars import Tenant, Authz
 
 L = logging.getLogger(__name__)
 
+
 #
 
 
 class ZooKeeperLibraryProvider(LibraryProviderABC):
-
 	"""
 
 	Configuration variant:
@@ -176,14 +176,14 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		self.App.PubSub.subscribe("ZooKeeperContainer.state/SUSPENDED!", self._on_zk_lost)
 
 		self.Subscriptions: typing.Set[typing.Tuple[typing.Union[str, tuple, None], str]] = set()
-		self.SubscriptionActualPaths: typing.Dict[typing.Tuple[typing.Union[str, tuple, None], str], typing.List[str]] = {}
+		self.SubscriptionActualPaths: typing.Dict[
+			typing.Tuple[typing.Union[str, tuple, None], str], typing.List[str]] = {}
 		self.SubscriptionDescriptors: typing.Dict[
 			typing.Tuple[typing.Union[str, tuple, None], str],
 			typing.List[typing.Dict[str, typing.Any]],
 		] = {}
 		self.WatchSubscriptions: typing.Dict[str, typing.List[typing.Dict[str, typing.Any]]] = {}
 		self.PersistentWatches: typing.Set[str] = set()
-
 
 	async def finalize(self, app):
 		"""
@@ -197,7 +197,6 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		self.SubscriptionDescriptors = {}
 		zksvc = self.App.get_service("asab.ZooKeeperService")
 		await zksvc.remove(self.ZookeeperContainer)
-
 
 	async def _on_zk_connected(self, event_name, zkcontainer):
 		"""
@@ -221,7 +220,6 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			await self._restore_subscription_watches()
 
 		await self._set_ready()
-
 
 	async def _on_zk_lost(self, event_name, zkcontainer):
 		if zkcontainer != self.ZookeeperContainer:
@@ -284,7 +282,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		watcher_type = getattr(kazoo.protocol.states, "WatcherType", None)
 		return getattr(watcher_type, "ANY", None) if watcher_type is not None else None
 
-	def _personal_node_path(self, path: str, tenant_id: typing.Optional[str], cred_id: typing.Optional[str]) -> typing.Optional[str]:
+	def _personal_node_path(self, path: str, tenant_id: typing.Optional[str], cred_id: typing.Optional[str]) -> \
+	typing.Optional[str]:
 		"""
 		Returns '/.personal/{tenant}/{cred}{path}' or None if tenant/cred are missing.
 		"""
@@ -539,7 +538,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 	async def _subscription_path_exists(self, actual_path: str) -> bool:
 		return (await self.Zookeeper.exists(self._zk_node_path(actual_path))) is not None
 
-	def _build_subscription_descriptor(self, target, publish_path: str, actual_path: str) -> typing.Dict[str, typing.Any]:
+	def _build_subscription_descriptor(self, target, publish_path: str, actual_path: str) -> typing.Dict[
+		str, typing.Any]:
 		actual_path = self._normalize_subscription_path(actual_path)
 		return {
 			"key": (target, publish_path, actual_path),
@@ -657,7 +657,6 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			cred_ids = []
 		return cred_ids
 
-
 	async def _get_tenants(self) -> typing.List[str]:
 		"""
 		List tenants that have custom content in the library (in the /.tenants directory).
@@ -670,7 +669,6 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		except kazoo.exceptions.NoNodeError:
 			tenants = []
 		return tenants
-
 
 	async def find(self, filename: str) -> list:
 		"""

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -248,11 +248,6 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			return None
 
 	@staticmethod
-	def _is_item_subscription(path: str) -> bool:
-		name = path.rstrip("/").rsplit("/", 1)[-1]
-		return "." in name and not name.endswith((".io", ".d"))
-
-	@staticmethod
 	def _normalize_subscription_path(path: str) -> str:
 		assert path[:1] == '/'
 		if path != '/':

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -11,6 +11,7 @@ import kazoo.recipe.watchers
 
 from .abc import LibraryProviderABC
 from ..item import LibraryItem
+from ...timer import Timer
 from ...zookeeper import ZooKeeperContainer
 from ...contextvars import Tenant, Authz
 
@@ -184,6 +185,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		] = {}
 		self.WatchSubscriptions: typing.Dict[str, typing.List[typing.Dict[str, typing.Any]]] = {}
 		self.PersistentWatches: typing.Set[str] = set()
+		self.AggrTimer = Timer(self.App, self._on_aggr_timer)
+		self.AggrEvents: typing.Set[str] = set()
 
 	async def finalize(self, app):
 		"""
@@ -191,6 +194,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		"""
 		await self._remove_subscription_watches()
 		self.DisabledWatch = None
+		self.AggrTimer.stop()
+		self.AggrEvents.clear()
 		self.PersistentWatches = set()
 		self.WatchSubscriptions = {}
 		self.SubscriptionActualPaths = {}
@@ -226,6 +231,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			return
 
 		self.DisabledWatch = None
+		self.AggrTimer.stop()
+		self.AggrEvents.clear()
 		self.PersistentWatches = set()
 		await self._set_ready(ready=False)
 
@@ -634,6 +641,16 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		for descriptor in list(self.WatchSubscriptions.get(zk_path, ())):
 			if self._subscription_matches_event(descriptor, event_path):
 				to_publish.add(descriptor["publish_path"])
+
+		if len(to_publish) == 0:
+			return
+
+		self.AggrEvents.update(to_publish)
+		self.AggrTimer.restart(0.2)
+
+	async def _on_aggr_timer(self) -> None:
+		to_publish = set(self.AggrEvents)
+		self.AggrEvents.clear()
 
 		for publish_path in to_publish:
 			self.App.PubSub.publish("Library.change!", self, publish_path)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -169,18 +169,26 @@ class LibraryService(Service):
 		"""
 		Wait for the library to be ready.
 
+		After the ready edge event fires, re-checks `is_ready()`; if another task
+		moved the library back to not-ready before this coroutine resumed, raises
+		instead of waiting again.
+
 		Args:
 			timeout (int): The timeout in seconds. If not provided, the default timeout is used.
 
 		Raises:
-			LibraryNotReadyError: If the library is not ready within the timeout.
+			LibraryNotReadyError: If the library is not ready within the timeout, or if it is
+				not ready when this coroutine continues after the wait.
 		"""
 		if timeout is None:
 			timeout = self.LibraryReadyTimeout
+		if self.is_ready():
+			return
 		try:
 			await asyncio.wait_for(self.LibraryReadyEvent.wait(), timeout=timeout)
 		except asyncio.TimeoutError:
 			raise LibraryNotReadyError("Library is not ready yet.")
+		self._ensure_ready()
 
 	async def _set_ready(self, provider):
 		if len(self.Libraries) == 0:
@@ -922,7 +930,7 @@ class LibraryService(Service):
 		In order to notify on changes in the Library, this method must be used after the Library is ready.
 
 		Args:
-			paths (str | list[str]): Either single path or list of paths to be subscribed. All the paths must be absolute (start with '/').
+			paths (str | list[str]): Either a single path or list of paths to be subscribed. Paths can point to directories or items, and all paths must be absolute (start with '/').
 			target: In which target to watch the changes. Possible values:
 				- "global" to watch global path changes
 				- "tenant" to watch path changes in tenants

--- a/docs/reference/services/library.md
+++ b/docs/reference/services/library.md
@@ -1,222 +1,175 @@
-# Library Service
+Library Service
+The ASAB Library is the concept of shared data content across microservices in the cluster. In the cluster/cloud microservice architectures, all microservices must have access to unified resources. The Library provides a read-only interface for listing and reading this content.
 
-The ASAB Library is the concept of shared data content across microservices in the cluster.
-In the cluster/cloud microservice architectures, all microservices must have access to unified resources.
-The Library provides a read-only interface for listing and reading this content.
-
-The Library is designed to be read-only. It also allows to *"stack"* various libraries into one view (overlayed), merging the content of each library into one united space.
+The Library is designed to be read-only. It also allows to "stack" various libraries into one view (overlayed), merging the content of each library into one united space.
 
 The library can also notify the ASAB microservice about changes, e.g. for automated update/reload.
 
-## Library structure
-
+Library structure
 The library content is organized in a simplified file system manner, with directories and files.
 
 !!! example "Example of the library structure"
 
-	```
-	+ /MyDirectory/
-		- /MyDirectory/item1.yaml
-		- /MyDirectory/item2.json
-	+ /AnotherDirectory/
-		- /AnotherDirectory/item3.yaml
-		+ /AnotherDirectory/Folder/
-			- /folder2/Folder/item4.json
-	```
-
+```
++ /MyDirectory/
+	- /MyDirectory/item1.yaml
+	- /MyDirectory/item2.json
++ /AnotherDirectory/
+	- /AnotherDirectory/item3.yaml
+	+ /AnotherDirectory/Folder/
+		- /folder2/Folder/item4.json
+```
 !!! warning "Library path rules"
 
-	- Any path must start with "/", including the root path.
-	- The directory path must end with "/".
-	- The directory name cannot contain ".".
-	- The item path must end with a file extension (e.g. ".txt", ".json", ...).
+- Any path must start with "/", including the root path.
+- The directory path must end with "/".
+- The directory name cannot contain ".".
+- The item path must end with a file extension (e.g. ".txt", ".json", ...).
+Layers
+The library content can be organized into an unlimited number of layers. Each layer is represented by a provider (e.g. filesystem, zookeeper, git, ...) with a specific configuration. Two layers can have the same provider but different base paths.
 
+The layers of the library are like slices of Swiss cheese layered on top of each other. Only if there is a hole in the top layer can you see the layer that shows through underneath. It means that files of the upper layer overwrite files with the same path in the lower layers.
 
-## Layers
-
-The library content can be organized into an unlimited number of **layers**.
-Each layer is represented by a **provider** (e.g. filesystem, zookeeper, git, ...) with a specific configuration. Two layers can have the same provider but different base paths.
-
-The layers of the library are like slices of Swiss cheese layered on top of each other.
-Only if there is a hole in the top layer can you see the layer that shows through underneath.
-It means that files of the upper layer overwrite files with the same path in the lower layers.
-
-<figure markdown>
-  ![Illustration of Library layers](/asab/images/library/asab-library.drawio.png)
-  <figcaption>Illustration of ASAB Library layers. Green items are visible, grey items are hidden. Moreover, Layer 1 contains .disabled.yaml file containing the list of disabled files.</figcaption>
-</figure>
-
+![Illustration of Library layers](/asab/images/library/asab-library.drawio.png)
+Illustration of ASAB Library layers. Green items are visible, grey items are hidden. Moreover, Layer 1 contains .disabled.yaml file containing the list of disabled files.
 !!! tip
 
-	In the most applications, it is common to create the first layer with *Zookeeper* provider and the layers beneath with *git* or *libsreg* provider. This allows you to quickly modify items of the Library on the first layer.
-
-## Disabling files
-
+In the most applications, it is common to create the first layer with *Zookeeper* provider and the layers beneath with *git* or *libsreg* provider. This allows you to quickly modify items of the Library on the first layer.
+Disabling files
 The library concept supports multi-tenancy. By default, all items of the library are visible for everyone, but you can disable some of them for specific tenants.
 
-In order to disable some items of the library, create a file `/.disabled.yaml`. This file must be created on the first layer.
+In order to disable some items of the library, create a file /.disabled.yaml. This file must be created on the first layer.
 
-In the following example, `file1.txt` is disabled for **tenant-1** and **tenant-2**, `file2.txt` for **tenant-1** and `file3.txt` for every tenant.
+In the following example, file1.txt is disabled for tenant-1 and tenant-2, file2.txt for tenant-1 and file3.txt for every tenant.
 
-```yaml title=".disabled.yaml"
 /file1.txt:
 	- tenant-1
 	- tenant-2
 /file2.txt: tenant-1
 /file3.txt: '*'
-```
+!!! warning When disabling a file for all tenants with a star, don't forget to close it in quotation marks. Otherwise, YAML would interpret star as an alias. Read more about anchors and aliases.
 
-!!! warning
-	When disabling a file for all tenants with a star, don't forget to close it in quotation marks. Otherwise, YAML would interpret star as an alias. Read more about [anchors and aliases](https://batalin.dev/posts/yaml-anchors-and-aliases/).
+Library service
+The library service may exist in multiple instances, with different paths setups. For that reason, you have to provide a unique service_name and there is no default value for that.
 
-
-## Library service
-
-The library service may exist in multiple instances, with different `paths` setups. 
-For that reason, you have to provide a unique `service_name` and there is no default value for that.
-
-Each Library item is represented by `LibraryItem` dataclass. Read more in the [reference section](#asab.library.item.LibraryItem).
+Each Library item is represented by LibraryItem dataclass. Read more in the reference section.
 
 !!! example "Example of the use:"
 
-	```python
-	import asab
-	import asab.library
+```python
+import asab
+import asab.library
 
-	class MyApplication(asab.Application):
+class MyApplication(asab.Application):
 
-		async def initialize(self):
-			self.LibraryService = asab.library.LibraryService(self, "LibraryService") #(1)!
-			self.PubSub.subscribe("Library.ready!", self.on_library_ready) #(2)!
+	async def initialize(self):
+		self.LibraryService = asab.library.LibraryService(self, "LibraryService") #(1)!
+		self.PubSub.subscribe("Library.ready!", self.on_library_ready) #(2)!
 
-		async def on_library_ready(self, event_name, library): #(3)!
+	async def on_library_ready(self, event_name, library): #(3)!
 
-			for item in await self.LibraryService.list("/", recursive=True): #(4)!
-				print("*", item)
-				if item.type == 'item': #(5)!
-					itemio = await self.LibraryService.read(item.name) #(6)!
-					if itemio is not None:
-						with itemio: #(7)!
-							content = itemio.read()
-							print("- content: {} bytes".format(len(content)))
-					else:
-						print("  - (DISABLED)")
+		for item in await self.LibraryService.list("/", recursive=True): #(4)!
+			print("*", item)
+			if item.type == 'item': #(5)!
+				itemio = await self.LibraryService.read(item.name) #(6)!
+				if itemio is not None:
+					with itemio: #(7)!
+						content = itemio.read()
+						print("- content: {} bytes".format(len(content)))
+				else:
+					print("  - (DISABLED)")
 
-	if __name__ == '__main__':
-		app = MyApplication()
-		app.run()
-	```
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()
+```
 
-	1. Initializes the Library Service. Remember to specify a unique `service_name`.
-	2. When the Library is initialized, `Library.ready!` PubSub message is emitted. 
-	3. The callback has to possess two arguments. `event_name` is the message "Library.ready!", `library` is the specific provider with
-	which is the Library initialized.
-	4. `list()` method returns list of `LibraryItem`s. For more information, see the reference section.
-	5. `item.type` can be either 'item' or 'dir'.
-	6. `read()` coroutine returns item IO object or None if the file is disabled.
-	7. Item IO object is used as a context manager.
-
-
+1. Initializes the Library Service. Remember to specify a unique `service_name`.
+2. When the Library is initialized, `Library.ready!` PubSub message is emitted. 
+3. The callback has to possess two arguments. `event_name` is the message "Library.ready!", `library` is the specific provider with
+which is the Library initialized.
+4. `list()` method returns list of `LibraryItem`s. For more information, see the reference section.
+5. `item.type` can be either 'item' or 'dir'.
+6. `read()` coroutine returns item IO object or None if the file is disabled.
+7. Item IO object is used as a context manager.
 !!! example "Example of the library configuration:"
 
-	``` ini
-	[library]
-	providers:
-		provider+1://...
-		provider+2://...
-		provider+3://...
-	```
+``` ini
+[library]
+providers:
+	provider+1://...
+	provider+2://...
+	provider+3://...
+```
+PubSub messages
+The Library is created in not-ready state. After the connection with the technologies behind is established, every library provider changes its state to ready. The Library switches to ready state after all its providers are ready.
 
+If some of the providers is disconnected, the Library switches to not-ready state again till the connection is reestablished.
 
-## PubSub messages
+Every time the Library changes its state, PubSub message is published, with the arguments provider and path.
 
-The Library is created in `not-ready` state. After the connection with the technologies behind is established, every library provider changes its state to `ready`.
-The Library switches to `ready` state after all its providers are ready.
-
-If some of the providers is disconnected, the Library switches to `not-ready` state again till the connection is reestablished.
-
-Every time the Library changes its state, `PubSub` message is published, with the arguments `provider` and `path`.
-
-| Message | Published when... |
-| --- | --- |
-| `Library.not_ready!` | at least one provider is not ready. |
-| `Library.ready!` | all of the providers are ready. |
-| `Library.change!` | the content of the Library has changed. |
-
-
-## Notification on changes
-
+Message	Published when...
+Library.not_ready!	at least one provider is not ready.
+Library.ready!	all of the providers are ready.
+Library.change!	the content of the Library has changed.
+Notification on changes
 Some providers are able to detect changes of the library items.
 
 !!! example
 
-	```python
-	class MyApplication(asab.Application):
+```python
+class MyApplication(asab.Application):
 
-	async def initialize(self):
-		self.PubSub.subscribe("Library.ready!", self.on_library_ready
-		self.PubSub.subscribe("Library.change!", self.on_library_change)
+async def initialize(self):
+	self.PubSub.subscribe("Library.ready!", self.on_library_ready
+	self.PubSub.subscribe("Library.change!", self.on_library_change)
 
-	async def on_library_ready(self, event_name, library=None):
-		await self.LibraryService.subscribe(["/asab"]) #(1)!
+async def on_library_ready(self, event_name, library=None):
+	await self.LibraryService.subscribe(["/asab"]) #(1)!
 
-	def on_library_change(self, message, provider, path): #(2)!
-		print("New changes in the library found by provider: '{}'".format(provider))
-	```
+def on_library_change(self, message, provider, path): #(2)!
+	print("New changes in the library found by provider: '{}'".format(provider))
+```
 
-	1. `self.LibraryService.subscribe()` method takes either a single path as a string or multiple paths in list and watches for changes in them.
-	2. This coroutine takes three arguments: `message` (`Library.change!` in this case), `provider` (name of the provider that has detected changes) and `path` (the path where changes were made).
-
+1. `self.LibraryService.subscribe()` method takes either a single path as a string or multiple paths in list and watches for changes in them. The subscribed path can point to a directory or to a single item.
+2. This coroutine takes three arguments: `message` (`Library.change!` in this case), `provider` (name of the provider that has detected changes) and `path` (the path where changes were made).
 !!! info
 
-	Note that the some of the providers detect changes immediately while others detect them periodically. For example, *git provider* pulls the repository every minute, only after that the changes can be detected.
-
-
-## Providers
-
+Note that the some of the providers detect changes immediately while others detect them periodically. For example, *git provider* pulls the repository every minute, only after that the changes can be detected.
+Providers
 The list of available providers:
 
-| Provider | Read the content | Notify on changes |
-| --- | :---: | :---: |
-| Filesystem | :material-check: | :material-check: |
-| Apache Zookeeper | :material-check: | :material-check: |
-| Microsoft Azure Storage | :material-check: | :material-close: |
-| Git | :material-check:  | :material-check: |
-| Libraries repository | :material-check: | :material-close: |
-
-### Filesystem
-
-The most basic provider that reads data from the local filesystem. 
-The notification on changes functionality is available only for Linux systems,
-as it uses [inotify](https://en.wikipedia.org/wiki/Inotify).
+Provider	Read the content	Notify on changes
+Filesystem	:material-check:	:material-check:
+Apache Zookeeper	:material-check:	:material-check:
+Microsoft Azure Storage	:material-check:	:material-close:
+Git	:material-check:	:material-check:
+Libraries repository	:material-check:	:material-close:
+Filesystem
+The most basic provider that reads data from the local filesystem. The notification on changes functionality is available only for Linux systems, as it uses inotify.
 
 !!! example "Configuration examples:"
 
-	```ini
-	[library]
-	providers: /home/user/directory
-	```
+```ini
+[library]
+providers: /home/user/directory
+```
 
-	```ini
-	[library]
-	providers: ./this_directory
-	```
+```ini
+[library]
+providers: ./this_directory
+```
 
-	```ini
-	[library]
-	providers: file:///home/user/directory
-	```
-
-### Apache Zookeeper
-
-ZooKeeper as a consensus technology is vital for microservices in the
-cluster.
+```ini
+[library]
+providers: file:///home/user/directory
+```
+Apache Zookeeper
+ZooKeeper as a consensus technology is vital for microservices in the cluster.
 
 There are several configuration strategies:
 
-1)  Configuration from `[zookeeper]` section.
-
-```ini
+Configuration from [zookeeper] section.
 [zookeeper]
 servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
 path=/library
@@ -224,11 +177,7 @@ path=/library
 [library]
 providers:
 	zk://
-```
-
-2)  Specify a path of a ZooKeeper node where only library lives.
-
-```ini
+Specify a path of a ZooKeeper node where only library lives.
 [zookeeper]
 servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
 path=/else
@@ -236,9 +185,6 @@ path=/else
 [library]
 providers:
 	zk:///library
-```
-
-``` ini
 [zookeeper]
 servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
 path=/else
@@ -246,22 +192,14 @@ path=/else
 [library]
 providers:
 	zk:///
-```
-
-3)  Configuration from the URL in the `[library]` section.
-
-``` ini
+Configuration from the URL in the [library] section.
 [library]
 providers:
 	zk://zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181/library
-```
+Configuration from [zookeeper] section and joined [path]{.title-ref} from [zookeeper] and [library] sections.
 
-4)  Configuration from `[zookeeper]` section and joined
-	[path]{.title-ref} from `[zookeeper]` and `[library]` sections.
+The resulting path will be [/else/library]{.title-ref}.
 
-	> The resulting path will be [/else/library]{.title-ref}.
-
-``` ini
 [zookeeper]
 servers=zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
 path=/else
@@ -269,31 +207,20 @@ path=/else
 [library]
 providers:
 	zk://./library
-```
+If a path from the [zookeeper] section is missing, an application class name will be used, e.g. /BSQueryApp/library.
 
-If a `path` from the `[zookeeper]` section is missing, an application class name will be used, e.g.
-`/BSQueryApp/library`.
+Working with target=tenant Layers
+The ASAB Library supports multi-tenancy, allowing you to manage and separate content specific to different tenants within layers in library. To handle tenant-specific contexts, use Tenant.set() to set the context and Tenant.reset() to reset it after processing.
 
+Implementing Tenant-Specific Logic in Your Application
+To handle tenant-specific logic, make sure the AuthService is present in app.py:
 
-## Working with target=tenant Layers
-
-The ASAB Library supports multi-tenancy, allowing you to manage and separate content specific to different tenants within layers in library. To handle tenant-specific contexts, use `Tenant.set()` to set the context and `Tenant.reset()` to reset it after processing.
-
-### Implementing Tenant-Specific Logic in Your Application
-
-To handle tenant-specific logic, make sure the `AuthService` is present in `app.py`:
-
-```
 # Install the AuthService for tenant-based authentication
 self.AuthService = asab.web.auth.AuthService(self)
 self.AuthService.install(self.WebContainer)
-```
-
-### Example: Processing Multiple Tenants
-
+Example: Processing Multiple Tenants
 The following example demonstrates how to iterate through multiple tenants, setting and resetting the tenant context for each one:
 
-```
 import asab.contextvars
 
 async def process_tenants(self):
@@ -306,17 +233,13 @@ async def process_tenants(self):
         finally:
             # Reset the tenant context
             asab.contextvars.Tenant.reset(tenant_context)
-```
-
 In this method:
-- `Tenant.set(tenant)` establishes the context for the current tenant.
-- `Tenant.reset(tenant_context)` ensures the context is cleared after processing, preventing any unintended carryover.
 
-### Example: Handling a Single Tenant
-
+Tenant.set(tenant) establishes the context for the current tenant.
+Tenant.reset(tenant_context) ensures the context is cleared after processing, preventing any unintended carryover.
+Example: Handling a Single Tenant
 If you need to handle only one tenant context, the process is straightforward:
 
-```
 import asab.contextvars
 
 async def process_single_tenant(self, tenant):
@@ -326,131 +249,85 @@ async def process_single_tenant(self, tenant):
         print(f"Processing data for tenant: {tenant}")
     finally:
         asab.contextvars.Tenant.reset(tenant_context)
-```
-
-
-### Microsoft Azure Storage
-
+Microsoft Azure Storage
 You can configure the microservice to read from the Microsoft Azure Storage container.
 
 Configuration:
 
-``` ini
 [library]
 providers: azure+https://ACCOUNT-NAME.blob.core.windows.net/BLOB-CONTAINER
-```
+If Container Public Access Level is not set to "Public access", then "Access Policy" must be created with "Read" and "List" permissions and "Shared Access Signature" (SAS) query string must be added to a URL in a configuration:
 
-If Container Public Access Level is not set to *"Public access"*, then
-*"Access Policy"* must be created with *"Read"* and *"List"* permissions
-and *"Shared Access Signature" (SAS)* query string must be added to a
-URL in a configuration:
-
-``` ini
 [library]
 providers: azure+https://ACCOUNT-NAME.blob.core.windows.net/BLOB-CONTAINER?sv=2020-10-02&si=XXXX&sr=c&sig=XXXXXXXXXXXXXX
-```
-
-### Git repository
-
+Git repository
 !!! warning
 
-	Connection to git repositories requires
-	[pygit2](https://www.pygit2.org/) library to be installed.
+Connection to git repositories requires
+[pygit2](https://www.pygit2.org/) library to be installed.
 
-	```shell
-	pip install pygit2
-	```
-
+```shell
+pip install pygit2
+```
 Please follow this format in the configuration:
 
-``` ini
 [library]
 providers: git+http(s)://<username>:<deploy-token>@<path>#<branch>
-```
-
 !!! example "Cloning from GitHub repository:"
 
-	Using a public repository from GitHub, the configuration may look like
-	this:
-
-	``` ini
-	[library]
-	providers: git+https://github.com/john/awesome_project.git
-	```
-
-!!! example "Using custom branch:"
-
-	Use hash `#<branch-name>` to clone a repository from a
-	selected branch:
-
-	``` ini
-	[library]
-	providers: git+https://github.com/john/awesome_project.git#name-of-the-branch
-	```
-
-#### Deploy tokens in GitLab
-
-GitLab uses deploy tokens to enable authentication of deployment tasks,
-independent of a user account. Authentication through deploy tokens is
-the only supported option for now.
-
-If you want to create a deploy token for your GitLab repository, follow
-these steps from the
-[manual](https://docs.gitlab.com/ee/user/project/deploy_tokens/#create-a-deploy-token):
-
-1.  Go to **Settings > Repository > Deploy tokens** section in your
-	repository. (Note that you have to possess a *"Maintainer"* or
-	*"Owner"* role for the repository.)
-2.  Expand the **"Deploy tokens"** section. The list of current Active
-	Deploy Tokens will be displayed.
-3.  Complete the fields and scopes. We recommend a custom *"username"*,
-	as you will need it later for the URL in the configuration.
-4.  Record the deploy token's values *before leaving or refreshing the
-	page*! After that, you cannot access it again.
-
-After the deploy token is created, use the URL for the repository in the
-following format:
+Using a public repository from GitHub, the configuration may look like
+this:
 
 ``` ini
 [library]
-providers: git+https://<username>:<deploy_token>@gitlab.example.com/john/awesome_project.git
+providers: git+https://github.com/john/awesome_project.git
 ```
+!!! example "Using custom branch:"
 
-#### Where does the repository clone?
-
-The git provider clones the repository into a temporary directory. The
-default path for the cloned repository is
-`/tmp/asab.library.git/` and it can be changed manually:
+Use hash `#<branch-name>` to clone a repository from a
+selected branch:
 
 ``` ini
+[library]
+providers: git+https://github.com/john/awesome_project.git#name-of-the-branch
+```
+Deploy tokens in GitLab
+GitLab uses deploy tokens to enable authentication of deployment tasks, independent of a user account. Authentication through deploy tokens is the only supported option for now.
+
+If you want to create a deploy token for your GitLab repository, follow these steps from the manual:
+
+Go to Settings > Repository > Deploy tokens section in your repository. (Note that you have to possess a "Maintainer" or "Owner" role for the repository.)
+Expand the "Deploy tokens" section. The list of current Active Deploy Tokens will be displayed.
+Complete the fields and scopes. We recommend a custom "username", as you will need it later for the URL in the configuration.
+Record the deploy token's values before leaving or refreshing the page! After that, you cannot access it again.
+After the deploy token is created, use the URL for the repository in the following format:
+
+[library]
+providers: git+https://<username>:<deploy_token>@gitlab.example.com/john/awesome_project.git
+Where does the repository clone?
+The git provider clones the repository into a temporary directory. The default path for the cloned repository is /tmp/asab.library.git/ and it can be changed manually:
+
 [library:git]
 repodir=path/to/repository/cache
-```
-
-### Libraries repository
-
-The `libsreg` provider downloads the content from the _distribution URL_.
-The distribution URL points to HTTP(S) server where _content archives_ are published.
+Libraries repository
+The libsreg provider downloads the content from the distribution URL. The distribution URL points to HTTP(S) server where content archives are published.
 
 !!! example "Configuration examples:"
 
-	```ini
-	[library]
-	providers: libsreg+https://libsreg.example.com/my-library
-	```
-
+```ini
+[library]
+providers: libsreg+https://libsreg.example.com/my-library
+```
 !!! example "More than one distribution server can be specified:"
 
-	```ini
-	[library]
-	providers: libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library
-	```
+```ini
+[library]
+providers: libsreg+https://libsreg1.example.com,libsreg2.example.com/my-library
+```
 
-	This variant provides more resiliency against a distribution server unavailability.
-
+This variant provides more resiliency against a distribution server unavailability.
 A structure of the distribution server filesystem:
 
-```
 + /my-library/
   - my-library-master.tar.xz
   - my-library-master.tar.xz.sha256
@@ -459,28 +336,19 @@ A structure of the distribution server filesystem:
   - my-library-v43.41.tar.xz
   - my-library-v43.41.tar.xz.sha256
   ...
-```
-
-* `*.tar.xz`: This is the TAR/XZ archive of the actual content
-* `*.tar.xz.sha256`: SHA256 checksum of the archive
-
+*.tar.xz: This is the TAR/XZ archive of the actual content
+*.tar.xz.sha256: SHA256 checksum of the archive
 The structure of the distribution is as follows:
 
-`/{archname}/{archname}-{version}.tar.xz`
+/{archname}/{archname}-{version}.tar.xz
 
-* `archname`: A name of the distribution archive, `my-library` in the example above
-* `version`: A version of the distribution archive, `master`, `production` are typically GIT branches, `v43.41` is a GIT tag.
-
-
+archname: A name of the distribution archive, my-library in the example above
+version: A version of the distribution archive, master, production are typically GIT branches, v43.41 is a GIT tag.
 !!! tip
 
-	This provider is designed to use Microsoft Azure Storage as a distribution point.
-	Is is assumed that the content archives are uploaded to the distribution point using CI/CD.
-
-
-
-## Reference
-
+This provider is designed to use Microsoft Azure Storage as a distribution point.
+Is is assumed that the content archives are uploaded to the distribution point using CI/CD.
+Reference
 ::: asab.library.LibraryService
 
 ::: asab.library.item.LibraryItem


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that subscriptions may reference directories or individual items; updated docs for readability.

* **Bug Fixes / Behavior**
  * Waiting for the library now returns immediately if already ready and re-validates readiness after waiting (may raise if not ready).

* **Refactor / Reliability**
  * Redesigned filesystem and ZooKeeper subscription/watch handling to reuse/restore watches and deliver change notifications more reliably and promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->