### PR TITLE
Git Provider: do not pull after init. if pull fails, library is not ready.

### DIFF
--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -353,13 +353,14 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 
 	async def initialize_git_repository(self):
 		"""
-		Initialize git repository by cloning or pulling latest changes.
+		Initialize git repository by cloning or opening existing.
+		Pull is NOT performed during init - it happens separately via _periodic_pull.
+		This ensures the library becomes ready as soon as the repo is accessible.
 		"""
 
 		def init_task():
-
 			if pygit2.discover_repository(self.RepoPath) is None:
-				# For a new repository, clone the remote bit
+				# For a new repository, clone the remote
 				os.makedirs(self.RepoPath, mode=0o700, exist_ok=True)
 				callbacks = self._create_callbacks()
 				self.GitRepository = pygit2.clone_repository(
@@ -368,11 +369,10 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 					checkout_branch=self.Branch,
 					callbacks=callbacks
 				)
-
 			else:
-				# For existing repository, pull the latest changes
+				# For existing repository, just open it
+				# Do NOT pull here - pull happens via _periodic_pull
 				self.GitRepository = pygit2.Repository(self.RepoPath)
-				self._do_pull()
 
 		try:
 			await self.ProactorService.execute(init_task)
@@ -451,6 +451,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 			return
 
 		# If everything went fine, set the provider as ready
+		# This has to be atomic. There must be no other code between the init task and setting the library ready.
 		await self._set_ready()
 
 


### PR DESCRIPTION
I went through the git provider with several robots and this is the only bug I found and it is not in the code that would be used. 
I failed to improve it more. 
So this is it. 

So, I am closing this MR: github.com/TeskaLabs/asab/pull/751
It is redundant refactoring. 

And I'll finish this: https://github.com/TeskaLabs/asab/pull/751
as I didn't find any other line to change. 

Let's see...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized git repository initialization to defer pull operations to periodic syncs, improving startup efficiency by avoiding redundant network operations during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->