### PR TITLE
Fix: Authenticate websocket requests with multivalued Upgrade header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Release candidate
 
-### Features
-...
+### Fixes
+- Authenticate websocket requests with multivalued Upgrade header (#748)
 
 ---
 
@@ -17,6 +17,7 @@
 - Filesystem supports reading from tenants (#722)
 - asab.library.git.GitProvider: When the repository is not initialized during provider init, retry is triggered once per minute(#727)
 - Library service waits until it is ready or timeout (#737)
+
 ---
 
 

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -41,9 +41,13 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 
 	async def _authorize(self, request: aiohttp.web.Request) -> Authorization:
 		access_token = None
-		if request.headers.get('connection', "").lower() == 'upgrade':
-			# Special handling for WebSocket connections
-			access_token = get_bearer_token_from_websocket_request(request)
+
+		# First, try to extract the access token from the WebSocket protocol header (if it's a WebSocket request)
+		if connection_header := request.headers.get(aiohttp.hdrs.CONNECTION):
+			for value in connection_header.casefold().split(","):
+				if value.strip() == "upgrade":
+					access_token = get_bearer_token_from_websocket_request(request)
+					break
 
 		if access_token is None:
 			access_token = get_bearer_token_from_authorization_header(request)


### PR DESCRIPTION
# Issue
In `development` auth mode, WebSocket authorization fails when the Connection header contains anything else than `upgrade`, e.g. `keepalive, upgrade`.

`production` mode is not impacted.

# Solution
Treat the Connection header as multi-valued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection authentication with enhanced header parsing. The authentication system now robustly handles connection headers with multiple comma-separated values and properly manages whitespace variations. These changes ensure more reliable authentication for WebSocket connections, prevent potential authentication failures in edge cases, and improve compatibility across different client types and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->