### PR TITLE
Library zk reconnect noise

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -185,6 +185,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		self.Subscriptions: typing.Iterable[str] = set()
 		self.NodeDigests: typing.Dict[str, bytes] = {}
+		self.SubscriptionActualPaths: typing.Dict[typing.Tuple[typing.Union[str, tuple, None], str], typing.List[str]] = {}
 
 
 	async def finalize(self, app):
@@ -291,6 +292,16 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		if not tenant_id or not cred_id:
 			return None
 		return "{}/.personal/{}/{}{}".format(self.BasePath, tenant_id, cred_id, path).rstrip("/")
+
+	def _subscription_personal_path(self, path: str, target: typing.Union[str, tuple, None]) -> typing.Optional[str]:
+		tenant_id = self._current_tenant_id()
+		if isinstance(target, tuple) and len(target) == 2 and target[0] == "personal":
+			cred_id = target[1]
+		else:
+			cred_id = self._current_credentials_id()
+		if not tenant_id or not cred_id:
+			return None
+		return "/.personal/{}/{}{}".format(tenant_id, cred_id, path)
 
 	async def read(self, path: str) -> typing.Optional[typing.IO]:
 		if self.Zookeeper is None:
@@ -463,34 +474,34 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		self.Subscriptions.add((target, path))
+		if not hasattr(self, "SubscriptionActualPaths"):
+			self.SubscriptionActualPaths = {}
 
 		if target in {None, "global"}:
+			self.SubscriptionActualPaths[(target, path)] = [path]
 			self.NodeDigests[path] = await self._get_directory_hash(path)
 
 		elif target == "tenant":
+			actual_paths = []
 			for tenant in await self._get_tenants():
 				actual_path = "/.tenants/{}{}".format(tenant, path)
+				actual_paths.append(actual_path)
 				self.NodeDigests[actual_path] = await self._get_directory_hash(actual_path)
+			self.SubscriptionActualPaths[(target, path)] = actual_paths
 
 		elif isinstance(target, tuple) and len(target) == 2 and target[0] == "tenant":
 			_, tenant = target
 			actual_path = "/.tenants/{}{}".format(tenant, path)
+			self.SubscriptionActualPaths[(target, path)] = [actual_path]
 			self.NodeDigests[actual_path] = await self._get_directory_hash(actual_path)
 
-		elif target == "personal":
-			# current tenant + current credentials
-			try:
-				tenant_id = Tenant.get()
-			except LookupError:
-				tenant_id = None
-			try:
-				authz = Authz.get()
-				cred_id = getattr(authz, "CredentialsId", None)
-			except LookupError:
-				cred_id = None
-			if tenant_id and cred_id:
-				actual_path = "/.personal/{}/{}{}".format(tenant_id, cred_id, path)
+		elif target == "personal" or (isinstance(target, tuple) and len(target) == 2 and target[0] == "personal"):
+			actual_path = self._subscription_personal_path(path, target)
+			if actual_path is not None:
+				self.SubscriptionActualPaths[(target, path)] = [actual_path]
 				self.NodeDigests[actual_path] = await self._get_directory_hash(actual_path)
+			else:
+				self.SubscriptionActualPaths[(target, path)] = []
 		else:
 			raise ValueError("Unexpected target: {!r}".format(target))
 
@@ -518,6 +529,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 	async def _on_library_changed(self, event_name=None):
 		if self.Zookeeper is None or not self.IsReady:
 			return
+		subscription_actual_paths = getattr(self, "SubscriptionActualPaths", {})
 
 		for (target, path) in list(self.Subscriptions):
 
@@ -560,25 +572,20 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				except Exception as e:
 					L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path, "tenant": tenant})
 
-			elif target == "personal":
-				try:
-					tenant_id = Tenant.get()
-				except LookupError:
-					tenant_id = None
-				try:
-					authz = Authz.get()
-					cred_id = getattr(authz, "CredentialsId", None)
-				except LookupError:
-					cred_id = None
-				if tenant_id and cred_id:
+			elif target == "personal" or (isinstance(target, tuple) and len(target) == 2 and target[0] == "personal"):
+				actual_paths = subscription_actual_paths.get((target, path))
+				if actual_paths is None:
+					actual_path = self._subscription_personal_path(path, target)
+					actual_paths = [actual_path] if actual_path is not None else []
+				for actual_path in actual_paths:
 					try:
-						await do_check_path(actual_path="/.personal/{}/{}{}".format(tenant_id, cred_id, path))
+						await do_check_path(actual_path=actual_path)
 					except kazoo.exceptions.ConnectionClosedError:
 						return
 					except Exception as e:
 						L.exception(
 							"Failed to process library changes: '{}'".format(e),
-							struct_data={"path": path, "tenant": tenant_id, "credentials_id": cred_id},
+							struct_data={"path": path},
 						)
 			else:
 				raise ValueError("Unexpected target: {!r}".format((target, path)))

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -233,10 +233,14 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 
 	async def _get_version_counter(self, event_name=None):
-		if self.Zookeeper is None:
+		if self.Zookeeper is None or not self.IsReady:
 			return
 
-		version = await self.Zookeeper.get_data(self.VersionNodePath)
+		try:
+			version = await self.Zookeeper.get_data(self.VersionNodePath)
+		except kazoo.exceptions.ConnectionClosedError:
+			return
+
 		self._check_version_counter(version)
 
 
@@ -512,6 +516,9 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 		return digest.digest()
 
 	async def _on_library_changed(self, event_name=None):
+		if self.Zookeeper is None or not self.IsReady:
+			return
+
 		for (target, path) in list(self.Subscriptions):
 
 			async def do_check_path(actual_path):
@@ -526,13 +533,21 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 			if target in {None, "global"}:
 				try:
 					await do_check_path(actual_path=path)
+				except kazoo.exceptions.ConnectionClosedError:
+					return
 				except Exception as e:
 					L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path})
 
 			elif target == "tenant":
-				for tenant in await self._get_tenants():
+				try:
+					tenants = await self._get_tenants()
+				except kazoo.exceptions.ConnectionClosedError:
+					return
+				for tenant in tenants:
 					try:
 						await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
+					except kazoo.exceptions.ConnectionClosedError:
+						return
 					except Exception as e:
 						L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path, "tenant": tenant})
 
@@ -540,6 +555,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				tenant = target[1]
 				try:
 					await do_check_path(actual_path="/.tenants/{}{}".format(tenant, path))
+				except kazoo.exceptions.ConnectionClosedError:
+					return
 				except Exception as e:
 					L.exception("Failed to process library changes: '{}'".format(e), struct_data={"path": path, "tenant": tenant})
 
@@ -556,6 +573,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 				if tenant_id and cred_id:
 					try:
 						await do_check_path(actual_path="/.personal/{}/{}{}".format(tenant_id, cred_id, path))
+					except kazoo.exceptions.ConnectionClosedError:
+						return
 					except Exception as e:
 						L.exception(
 							"Failed to process library changes: '{}'".format(e),

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -947,13 +947,17 @@ class LibraryService(Service):
 		Args:
 			paths (str | list[str]): Either single path or list of paths to be subscribed. All the paths must be absolute (start with '/').
 			target: In which target to watch the changes. Possible values:
-				- "global" to watch global path changes
-				- "tenant" to watch path changes in tenants
+				- "global" (or None) to watch global path changes
+				- "tenant" to watch path changes in tenant scopes
 				- ("tenant", TENANT_ID) to watch path changes in one specified tenant TENANT_ID
-				- "personal" to watch path changes for all personal credential IDs
-				- ("personal", CREDENTIALS_ID) to watch in one specific personal scope
+				- "personal" to watch the current `(tenant, credentials)` personal scope from contextvars
+				- ("personal", CREDENTIALS_ID) to watch one specific personal scope under the current tenant
 
-		Examples:
+			Callers that need blocking bootstrap behavior should wait for `Library.ready!`
+			or call `wait_for_library_ready()` before subscribing. `subscribe()` itself
+			remains a fail-fast readiness gate.
+
+			Examples:
 		```python
 		class MyApplication(asab.Application):
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -230,6 +230,8 @@ class LibraryService(Service):
 		Returns:
 			typing.List[str]: A list of paths to the found files. If no files are found, the list will be empty.
 		"""
+		self._ensure_ready()
+
 		_validate_path_item(path)
 
 		results = []

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -117,6 +117,9 @@ class LibraryService(Service):
 			await lib.finalize(self.App)
 
 	async def _on_tick60(self, message_type):
+		if len(self.Libraries) == 0 or not self.Libraries[0].IsReady:
+			return
+
 		await self._read_disabled()
 		await self._read_favorites()
 
@@ -434,18 +437,21 @@ class LibraryService(Service):
 			- self.Favorites: { '/path/file.ext': ['tenant', '*', ...] }
 			- self.FavoritePaths: [ ('/path/folder/', ['tenant', '*', ...]), ... ]
 		Expected YAML shape:
-			/path:
-				tenants:
-				- system
+				/path:
+					tenants:
+					- system
 		"""
+		if len(self.Libraries) == 0:
+			return
+
 		fav_data = None
+		fav_file = None
 
 		try:
 			fav_file = await self.Libraries[0].read('/.favorites.yaml')
 		except Exception as e:
-			L.warning("Failed to read '/.favorites.yaml': {}.".format(e))
-			self.Favorites = {}
-			self.FavoritePaths = []
+			if getattr(self.Libraries[0], "IsReady", False):
+				L.warning("Failed to read '/.favorites.yaml': {}.".format(e))
 			return
 
 		if fav_file is None:
@@ -515,41 +521,56 @@ class LibraryService(Service):
 		self.FavoritePaths = folders
 
 	async def _read_disabled(self, publish_changes=False):
+		if len(self.Libraries) == 0:
+			return
 
 		old_disabled = self.Disabled.copy()
 		old_disabled_paths = list(self.DisabledPaths)
-		# Read the file
-		disabled_file = await self.Libraries[0].read('/.disabled.yaml')
+		disabled_file = None
+		try:
+			# Read the file
+			disabled_file = await self.Libraries[0].read('/.disabled.yaml')
+		except Exception as e:
+			if getattr(self.Libraries[0], "IsReady", False):
+				L.warning("Failed to read '/.disabled.yaml': {}.".format(e))
+			return
 
-		if disabled_file is None:
-			self.Disabled = {}
-			self.DisabledPaths = []
-		else:
-			try:
-				disabled_data = yaml.load(disabled_file, Loader=yaml.CSafeLoader)
-			except Exception:
-				L.exception("Failed to parse '/.disabled.yaml'")
+		try:
+			if disabled_file is None:
 				self.Disabled = {}
-				self.DisabledPaths = []
-				return
-
-			if disabled_data is None:
-				self.Disabled = {}
-				self.DisabledPaths = []
-				return
-
-			if isinstance(disabled_data, set):
-				# Backward compatibility (August 2023)
-				self.Disabled = {key: '*' for key in disabled_data}
 				self.DisabledPaths = []
 			else:
-				self.Disabled = {}
-				self.DisabledPaths = []
-				for k, v in disabled_data.items():
-					if k.endswith('/'):
-						self.DisabledPaths.append((k, v))
-					else:
-						self.Disabled[k] = v
+				try:
+					disabled_data = yaml.load(disabled_file, Loader=yaml.CSafeLoader)
+				except Exception:
+					L.exception("Failed to parse '/.disabled.yaml'")
+					self.Disabled = {}
+					self.DisabledPaths = []
+					return
+
+				if disabled_data is None:
+					self.Disabled = {}
+					self.DisabledPaths = []
+					return
+
+				if isinstance(disabled_data, set):
+					# Backward compatibility (August 2023)
+					self.Disabled = {key: '*' for key in disabled_data}
+					self.DisabledPaths = []
+				else:
+					self.Disabled = {}
+					self.DisabledPaths = []
+					for k, v in disabled_data.items():
+						if k.endswith('/'):
+							self.DisabledPaths.append((k, v))
+						else:
+							self.Disabled[k] = v
+		finally:
+			if hasattr(disabled_file, "close"):
+				try:
+					disabled_file.close()
+				except Exception:
+					pass
 
 		self.DisabledPaths.sort(key=lambda x: len(x[0]))
 

--- a/docs/reference/services/library.md
+++ b/docs/reference/services/library.md
@@ -172,14 +172,6 @@ The top-most provider owns the read-side metadata files:
 Those files are reloaded from the first provider on readiness transitions and on the periodic `Application.tick/60!` refresh.
 Changes in `/.disabled.yaml` may also trigger `Library.change!` when the disabled diff affects an active subscription path.
 
-### Current audit gaps
-
-The focused audit suite currently tracks several known contract risks that still require production fixes:
-
-- filesystem subscriptions still ignore `target`-specific scoping
-
-These are covered by regression tests so they stay visible during future changes.
-
 
 ## Notification on changes
 

--- a/docs/reference/services/library.md
+++ b/docs/reference/services/library.md
@@ -143,6 +143,43 @@ Every time the Library changes its state, `PubSub` message is published, with th
 | `Library.ready!` | all of the providers are ready. |
 | `Library.change!` | the content of the Library has changed. |
 
+## Readiness and Contract Notes
+
+The public read-side methods are not all gated in exactly the same way:
+
+- `read()` checks readiness immediately and raises `LibraryNotReadyError` when any provider is not ready.
+- `open()` and `list()` wait on `Library.ready!` and then raise `LibraryNotReadyError` on timeout.
+- `subscribe()` also requires the library to be ready before it fans out to providers, but it stays fail-fast rather than waiting internally.
+- `find()` also checks readiness immediately before it delegates to providers.
+
+The current merged `subscribe()` target contract is:
+
+- `target=None` or `target="global"` watches the global path.
+- `target="tenant"` watches tenant-scoped paths.
+- `target=("tenant", "<tenant-id>")` watches one explicit tenant scope.
+- `target="personal"` watches the current `(tenant, credentials)` context.
+- `target=("personal", "<credentials-id>")` watches one explicit personal scope under the current tenant.
+
+During bootstrap, services that must install subscriptions before continuing should wait for
+`Library.ready!` or call `wait_for_library_ready()` first and only then call `subscribe()`.
+That waiting policy lives at the call site; `subscribe()` itself remains a fail-fast registration call.
+
+The top-most provider owns the read-side metadata files:
+
+- `/.disabled.yaml`
+- `/.favorites.yaml`
+
+Those files are reloaded from the first provider on readiness transitions and on the periodic `Application.tick/60!` refresh.
+Changes in `/.disabled.yaml` may also trigger `Library.change!` when the disabled diff affects an active subscription path.
+
+### Current audit gaps
+
+The focused audit suite currently tracks several known contract risks that still require production fixes:
+
+- filesystem subscriptions still ignore `target`-specific scoping
+
+These are covered by regression tests so they stay visible during future changes.
+
 
 ## Notification on changes
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid spurious processing when the backend is unready or disconnected; stop further work on connection loss.
  * Personal and tenant subscription change detection now uses resolved actual paths.
  * File reads no longer clear state on read failures and only warn when providers are ready.
  * Search/find and periodic reloads respect provider readiness.

* **Refactor**
  * Track resolved subscription paths for accurate digests and change checks.
  * Explicitly close metadata file handles and streamline read control flow.

* **Documentation**
  * Clarified readiness/contract notes and subscribe() target semantics; guidance to wait for Library.ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->