### PR TITLE
Configure pull interval in git provider

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -53,7 +53,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		# HTTPS with deploy token
 		[library]
 		providers=git+https://<username>:<deploy token>@<url>#<branch name>
-		# optional pull interval: fragment may be ``<branch>#pull=10h`` 
+		# optional pull interval: fragment may be ``<branch>#pull=10h``
 		# interval shorter than 1 minute defaults to 1 minute
 		providers=git+https://<username>:<deploy token>@<url>#main#pull=10h
 

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -8,6 +8,7 @@ import typing
 
 from .filesystem import FileSystemLibraryProvider
 from ...config import Config
+from ...utils import convert_to_seconds
 
 #
 
@@ -52,6 +53,9 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		# HTTPS with deploy token
 		[library]
 		providers=git+https://<username>:<deploy token>@<url>#<branch name>
+		# optional pull interval: fragment may be ``<branch>#pull=10h`` 
+		# interval shorter than 1 minute defaults to 1 minute
+		providers=git+https://<username>:<deploy token>@<url>#main#pull=10h
 
 		# SSH (uses default SSH keys from ~/.ssh/)
 		[library]
@@ -76,6 +80,8 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self.URL = ""
 		self.UsesSSH = False
 		self.GitRepository: typing.Optional[pygit2.Repository] = None
+		self.LastPull = None
+		self.PullInterval = 43200  # default 12 h; overridden by ``#pull=`` in URL fragment
 
 		# Parse URL - supports both HTTPS and SSH formats
 		self._parse_url(path)
@@ -123,12 +129,41 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
 
 
+	def _parse_url_fragment(self, fragment):
+		"""
+		Parse the URL fragment for checkout branch and optional ``pull=`` interval.
+
+		There is only one ``#`` in a URL; further ``#`` appear inside the fragment
+		(e.g. ``#main#pull=10h``), matching the libsreg provider convention.
+
+		:return: ``(branch, pull_interval)`` where ``pull_interval`` is the raw value
+			after ``pull=``, or ``None`` if absent.
+		"""
+		branch = ""
+		pull_interval = None
+		if fragment:
+			for part in fragment.split("#"):
+				if part.startswith("pull="):
+					pull_interval = part[5:]
+				elif "=" not in part:
+					branch = part
+		return branch, pull_interval
+
+
 	def _parse_url(self, path):
 		"""
 		Parse git URL from various formats:
-		- git+https://[user:token@]host/path[#branch]
-		- git+ssh://[user@]host/path[#branch]  (e.g., git+ssh://git@github.com/user/repo.git)
-		- git+git@host:path[#branch]  (SSH shorthand, e.g., git+git@github.com:user/repo.git)
+		- git+https://[user:token@]host/path[#branch[#pull=<interval>]]
+		- git+ssh://[user@]host/path[#branch[#pull=<interval>]]  (e.g., git+ssh://git@github.com/user/repo.git)
+		- git+git@host:path[#branch[#pull=<interval>]]  (SSH shorthand, e.g., git+git@github.com:user/repo.git)
+
+		Full example (branch ``main``, pull interval 10 hours; only one ``#`` starts the URL fragment,
+		the second ``#`` separates ``main`` and ``pull=10h`` inside that fragment)::
+
+			git+https://deploy:token@git.example.com/org/repo.git#main#pull=10h
+
+		That yields clone URL ``https://deploy:token@git.example.com/org/repo.git``, branch ``main``,
+		and ``pull=10h`` is applied to ``PullInterval`` (not part of the clone URL).
 		"""
 		# First, try HTTPS pattern
 		https_pattern = re.compile(r"git\+(https?://)((.*):(.*)@)?([^#]*)(?:#(.*))?$")
@@ -142,7 +177,9 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			self.User = groups[2] or ""
 			self.DeployToken = groups[3] or ""
 			self.URLPath = groups[4]
-			self.Branch = groups[5] or ""
+			self.Branch, pull_interval = self._parse_url_fragment(groups[5] or "")
+			if pull_interval is not None:
+				self.PullInterval = convert_to_seconds(pull_interval)
 			self.URL = "".join([self.URLScheme, self.UserInfo, self.URLPath])
 			self.UsesSSH = False
 			return
@@ -157,9 +194,11 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			user = groups[0] or "git@"
 			host = groups[1]
 			repo_path = groups[2] or ""
-			self.Branch = groups[3] or ""
-			self.URL = f"ssh://{user}{host}{repo_path}"
-			self.URLPath = f"{host}{repo_path}"
+			self.Branch, pull_interval = self._parse_url_fragment(groups[3] or "")
+			if pull_interval is not None:
+				self.PullInterval = convert_to_seconds(pull_interval)
+			self.URL = "ssh://{}{}{}".format(user, host, repo_path)
+			self.URLPath = "{}{}".format(host, repo_path)
 			self.User = user.rstrip("@")
 			self.DeployToken = ""
 			self.URLScheme = "ssh://"
@@ -177,10 +216,12 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			user = groups[0] or "git@"
 			host = groups[1]
 			repo_path = groups[2]
-			self.Branch = groups[3] or ""
+			self.Branch, pull_interval = self._parse_url_fragment(groups[3] or "")
+			if pull_interval is not None:
+				self.PullInterval = convert_to_seconds(pull_interval)
 			# Convert to full SSH URL for pygit2
-			self.URL = f"{user}{host}:{repo_path}"
-			self.URLPath = f"{host}:{repo_path}"
+			self.URL = "{}{}:{}".format(user, host, repo_path)
+			self.URLPath = "{}:{}".format(host, repo_path)
 			self.User = user.rstrip("@")
 			self.DeployToken = ""
 			self.URLScheme = ""
@@ -288,6 +329,10 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		if self.PullLock.locked():
 			return
 
+		if self.LastPull is not None and self.App.time() - self.LastPull < self.PullInterval:
+			# Do not pull if the last pull was done less than PullInterval ago
+			return
+
 		async with self.PullLock:
 			if self.GitRepository is None:
 				self.App.TaskService.schedule(self.initialize_git_repository())
@@ -295,6 +340,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 			try:
 				to_publish = await self.ProactorService.execute(self._do_pull)
+				self.LastPull = self.App.time()
 				# Once reset of the head is finished, PubSub message about the change in the subscribed directory gets published.
 				for path in to_publish:
 					self.App.PubSub.publish("Library.change!", self, path)
@@ -444,6 +490,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self.GitRepository.head.set_target(new_commit_id)
 		self.GitRepository.reset(new_commit_id, pygit2.GIT_RESET_HARD)
 
+		L.info("Pulled repository", struct_data={"layer": self.Layer, "url": self.URLPath, "commit_id": new_commit_id})
 		return to_publish
 
 


### PR DESCRIPTION
I'd rather use timer, but I wanted to implement it the same way as in the libsreg provider, so that it is easier to maintain and both providers behave the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring pull frequency via URL fragment syntax for Git repositories
  * Implemented pull throttling to automatically skip pulls when insufficient time has elapsed since the last pull
  * Enhanced logging output with repository details and pulled commit information after successful operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->