### PR TITLE
Git provider: retry more

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -124,9 +124,9 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			self.SSHPassphrase = Config.get("library:git", "ssh_passphrase", fallback=None)
 			self.VerifySSHFingerprint = Config.getboolean("library:git", "verify_ssh_fingerprint", fallback=False)
 
-		self.App.TaskService.schedule(self.initialize_git_repository())
+		self.App.TaskService.schedule(self.initialize_git_repository_with_retry())
 
-		self.App.PubSub.subscribe("Application.tick/600!", self._periodic_pull) # 10 minutes
+		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
 
 
 	def _parse_url_fragment(self, fragment):
@@ -335,6 +335,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 		async with self.PullLock:
 			if self.GitRepository is None:
+				# Simple init without retries - retry logic is handled by the scheduled task
 				self.App.TaskService.schedule(self.initialize_git_repository())
 				return
 
@@ -351,127 +352,127 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				)
 
 
+	def _init_task(self):
+		"""
+		The actual git repository initialization task.
+		This is the core logic without any retry handling.
+		This is a synchronous method that runs in the proactor thread.
+		"""
+		if pygit2.discover_repository(self.RepoPath) is None:
+			# For a new repository, clone the remote bit
+			os.makedirs(self.RepoPath, mode=0o700, exist_ok=True)
+			callbacks = self._create_callbacks()
+			self.GitRepository = pygit2.clone_repository(
+				url=self.URL,
+				path=self.RepoPath,
+				checkout_branch=self.Branch,
+				callbacks=callbacks
+			)
+		else:
+			# For existing repository, pull the latest changes
+			self.GitRepository = pygit2.Repository(self.RepoPath)
+			self._do_pull()
+
+		# Verify the repository is valid
+		if not hasattr(self.GitRepository, "remotes"):
+			raise RuntimeError("Git repository object is in an invalid state (missing remote configuration)")
+
+
 	async def initialize_git_repository(self):
 		"""
 		Initialize git repository by cloning or pulling latest changes.
-		Retries with exponential backoff on failure, starting at 30 seconds.
+		This is a single attempt without retries. Callers should handle retries if needed.
+		On failure, logs the error but does not retry.
+		All exceptions are caught and logged to prevent unhandled exceptions in scheduled tasks.
 		"""
-
-		def init_task():
-
-			if pygit2.discover_repository(self.RepoPath) is None:
-				# For a new repository, clone the remote bit
-				os.makedirs(self.RepoPath, mode=0o700, exist_ok=True)
-				callbacks = self._create_callbacks()
-				self.GitRepository = pygit2.clone_repository(
-					url=self.URL,
-					path=self.RepoPath,
-					checkout_branch=self.Branch,
-					callbacks=callbacks
-				)
-
-			else:
-				# For existing repository, pull the latest changes
-				self.GitRepository = pygit2.Repository(self.RepoPath)
-				self._do_pull()
-
-			# Verify the repository is valid
-			if not hasattr(self.GitRepository, "remotes"):
-				raise RuntimeError("Git repository object is in an invalid state (missing remote configuration)")
-
-		# Exponential backoff retry loop
-		retry_delay = 30  # Start with 30 seconds
-
-		while True:
-			success = False
+		try:
 			try:
-				await self.ProactorService.execute(init_task)
-				success = True
-
+				await self.ProactorService.execute(self._init_task)
 			except KeyError as err:
 				pygit_message = str(err).replace('\"', '')
 				if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
-					# branch does not exist - this is a permanent error, don't retry
 					L.exception(
 						"Branch does not exist.",
-						struct_data={
-							"url": self.URLPath,
-							"branch": self.Branch
-						}
+						struct_data={"url": self.URLPath, "branch": self.Branch}
 					)
-					return
 				else:
 					L.exception(
 						"Error when initializing git repository",
 						struct_data={"layer": self.Layer, "error": pygit_message}
 					)
-
+				return
 			except pygit2.GitError as err:
 				pygit_message = str(err).replace('\"', '')
 				if "unexpected http status code: 404" in pygit_message:
-					# repository not found - permanent error, don't retry
 					L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})
-					return
 				elif "remote authentication required but no callback set" in pygit_message:
-					# either repository not found or authentication failed - permanent error, don't retry
 					L.exception(
 						"Authentication failed when initializing git repository.\n"
 						"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
-						struct_data={
-							"layer": self.Layer,
-							"url": self.URLPath,
-							"username": self.User,
-							"deploy_token": self.DeployToken
-						}
+						struct_data={"layer": self.Layer, "url": self.URLPath, "username": self.User, "deploy_token": self.DeployToken}
 					)
-					return
 				elif 'cannot redirect from' in pygit_message:
-					# bad URL - permanent error, don't retry
-					L.exception(
-						"Git repository not found.",
-						struct_data={"layer": self.Layer, "url": self.URLPath}
-					)
-					return
+					L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})
 				elif 'Temporary failure in name resolution' in pygit_message:
-					# Internet connection does not work
 					L.exception(
 						"Git repository not initialized: connection failed. Check your network connection.",
-						struct_data={
-							"layer": self.Layer,
-							"url": self.URLPath
-						}
+						struct_data={"layer": self.Layer, "url": self.URLPath}
 					)
 				else:
 					L.exception(
 						"Git repository not initialized",
 						struct_data={"layer": self.Layer, "error": str(err)}
 					)
-
+				return
 			except RuntimeError as err:
-				# Repository object is invalid
 				L.error(
 					"Git repository not initialized: {}".format(str(err)),
 					struct_data={"layer": self.Layer, "url": self.URLPath}
 				)
-
+				return
 			except Exception as err:
 				L.exception(
 					"Git repository not initialized",
 					struct_data={"layer": self.Layer, "error": str(err)}
 				)
-
-			if success:
-				# If everything went fine, set the provider as ready
-				await self._set_ready()
 				return
 
-			# Retry with exponential backoff
+			# If everything went fine, set the provider as ready
+			await self._set_ready()
+
+		except Exception as err:
+			# Catch-all for any unexpected errors (e.g., in _set_ready)
+			L.exception(
+				"Unexpected error during git repository initialization",
+				struct_data={"layer": self.Layer, "url": self.URLPath, "error": str(err)}
+			)
+
+
+	async def initialize_git_repository_with_retry(self):
+		"""
+		Initialize git repository with exponential backoff retry.
+		Retries with delays starting at 30 seconds and growing up to 1 hour.
+		Permanent errors (404, auth failure, bad URL, branch not found) don't retry.
+		"""
+		retry_delay = 30  # Start with 30 seconds
+
+		while True:
+			# Store current state to detect if init succeeded
+			was_ready = self.IsReady
+
+			await self.initialize_git_repository()
+
+			# Check if initialization succeeded (provider became ready)
+			if self.IsReady and not was_ready:
+				return
+
+			# If we get here, initialization failed - retry with backoff
 			L.warning(
 				"Retrying git repository initialization in {} seconds...".format(retry_delay),
 				struct_data={"layer": self.Layer, "url": self.URLPath, "retry_delay": retry_delay}
 			)
 			await asyncio.sleep(retry_delay)
-			retry_delay = min(retry_delay * 2, 3600)  # Exponential backoff, capped at 1 hour
+			retry_delay = min(retry_delay * 1.5, 3600)  # Exponential backoff, capped at 1 hour
 
 
 	def _do_fetch(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -371,6 +371,9 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		The actual git repository initialization task.
 		This is the core logic without any retry handling.
 		This is a synchronous method that runs in the proactor thread.
+
+		For new repositories, clones the remote repository.
+		For existing repositories, pulls the latest changes.
 		"""
 		if pygit2.discover_repository(self.RepoPath) is None:
 			# For a new repository, clone the remote bit
@@ -386,6 +389,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			# For existing repository, pull the latest changes
 			self.GitRepository = pygit2.Repository(self.RepoPath)
 			self._do_pull()
+			self.LastPull = self.App.time()
 
 		# Verify the repository is valid
 		if not hasattr(self.GitRepository, "remotes"):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -124,9 +124,9 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			self.SSHPassphrase = Config.get("library:git", "ssh_passphrase", fallback=None)
 			self.VerifySSHFingerprint = Config.getboolean("library:git", "verify_ssh_fingerprint", fallback=False)
 
-		self.App.TaskService.schedule(self.initialize_git_repository_with_retry())
+		self.App.TaskService.schedule(self.initialize_git_repository())
 
-		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
+		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_check)
 
 
 	def _parse_url_fragment(self, fragment):
@@ -322,10 +322,17 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		return callbacks
 
 
-	async def _periodic_pull(self, event_name):
+	async def _periodic_check(self, event_name):
 		"""
-		Changes in remote repository are being pulled every minute. `PullLock` flag ensures that only if previous "pull" has finished, new one can start.
+		Periodic check that runs every 60 seconds.
+		If the git repository is not initialized, attempts to initialize it.
+		If initialized and PullInterval has passed, performs a pull.
 		"""
+		if self.GitRepository is None:
+			# Repository not initialized yet - try to init. Retry happens on next tick (60s).
+			self.App.TaskService.schedule(self.initialize_git_repository())
+			return
+
 		if self.PullLock.locked():
 			return
 
@@ -333,12 +340,15 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			# Do not pull if the last pull was done less than PullInterval ago
 			return
 
-		async with self.PullLock:
-			if self.GitRepository is None:
-				# Simple init without retries - retry logic is handled by the scheduled task
-				self.App.TaskService.schedule(self.initialize_git_repository())
-				return
+		await self._periodic_pull()
 
+
+	async def _periodic_pull(self):
+		"""
+		Perform the actual pull from the remote repository.
+		This should only be called when all conditions are met (initialized, not locked, interval passed).
+		"""
+		async with self.PullLock:
 			try:
 				to_publish = await self.ProactorService.execute(self._do_pull)
 				self.LastPull = self.App.time()
@@ -357,6 +367,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		The actual git repository initialization task.
 		This is the core logic without any retry handling.
 		This is a synchronous method that runs in the proactor thread.
+		Only clones/opens the repository - does NOT pull (that's handled by _periodic_pull).
 		"""
 		if pygit2.discover_repository(self.RepoPath) is None:
 			# For a new repository, clone the remote bit
@@ -446,33 +457,6 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				"Unexpected error during git repository initialization",
 				struct_data={"layer": self.Layer, "url": self.URLPath, "error": str(err)}
 			)
-
-
-	async def initialize_git_repository_with_retry(self):
-		"""
-		Initialize git repository with exponential backoff retry.
-		Retries with delays starting at 30 seconds and growing up to 1 hour.
-		Permanent errors (404, auth failure, bad URL, branch not found) don't retry.
-		"""
-		retry_delay = 30  # Start with 30 seconds
-
-		while True:
-			# Store current state to detect if init succeeded
-			was_ready = self.IsReady
-
-			await self.initialize_git_repository()
-
-			# Check if initialization succeeded (provider became ready)
-			if self.IsReady and not was_ready:
-				return
-
-			# If we get here, initialization failed - retry with backoff
-			L.warning(
-				"Retrying git repository initialization in {} seconds...".format(retry_delay),
-				struct_data={"layer": self.Layer, "url": self.URLPath, "retry_delay": retry_delay}
-			)
-			await asyncio.sleep(retry_delay)
-			retry_delay = min(retry_delay * 1.5, 3600)  # Exponential backoff, capped at 1 hour
 
 
 	def _do_fetch(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -373,10 +373,13 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		This is a synchronous method that runs in the proactor thread.
 
 		For new repositories, clones the remote repository.
-		For existing repositories, pulls the latest changes.
+		For existing repositories, opens the existing repository.
+
+		Returns:
+			bool: True if a fresh clone was performed, False if using existing repo
 		"""
 		if pygit2.discover_repository(self.RepoPath) is None:
-			# For a new repository, clone the remote bit
+			# For a new repository, clone the remote
 			os.makedirs(self.RepoPath, mode=0o700, exist_ok=True)
 			callbacks = self._create_callbacks()
 			self.GitRepository = pygit2.clone_repository(
@@ -385,11 +388,11 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				checkout_branch=self.Branch,
 				callbacks=callbacks
 			)
+			is_fresh_clone = True
 		else:
-			# For existing repository, pull the latest changes
+			# For existing repository, just open it (pull happens separately after init)
 			self.GitRepository = pygit2.Repository(self.RepoPath)
-			self._do_pull()
-			self.LastPull = self.App.time()
+			is_fresh_clone = False
 
 		# Verify the repository is valid
 		if not hasattr(self.GitRepository, "remotes"):
@@ -413,18 +416,22 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
+		return is_fresh_clone
+
 
 	async def initialize_git_repository(self):
 		"""
-		Initialize git repository by cloning or pulling latest changes.
+		Initialize git repository by cloning or opening existing.
 		This is a single attempt without retries. Callers should handle retries if needed.
 		On failure, logs the error but does not retry.
 		All exceptions are caught and logged to prevent unhandled exceptions in scheduled tasks.
+		After successful init, if using existing repo (not fresh clone), performs immediate pull.
 		"""
 		self.InitInProgress = True
+		fresh_clone = False
 		try:
 			try:
-				await self.ProactorService.execute(self._init_task)
+				fresh_clone = await self.ProactorService.execute(self._init_task)
 			except KeyError as err:
 				pygit_message = str(err).replace('\"', '')
 				if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
@@ -477,8 +484,12 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			# If everything went fine, set the provider as ready
 			await self._set_ready()
 
+			# If using existing repo (not fresh clone), pull immediately to update
+			if not fresh_clone:
+				await self._periodic_pull()
+
 		except Exception as err:
-			# Catch-all for any unexpected errors (e.g., in _set_ready)
+			# Catch-all for any unexpected errors (e.g., in _set_ready or _periodic_pull)
 			L.exception(
 				"Unexpected error during git repository initialization",
 				struct_data={"layer": self.Layer, "url": self.URLPath, "error": str(err)}

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -446,7 +446,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 					L.exception(
 						"Authentication failed when initializing git repository.\n"
 						"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
-						struct_data={"layer": self.Layer, "url": self.URLPath, "username": self.User, "deploy_token": self.DeployToken}
+						struct_data={"layer": self.Layer, "url": self.URLPath, "username": self.User}
 					)
 				elif 'cannot redirect from' in pygit_message:
 					L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -9,6 +9,7 @@ import typing
 from .filesystem import FileSystemLibraryProvider
 from ...config import Config
 from ...utils import convert_to_seconds
+from ...log import LOG_NOTICE
 
 #
 
@@ -356,6 +357,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			try:
 				to_publish = await self.ProactorService.execute(self._do_pull)
 				self.LastPull = self.App.time()
+				L.log(LOG_NOTICE, "Periodic pull from the remote repository succeeded", struct_data={"layer": self.Layer, "url": self.URLPath})
 				# Once reset of the head is finished, PubSub message about the change in the subscribed directory gets published.
 				for path in to_publish:
 					self.App.PubSub.publish("Library.change!", self, path)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -367,7 +367,6 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		The actual git repository initialization task.
 		This is the core logic without any retry handling.
 		This is a synchronous method that runs in the proactor thread.
-		Only clones/opens the repository - does NOT pull (that's handled by _periodic_pull).
 		"""
 		if pygit2.discover_repository(self.RepoPath) is None:
 			# For a new repository, clone the remote bit
@@ -387,6 +386,24 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		# Verify the repository is valid
 		if not hasattr(self.GitRepository, "remotes"):
 			raise RuntimeError("Git repository object is in an invalid state (missing remote configuration)")
+
+		# Check that the working tree is not empty (has actual files)
+		# Walk the RepoPath and check for any files (not just .git directory)
+		has_files = False
+		for root, dirs, files in os.walk(self.RepoPath):
+			# Skip the .git directory
+			if '.git' in dirs:
+				dirs.remove('.git')
+			if files:
+				has_files = True
+				break
+		if not has_files:
+			# Remove the repo directory to force fresh clone on next retry
+			# This handles transient issues where clone didn't populate working tree
+			import shutil
+			shutil.rmtree(self.RepoPath, ignore_errors=True)
+			self.GitRepository = None
+			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
 
 	async def initialize_git_repository(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -112,6 +112,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self.PullLock = asyncio.Lock()
 
 		self.SubscribedPaths = set()
+		self.InitInProgress = False
 
 		# SSH configuration
 		self.SSHKeyPath = None
@@ -330,6 +331,9 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		"""
 		if self.GitRepository is None:
 			# Repository not initialized yet - try to init. Retry happens on next tick (60s).
+			if self.InitInProgress:
+				# Initialization already in progress, skip scheduling
+				return
 			self.App.TaskService.schedule(self.initialize_git_repository())
 			return
 
@@ -413,6 +417,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		On failure, logs the error but does not retry.
 		All exceptions are caught and logged to prevent unhandled exceptions in scheduled tasks.
 		"""
+		self.InitInProgress = True
 		try:
 			try:
 				await self.ProactorService.execute(self._init_task)
@@ -474,6 +479,8 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				"Unexpected error during git repository initialization",
 				struct_data={"layer": self.Layer, "url": self.URLPath, "error": str(err)}
 			)
+		finally:
+			self.InitInProgress = False
 
 
 	def _do_fetch(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -126,7 +126,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 		self.App.TaskService.schedule(self.initialize_git_repository())
 
-		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_pull)
+		self.App.PubSub.subscribe("Application.tick/600!", self._periodic_pull) # 10 minutes
 
 
 	def _parse_url_fragment(self, fragment):
@@ -354,6 +354,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 	async def initialize_git_repository(self):
 		"""
 		Initialize git repository by cloning or pulling latest changes.
+		Retries with exponential backoff on failure, starting at 30 seconds.
 		"""
 
 		def init_task():
@@ -374,84 +375,103 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 				self.GitRepository = pygit2.Repository(self.RepoPath)
 				self._do_pull()
 
-		try:
-			await self.ProactorService.execute(init_task)
+			# Verify the repository is valid
+			if not hasattr(self.GitRepository, "remotes"):
+				raise RuntimeError("Git repository object is in an invalid state (missing remote configuration)")
 
-		except KeyError as err:
-			pygit_message = str(err).replace('\"', '')
-			if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
-				# branch does not exist
-				L.exception(
-					"Branch does not exist.",
-					struct_data={
-						"url": self.URLPath,
-						"branch": self.Branch
-					}
-				)
-			else:
-				L.exception(
-					"Error when initializing git repository",
-					struct_data={"layer": self.Layer, "error": pygit_message}
-				)
+		# Exponential backoff retry loop
+		retry_delay = 30  # Start with 30 seconds
 
-			return
+		while True:
+			success = False
+			try:
+				await self.ProactorService.execute(init_task)
+				success = True
 
-		except pygit2.GitError as err:
-			pygit_message = str(err).replace('\"', '')
-			if "unexpected http status code: 404" in pygit_message:
-				# repository not found
-				L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})
-			elif "remote authentication required but no callback set" in pygit_message:
-				# either repository not found or authentication failed
-				L.exception(
-					"Authentication failed when initializing git repository.\n"
-					"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
-					struct_data={
-						"layer": self.Layer,
-						"url": self.URLPath,
-						"username": self.User,
-						"deploy_token": self.DeployToken
-					}
-				)
-			elif 'cannot redirect from' in pygit_message:
-				# bad URL
-				L.exception(
-					"Git repository not found.",
+			except KeyError as err:
+				pygit_message = str(err).replace('\"', '')
+				if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
+					# branch does not exist - this is a permanent error, don't retry
+					L.exception(
+						"Branch does not exist.",
+						struct_data={
+							"url": self.URLPath,
+							"branch": self.Branch
+						}
+					)
+					return
+				else:
+					L.exception(
+						"Error when initializing git repository",
+						struct_data={"layer": self.Layer, "error": pygit_message}
+					)
+
+			except pygit2.GitError as err:
+				pygit_message = str(err).replace('\"', '')
+				if "unexpected http status code: 404" in pygit_message:
+					# repository not found - permanent error, don't retry
+					L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})
+					return
+				elif "remote authentication required but no callback set" in pygit_message:
+					# either repository not found or authentication failed - permanent error, don't retry
+					L.exception(
+						"Authentication failed when initializing git repository.\n"
+						"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
+						struct_data={
+							"layer": self.Layer,
+							"url": self.URLPath,
+							"username": self.User,
+							"deploy_token": self.DeployToken
+						}
+					)
+					return
+				elif 'cannot redirect from' in pygit_message:
+					# bad URL - permanent error, don't retry
+					L.exception(
+						"Git repository not found.",
+						struct_data={"layer": self.Layer, "url": self.URLPath}
+					)
+					return
+				elif 'Temporary failure in name resolution' in pygit_message:
+					# Internet connection does not work
+					L.exception(
+						"Git repository not initialized: connection failed. Check your network connection.",
+						struct_data={
+							"layer": self.Layer,
+							"url": self.URLPath
+						}
+					)
+				else:
+					L.exception(
+						"Git repository not initialized",
+						struct_data={"layer": self.Layer, "error": str(err)}
+					)
+
+			except RuntimeError as err:
+				# Repository object is invalid
+				L.error(
+					"Git repository not initialized: {}".format(str(err)),
 					struct_data={"layer": self.Layer, "url": self.URLPath}
 				)
-			elif 'Temporary failure in name resolution' in pygit_message:
-				# Internet connection does not work
-				L.exception(
-					"Git repository not initialized: connection failed. Check your network connection.",
-					struct_data={
-						"layer": self.Layer,
-						"url": self.URLPath
-					}
-				)
-			else:
+
+			except Exception as err:
 				L.exception(
 					"Git repository not initialized",
 					struct_data={"layer": self.Layer, "error": str(err)}
 				)
 
-			return
+			if success:
+				# If everything went fine, set the provider as ready
+				await self._set_ready()
+				return
 
-		except Exception as err:
-			L.exception(
-				"Git repository not initialized",
-				struct_data={"layer": self.Layer, "error": str(err)}
+			# Retry with exponential backoff
+			L.warning(
+				"Retrying git repository initialization in {} seconds...".format(retry_delay),
+				struct_data={"layer": self.Layer, "url": self.URLPath, "retry_delay": retry_delay}
 			)
-			return
-
-		if not hasattr(self.GitRepository, "remotes"):
-			L.error(
-				"Git repository not initialized: Git repository object is in an invalid state (missing remote configuration)",
-				struct_data={"layer": self.Layer, "url": self.URLPath}
-			)
-			return
-
-		# If everything went fine, set the provider as ready
-		await self._set_ready()
+			await asyncio.sleep(retry_delay)
+			retry_delay = min(retry_delay * 2, 3600)  # Exponential backoff, capped at 1 hour
 
 
 	def _do_fetch(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -69,6 +69,22 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		ssh_passphrase=<optional passphrase for SSH key>
 		verify_ssh_fingerprint=yes|no (default: no - auto-accepts host keys)
 	"""
+# Initialization and periodic pull flow:
+#     [UNINITIALIZED] ←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←
+#           │                                                                          │
+#           │  _periodic_check() every 60s                                             │
+#           ▼                                                                          │
+#     [INIT_IN_PROGRESS] ──fail──→ (wait next tick) ──────────────────────────────────┘
+#           │
+#           └──success──→ [INITIALIZED] ←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←←
+#                              │                                                        │
+#                              │  _periodic_check() every 60s, PullInterval gate        │
+#                              ▼                                                        │
+#                        [PULL_IN_PROGRESS] ──fail──→ (wait next tick) ────────────────┘
+#                              │
+#                              └──success──→ [INITIALIZED] (with updated LastPull)
+#
+
 	def __init__(self, library, path, layer):
 
 		# Initialize attributes to avoid attribute errors
@@ -131,25 +147,6 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self.App.PubSub.subscribe("Application.tick/60!", self._periodic_check)
 
 
-	def _parse_url_fragment(self, fragment):
-		"""
-		Parse the URL fragment for checkout branch and optional ``pull=`` interval.
-
-		There is only one ``#`` in a URL; further ``#`` appear inside the fragment
-		(e.g. ``#main#pull=10h``), matching the libsreg provider convention.
-
-		:return: ``(branch, pull_interval)`` where ``pull_interval`` is the raw value
-			after ``pull=``, or ``None`` if absent.
-		"""
-		branch = ""
-		pull_interval = None
-		if fragment:
-			for part in fragment.split("#"):
-				if part.startswith("pull="):
-					pull_interval = part[5:]
-				elif "=" not in part:
-					branch = part
-		return branch, pull_interval
 
 
 	def _parse_url(self, path):
@@ -179,7 +176,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			self.User = groups[2] or ""
 			self.DeployToken = groups[3] or ""
 			self.URLPath = groups[4]
-			self.Branch, pull_interval = self._parse_url_fragment(groups[5] or "")
+			self.Branch, pull_interval = _parse_url_fragment(groups[5] or "")
 			if pull_interval is not None:
 				self.PullInterval = convert_to_seconds(pull_interval)
 			self.URL = "".join([self.URLScheme, self.UserInfo, self.URLPath])
@@ -196,7 +193,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			user = groups[0] or "git@"
 			host = groups[1]
 			repo_path = groups[2] or ""
-			self.Branch, pull_interval = self._parse_url_fragment(groups[3] or "")
+			self.Branch, pull_interval = _parse_url_fragment(groups[3] or "")
 			if pull_interval is not None:
 				self.PullInterval = convert_to_seconds(pull_interval)
 			self.URL = "ssh://{}{}{}".format(user, host, repo_path)
@@ -218,7 +215,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			user = groups[0] or "git@"
 			host = groups[1]
 			repo_path = groups[2]
-			self.Branch, pull_interval = self._parse_url_fragment(groups[3] or "")
+			self.Branch, pull_interval = _parse_url_fragment(groups[3] or "")
 			if pull_interval is not None:
 				self.PullInterval = convert_to_seconds(pull_interval)
 			# Convert to full SSH URL for pygit2
@@ -542,3 +539,25 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		self.SubscribedPaths.add(path)
+
+
+def _parse_url_fragment(fragment):
+	"""
+	Parse the URL fragment for checkout branch and optional ``pull=`` interval.
+
+	There is only one ``#`` in a URL; further ``#`` appear inside the fragment
+	(e.g. ``#main#pull=10h``), matching the libsreg provider convention.
+
+	:param fragment: The URL fragment string (without the leading ``#``).
+	:return: ``(branch, pull_interval)`` where ``pull_interval`` is the raw value
+		after ``pull=``, or ``None`` if absent.
+	"""
+	branch = ""
+	pull_interval = None
+	if fragment:
+		for part in fragment.split("#"):
+			if part.startswith("pull="):
+				pull_interval = part[5:]
+			elif "=" not in part:
+				branch = part
+	return branch, pull_interval

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -431,56 +431,13 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		try:
 			try:
 				fresh_clone = await self.ProactorService.execute(self._init_task)
-			except KeyError as err:
-				pygit_message = str(err).replace('\"', '')
-				if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
-					L.exception(
-						"Branch does not exist.",
-						struct_data={"url": self.URLPath, "branch": self.Branch}
-					)
-				else:
-					L.exception(
-						"Error when initializing git repository",
-						struct_data={"layer": self.Layer, "error": pygit_message}
-					)
-				return
-			except pygit2.GitError as err:
-				pygit_message = str(err).replace('\"', '')
-				if "unexpected http status code: 404" in pygit_message:
-					L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})
-				elif "remote authentication required but no callback set" in pygit_message:
-					L.exception(
-						"Authentication failed when initializing git repository.\n"
-						"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
-						struct_data={"layer": self.Layer, "url": self.URLPath, "username": self.User}
-					)
-				elif 'cannot redirect from' in pygit_message:
-					L.exception("Git repository not found.", struct_data={"layer": self.Layer, "url": self.URLPath})
-				elif 'Temporary failure in name resolution' in pygit_message:
-					L.exception(
-						"Git repository not initialized: connection failed. Check your network connection.",
-						struct_data={"layer": self.Layer, "url": self.URLPath}
-					)
-				else:
-					L.exception(
-						"Git repository not initialized",
-						struct_data={"layer": self.Layer, "error": str(err)}
-					)
-				return
-			except RuntimeError as err:
-				L.error(
-					"Git repository not initialized: {}".format(str(err)),
-					struct_data={"layer": self.Layer, "url": self.URLPath}
-				)
-				return
 			except Exception as err:
-				L.exception(
-					"Git repository not initialized",
-					struct_data={"layer": self.Layer, "error": str(err)}
-				)
+				msg, struct_data = self._translate_init_error(err)
+				L.exception(msg, struct_data=struct_data)
 				return
 
-			# If everything went fine, set the provider as ready
+			# If everything went fine, log success and set the provider as ready
+			L.log(LOG_NOTICE, "Git repository initialized", struct_data={"layer": self.Layer, "url": self.URLPath})
 			await self._set_ready()
 
 			# If using existing repo (not fresh clone), pull immediately to update
@@ -495,6 +452,44 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			)
 		finally:
 			self.InitInProgress = False
+
+
+	def _translate_init_error(self, err: Exception) -> tuple[str, dict]:
+		"""
+		Translate initialization exceptions into user-friendly log messages.
+
+		:param err: The exception that occurred during initialization.
+		:return: Tuple of (message, struct_data) to log.
+		"""
+		pygit_message = str(err).replace('"', '')
+
+		if isinstance(err, KeyError):
+			if "'refs/remotes/origin/{}'".format(self.Branch) in pygit_message:
+				return "Branch does not exist.", {"url": self.URLPath, "branch": self.Branch}
+			return "Error when initializing git repository", {"layer": self.Layer, "error": pygit_message}
+
+		if isinstance(err, pygit2.GitError):
+			if "unexpected http status code: 404" in pygit_message:
+				return "Git repository not found.", {"layer": self.Layer, "url": self.URLPath}
+			if "remote authentication required but no callback set" in pygit_message:
+				return (
+					"Authentication failed when initializing git repository.\n"
+					"Check if the 'providers' option satisfies the format: 'git+<username>:<deploy token>@<URL>#<branch name>'",
+					{"layer": self.Layer, "url": self.URLPath, "username": self.User}
+				)
+			if "cannot redirect from" in pygit_message:
+				return "Git repository not found.", {"layer": self.Layer, "url": self.URLPath}
+			if "Temporary failure in name resolution" in pygit_message:
+				return (
+					"Git repository not initialized: connection failed. Check your network connection.",
+					{"layer": self.Layer, "url": self.URLPath}
+				)
+			return "Git repository not initialized", {"layer": self.Layer, "error": str(err)}
+
+		if isinstance(err, RuntimeError):
+			return "Git repository not initialized: {}".format(str(err)), {"layer": self.Layer, "url": self.URLPath}
+
+		return "Git repository not initialized", {"layer": self.Layer, "error": str(err)}
 
 
 	def _do_fetch(self):


### PR DESCRIPTION
I tested on localhost that :

    clone is retried every 60s when git server is not ready
    pull is retried every 60s unless successful
    pull interval can be configured via #pull=10m URL fragment

I added a check that the initialition task does not run mutliple times at once.

I rearranged the code (parse_url_fragment, error flow in init) to improve readability.

I have separated periodic_pull method to periodic_check (with check interval 60s) and periodic_pull (with pull interval 12h if not configured). Only to improve readability.