### PR TITLE
More intuitive Authorization checks

### DIFF
--- a/asab/web/auth/authorization.py
+++ b/asab/web/auth/authorization.py
@@ -180,7 +180,7 @@ class Authorization:
 			>>> print("I am a superuser and can do anything!")
 		"""
 		self.require_valid()
-		if not self.has_superuser_access():
+		if not is_superuser(self._Resources):
 			L.warning("Superuser authorization required.", struct_data={
 				"cid": self.CredentialsId})
 			raise AccessDeniedError()
@@ -204,7 +204,7 @@ class Authorization:
 			>>> print("I can read and write articles!")
 		"""
 		self.require_valid()
-		if not self.has_resource_access(*resources):
+		if not has_resource_access(self._Resources, resources, tenant=Tenant.get(None)):
 			L.warning("Resource authorization required.", struct_data={
 				"resource": resources, "cid": self.CredentialsId})
 			scope = set()

--- a/asab/web/auth/authorization.py
+++ b/asab/web/auth/authorization.py
@@ -61,15 +61,14 @@ class Authorization:
 
 
 	def __repr__(self):
-		try:
-			return "<Authorization {}cid={!r}>".format(
-				"[SUPERUSER] " if self.has_superuser_access() else "",
-				self.CredentialsId,
-			)
-		except NotAuthenticatedError:
+		if not self.is_valid():
 			return "<Authorization [EXPIRED] cid={!r}>".format(
 				self.CredentialsId
 			)
+		return "<Authorization {}cid={!r}>".format(
+			"[SUPERUSER] " if self.has_superuser_access() else "",
+			self.CredentialsId,
+		)
 
 
 	def is_valid(self):
@@ -84,10 +83,7 @@ class Authorization:
 		Check whether the agent is a superuser.
 
 		Returns:
-			bool: Does the agent have superuser access?
-
-		Raises:
-			NotAuthenticatedError: When the authorization is expired or otherwise invalid.
+			bool: Does the subject have superuser access?
 
 		Examples:
 			>>> import asab.contextvars
@@ -97,8 +93,7 @@ class Authorization:
 			>>> else:
 			>>>     print("I am but a mere mortal.")
 		"""
-		self.require_valid()
-		return is_superuser(self._Resources)
+		return self.is_valid() and is_superuser(self._Resources)
 
 
 	def has_resource_access(self, *resources: str) -> bool:
@@ -109,10 +104,7 @@ class Authorization:
 			*resources (str): A variable number of resource IDs whose authorization is requested.
 
 		Returns:
-			bool: Is the agent authorized to access requested resources?
-
-		Raises:
-			NotAuthenticatedError: When the authorization is expired or otherwise invalid.
+			bool: Is the subject authorized to access requested resources?
 
 		Examples:
 			>>> import asab.contextvars
@@ -122,8 +114,7 @@ class Authorization:
 			>>> else:
 			>>>     print("Not much to do here.")
 		"""
-		self.require_valid()
-		return has_resource_access(self._Resources, resources, tenant=Tenant.get(None))
+		return self.is_valid() and has_resource_access(self._Resources, resources, tenant=Tenant.get(None))
 
 
 	def has_tenant_access(self, tenant=None) -> bool:
@@ -134,10 +125,7 @@ class Authorization:
 			tenant (str, optional): The tenant to check access for. If None, uses the tenant from context.
 
 		Returns:
-			bool: Is the agent authorized to access requested tenant?
-
-		Raises:
-			NotAuthenticatedError: When the authorization is expired or otherwise invalid.
+			bool: Is the subject authorized to access requested tenant?
 
 		Examples:
 			>>> # Using tenant context
@@ -155,15 +143,13 @@ class Authorization:
 			>>> # Specifying tenant directly
 			>>> authz.has_tenant_access("big-corporation")
 		"""
-		self.require_valid()
-
 		if tenant is None:
 			try:
 				tenant = Tenant.get()
 			except LookupError as e:
 				raise ValueError("No tenant in context.") from e
 
-		return has_tenant_access(self._Resources, tenant)
+		return self.is_valid() and has_tenant_access(self._Resources, tenant)
 
 
 	def require_valid(self):
@@ -193,6 +179,7 @@ class Authorization:
 			>>> authz.require_superuser_access()
 			>>> print("I am a superuser and can do anything!")
 		"""
+		self.require_valid()
 		if not self.has_superuser_access():
 			L.warning("Superuser authorization required.", struct_data={
 				"cid": self.CredentialsId})
@@ -216,6 +203,7 @@ class Authorization:
 			>>> authz.require_resource_access("article:read", "article:write")
 			>>> print("I can read and write articles!")
 		"""
+		self.require_valid()
 		if not self.has_resource_access(*resources):
 			L.warning("Resource authorization required.", struct_data={
 				"resource": resources, "cid": self.CredentialsId})

--- a/test/test_auth/test_authorization.py
+++ b/test/test_auth/test_authorization.py
@@ -77,29 +77,37 @@ class TestExpiredSuperuser(unittest.TestCase):
 			self.Authz.require_valid()
 
 	def test_resource_access(self):
-		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
-			self.Authz.has_resource_access(RESOURCE_1)
+		self.assertFalse(
+			self.Authz.has_resource_access(RESOURCE_1),
+			"Access to RESOURCE_1 is not authorized with expired authorization.",
+		)
 
 		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
 			self.Authz.require_resource_access(RESOURCE_1)
 
 	def test_tenant_access(self):
-		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
-			self.Authz.has_tenant_access()
+		self.assertFalse(
+			self.Authz.has_tenant_access(),
+			"Access to TENANT_1 is not authorized with expired authorization.",
+		)
 
 		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
 			self.Authz.require_tenant_access()
 
 		# Explicit tenant param
-		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
-			self.Authz.has_tenant_access(TENANT_1)
+		self.assertFalse(
+			self.Authz.has_tenant_access(TENANT_1),
+			"Access to TENANT_1 is not authorized with expired authorization.",
+		)
 
 		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
 			self.Authz.require_tenant_access(TENANT_1)
 
 	def test_superuser_access(self):
-		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
-			self.Authz.has_superuser_access()
+		self.assertFalse(
+			self.Authz.has_superuser_access(),
+			"Superuser access is not valid with expired authorization.",
+		)
 
 		with self.assertRaises(asab.exceptions.NotAuthenticatedError):
 			self.Authz.require_superuser_access()


### PR DESCRIPTION
# Issue
`Authorization`'s methods `has_resource_access`, `has_tenant_access` and `has_superuser_access` raise `NotAuthenticatedError` when the authorization is expired. This is a rather surprising behavior; a return value of `False` would be more useful.

# Solution
`Authorization.has_*_access` now return `False` when the authorization is expired. This is a potentially **breaking change**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission checks now return false for expired/invalid authorizations instead of triggering errors, allowing smoother permission handling.
  * Methods that enforce access still raise when required, preserving strict checks where callers explicitly demand validity.

* **Changes**
  * Expired authorizations are presented more clearly in diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->