### PR TITLE
Implementation of the cache library provider.

### DIFF
--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -1,0 +1,19 @@
+import os
+import asyncio
+
+from .filesystem import FileSystemLibraryProvider
+
+
+class CacheLibraryProvider(FileSystemLibraryProvider):
+
+	def __init__(self, library, path, layer, *, repodir, ready_file):
+		self.ReadyFile = ready_file
+		super().__init__(library, repodir, layer, set_ready=False)
+
+		self.App.TaskService.schedule(self.wait_for_ready())
+
+
+	async def wait_for_ready(self):
+		while not os.path.exists(self.ReadyFile):
+			await asyncio.sleep(1)
+		await self._set_ready()

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -1,15 +1,16 @@
 import os
 import asyncio
 
-from .filesystem import FileSystemLibraryProvider
+from .filesystem import SimpleFileSystemLibraryProvider
 
 
-class CacheLibraryProvider(FileSystemLibraryProvider):
+class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 
 	def __init__(self, library, path, layer, *, repodir, ready_file):
 		self.ReadyFile = ready_file
 		super().__init__(library, repodir, layer, set_ready=False)
 
+		# Wait for the ready file to be created by the asab-library service, indicating that the cache folder is ready.
 		self.App.TaskService.schedule(self.wait_for_ready())
 
 

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -23,4 +23,5 @@ class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 			if cnt > 20 and cnt % 10 == 0:
 				L.warning("Waiting for the cache to be ready...", struct_data={'path': self.ReadyFile})
 			await asyncio.sleep(1)
+			cnt += 1
 		await self._set_ready()

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -1,7 +1,10 @@
 import os
+import logging
 import asyncio
 
 from .filesystem import SimpleFileSystemLibraryProvider
+
+L = logging.getLogger(__name__)
 
 
 class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
@@ -15,6 +18,9 @@ class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 
 
 	async def wait_for_ready(self):
+		cnt = 0
 		while not os.path.exists(self.ReadyFile):
+			if cnt > 20 and cnt % 10 == 0:
+				L.warning("Waiting for the cache to be ready...", struct_data={'path': self.ReadyFile})
 			await asyncio.sleep(1)
 		await self._set_ready()

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -54,6 +54,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 	def __init__(self, library, path, layer, *, set_ready=True):
 		super().__init__(library, layer)
+
 		# Check for `file://` prefix and strip it if present
 		if path.startswith('file://'):
 			path = path[7:]  # Strip "file://"
@@ -83,6 +84,13 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		self.AggrEvents = []
 		self.WDs = {}  # wd -> (subscribed_path, child_path)
 
+
+	async def finalize(self, app):
+		if self.FD is not None:
+			self.App.Loop.remove_reader(self.FD)
+			os.close(self.FD)
+
+
 	def _current_tenant_id(self):
 		try:
 			return Tenant.get()
@@ -95,6 +103,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			return getattr(authz, "CredentialsId", None)
 		except LookupError:
 			return None
+
 
 	def _personal_path(self, path, tenant_id, cred_id):
 		assert path[:1] == '/'
@@ -111,6 +120,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			raise ValueError("Path traversal detected")
 
 		return full
+
 
 	def _resolve_fs_path_from_info(self, info):
 		scope = info["scope"]
@@ -132,6 +142,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 		raise RuntimeError("Unknown scope: {}".format(scope))
 
+
 	async def _get_personal_scopes(self) -> typing.List[tuple[str, str]]:
 		"""
 		Return list of (tenant_id, cred_id) that exist under /.personal
@@ -152,6 +163,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 				scopes.append((tenant, cred))
 		return scopes
 
+
 	def _validate_read_path(self, path: str) -> None:
 		"""
 		Validate a library item path for read().
@@ -165,6 +177,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		assert len(
 			os.path.splitext(path)[1]) > 0, "File path must end with an extension (e.g. /library/Templates/item.json)"
 		assert '//' not in path, "File path cannot contain double slashes (//)"
+
 
 	def build_path(self, path, tenant_specific=False, tenant=None):
 		"""
@@ -205,6 +218,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 		return node_path
 
+
 	async def read(self, path: str) -> typing.Optional[typing.IO]:
 		"""
 		Read a file from filesystem overlays in precedence order:
@@ -240,6 +254,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			return io.FileIO(global_path, 'rb')
 		except (FileNotFoundError, IsADirectoryError):
 			return None
+
 
 	async def list(self, path: str) -> list:
 		"""
@@ -286,6 +301,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 					personal_items = []
 
 		return personal_items + tenant_items + global_items
+
 
 	def _list_from_node_path(self, node_path: str, base_path: str, target="global"):
 		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
@@ -343,6 +359,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 		return items
 
+
 	def _list(self, path: str):
 		node_path = self.BasePath + path
 		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
@@ -379,6 +396,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			))
 
 		return items
+
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		"""
@@ -457,6 +475,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 				continue
 			self.App.PubSub.publish("Library.change!", self, path)
 
+
 	async def find(self, filename: str) -> list:
 		"""
 		Recursively search for files ending with a specific name in the file system, starting from the base path.
@@ -468,6 +487,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		results = []
 		self._recursive_find(self.BasePath, filename, results)
 		return results
+
 
 	def _recursive_find(self, path, filename, results):
 		"""
@@ -500,7 +520,3 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 
 				self._recursive_find(full_path, filename, results)
 
-	async def finalize(self, app):
-		if self.FD is not None:
-			self.App.Loop.remove_reader(self.FD)
-			os.close(self.FD)

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -10,6 +10,8 @@ import logging
 from .abc import LibraryProviderABC
 from ..item import LibraryItem
 from ...timer import Timer
+
+# Only import context vars in the full provider, not base
 from ...contextvars import Tenant, Authz
 
 try:
@@ -30,7 +32,321 @@ except OSError:
 L = logging.getLogger(__name__)
 
 
-class FileSystemLibraryProvider(LibraryProviderABC):
+class SimpleFileSystemLibraryProvider(LibraryProviderABC):
+	"""
+	Simple filesystem provider with only global path support.
+	Serves as a base class for other providers that don't need
+	multi-tenancy or disabled file functionality.
+
+	- global path: <BasePath>/<path>
+	"""
+
+	def __init__(self, library, path, layer, *, set_ready=True):
+		super().__init__(library, layer)
+
+		# Check for `file://` prefix and strip it if present
+		if path.startswith('file://'):
+			path = path[7:]  # Strip "file://"
+
+		path = os.path.abspath(path)
+		self.BasePath = path.rstrip("/")
+
+		L.info("is connected.", struct_data={'path': path})
+		if set_ready:
+			self.App.TaskService.schedule(self._set_ready())
+
+		self.AggrEvents = []
+		self.WDs = {}  # wd -> (subscribed_path, child_path)
+
+		# Initialize inotify for subscription support (optional in base class)
+		if inotify_init is not None:
+			init = inotify_init()
+			if init == -1:
+				L.warning(
+					"Subscribing to library changes in filesystem provider is not available. Inotify was not initialized.")
+				self.FD = None
+			else:
+				self.FD = init
+				self.App.Loop.add_reader(self.FD, self._on_inotify_read)
+				self.AggrTimer = Timer(self.App, self._on_aggr_timer)
+		else:
+			self.FD = None
+
+
+	async def finalize(self, app):
+		if self.FD is not None:
+			self.App.Loop.remove_reader(self.FD)
+			os.close(self.FD)
+
+
+	def _validate_read_path(self, path: str) -> None:
+		"""
+		Validate a library item path for read().
+
+		Enforces:
+			- absolute path (starts with '/')
+			- file extension present
+			- no double slashes
+		"""
+		assert path[:1] == '/', "File path must start with '/' (e.g. /library/Templates/file.json)"
+		assert len(
+			os.path.splitext(path)[1]) > 0, "File path must end with an extension (e.g. /library/Templates/item.json)"
+		assert '//' not in path, "File path cannot contain double slashes (//)"
+
+
+	def build_path(self, path):
+		"""
+		Build an absolute filesystem path under this provider base path.
+
+		Args:
+			path: Library path starting with '/'.
+
+		Returns:
+			Absolute filesystem path.
+
+		Notes:
+			- This method is for both file and directory paths.
+			- It does not enforce file-extension rules.
+		"""
+		assert path[:1] == '/'
+
+		node_path = self.BasePath + path if path != '/' else self.BasePath
+		node_path = node_path.rstrip("/")
+
+		assert '//' not in node_path, "Directory path cannot contain double slashes (//). Example format: /library/Templates/"
+		assert node_path[0] == '/', "Directory path must start with '/'"
+
+		return node_path
+
+
+	async def read(self, path: str) -> typing.Optional[typing.IO]:
+		"""
+		Read a file from global filesystem path.
+
+		Returns:
+			Binary file object, or None if not found.
+		"""
+		self._validate_read_path(path)
+
+		global_path = self.build_path(path)
+		try:
+			return io.FileIO(global_path, 'rb')
+		except (FileNotFoundError, IsADirectoryError):
+			return None
+
+
+	async def list(self, path: str) -> list:
+		"""
+		List directory items from global path only.
+
+		Returns:
+			List[LibraryItem]
+		"""
+		global_node_path = self.build_path(path)
+		return self._list_from_node_path(global_node_path, path)
+
+
+	def _list_from_node_path(self, node_path: str, base_path: str):
+		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
+		if not exists:
+			raise KeyError("Path '{}' not found by FileSystemLibraryProvider.".format(base_path))
+
+		items = []
+		for fname in glob.iglob(os.path.join(node_path, "*")):
+			try:
+				fstat = os.stat(fname)
+			except FileNotFoundError:
+				continue
+
+			# Turn absolute filesystem path back into library path under base_path
+			rel_name = os.path.basename(fname)
+			if rel_name.startswith('.'):
+				continue
+
+			if stat.S_ISREG(fstat.st_mode):
+				ftype = "item"
+				size = fstat.st_size
+				lib_name = "{}/{}".format(base_path.rstrip("/"), rel_name)
+			elif stat.S_ISDIR(fstat.st_mode):
+				ftype = "dir"
+				size = None
+				lib_name = "{}/{}/".format(base_path.rstrip("/"), rel_name)
+			else:
+				ftype = "?"
+				size = None
+				lib_name = "{}/{}".format(base_path.rstrip("/"), rel_name)
+
+			# Remove any component that starts with '.'
+			if any(x.startswith('.') for x in lib_name.split('/')):
+				continue
+
+			items.append(LibraryItem(
+				name=lib_name,
+				type=ftype,
+				layers=[self.Layer],
+				providers=[self],
+				size=size,
+			))
+
+		return items
+
+
+	def _list(self, path: str):
+		node_path = self.BasePath + path
+		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
+		if not exists:
+			raise KeyError("Path '{}' not found by FileSystemLibraryProvider.".format(path))
+
+		items = []
+		for fname in glob.iglob(os.path.join(node_path, "*")):
+			fstat = os.stat(fname)
+
+			assert fname.startswith(self.BasePath)
+			fname = fname[len(self.BasePath):]
+
+			if stat.S_ISREG(fstat.st_mode):
+				ftype = "item"
+				size = fstat.st_size
+			elif stat.S_ISDIR(fstat.st_mode):
+				ftype = "dir"
+				fname += '/'
+				size = None
+			else:
+				ftype = "?"
+				size = None
+
+			if any(x.startswith('.') for x in fname.split('/')):
+				continue
+
+			items.append(LibraryItem(
+				name=fname,
+				type=ftype,
+				layers=[self.Layer],
+				providers=[self],
+				size=size,
+			))
+
+		return items
+
+
+	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
+		"""
+		Subscribe to filesystem changes under `path`.
+
+		Note:
+			`target` is accepted for API compatibility; current filesystem implementation
+			watches the resolved path without target-specific scoping.
+		"""
+		if not os.path.isdir(self.BasePath + path):
+			return
+		if self.FD is None:
+			L.warning("Cannot subscribe to changes in the filesystem layer of the library: '{}'".format(self.BasePath))
+			return
+		self._subscribe_recursive(path, path)
+
+
+	def _subscribe_recursive(self, subscribed_path, path_to_be_listed):
+		binary = (self.BasePath + path_to_be_listed).encode()
+		wd = inotify_add_watch(self.FD, binary, IN_ALL_EVENTS)
+		if wd == -1:
+			L.error("Error in inotify_add_watch")
+			return
+		self.WDs[wd] = (subscribed_path, path_to_be_listed)
+
+		try:
+			items = self._list(path_to_be_listed)
+		except KeyError:
+			# subscribing to non-existing directory is silent
+			return
+
+		for item in items:
+			if item.type == "dir":
+				self._subscribe_recursive(subscribed_path, item.name)
+
+
+	def _on_inotify_read(self):
+		data = os.read(self.FD, 64 * 1024)
+
+		pos = 0
+		while pos < len(data):
+			wd, mask, cookie, namesize = struct.unpack_from(EVENT_FMT, data, pos)
+			pos += EVENT_SIZE + namesize
+			name = (data[pos - namesize: pos].split(b'\x00', 1)[0]).decode()
+
+			if mask & IN_ISDIR == IN_ISDIR and ((mask & IN_CREATE == IN_CREATE) or (mask & IN_MOVED_TO == IN_MOVED_TO)):
+				subscribed_path, child_path = self.WDs[wd]
+				self._subscribe_recursive(subscribed_path, "/".join([child_path, name]))
+
+			if mask & IN_IGNORED == IN_IGNORED:
+				# cleanup
+				del self.WDs[wd]
+				continue
+
+		self.AggrTimer.restart(0.2)
+
+
+	async def _on_aggr_timer(self):
+		to_advertise = set()
+		for wd, mask, cookie, name in self.AggrEvents:
+			# When wathed directory is being removed, more than one inotify events are being produced.
+			# When IN_IGNORED event occurs, respective wd is removed from self.WDs,
+			# but some other events (like IN_DELETE_SELF) get to this point, without having its reference in self.WDs.
+			subscribed_path, _ = self.WDs.get(wd, (None, None))
+			to_advertise.add(subscribed_path)
+		self.AggrEvents.clear()
+
+		for path in to_advertise:
+			if path is None:
+				continue
+			self.App.PubSub.publish("Library.change!", self, path)
+
+
+	async def find(self, filename: str) -> list:
+		"""
+		Recursively search for files ending with a specific name in the file system, starting from the base path.
+
+		:param filename: The filename to search for (e.g., '.setup.yaml')
+		:return: A list of LibraryItem objects for files ending with the specified name,
+				or an empty list if no matching files were found.
+		"""
+		results = []
+		self._recursive_find(self.BasePath, filename, results)
+		return results
+
+
+	def _recursive_find(self, path, filename, results):
+		"""
+		The recursive part of the find method.
+
+		:param path: The current path to search
+		:param filename: The filename to search for
+		:param results: The list where results are accumulated
+		"""
+		if not os.path.exists(path):
+			return
+
+		if os.path.isfile(path) and path.endswith(filename):
+			item = LibraryItem(
+				name=path[len(self.BasePath):],  # Store relative path
+				type="item",  # or "dir" if applicable
+				layers=[self.Layer],
+				providers=[self],
+			)
+			results.append(item)
+			return
+
+		if os.path.isdir(path):
+			for entry in os.listdir(path):
+				full_path = os.path.join(path, entry)
+
+				# Skip dotted dirs except internal ones ending with .io or .d
+				if os.path.isdir(full_path) and '.' in entry and not entry.endswith(('.io', '.d')):
+					continue
+
+				self._recursive_find(full_path, filename, results)
+
+
+class FileSystemLibraryProvider(SimpleFileSystemLibraryProvider):
 	"""
 	Filesystem provider with ZooKeeper-like target semantics:
 
@@ -53,42 +369,13 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 	"""
 
 	def __init__(self, library, path, layer, *, set_ready=True):
-		super().__init__(library, layer)
+		super().__init__(library, path, layer, set_ready=False)
 
-		# Check for `file://` prefix and strip it if present
-		if path.startswith('file://'):
-			path = path[7:]  # Strip "file://"
-
-		path = os.path.abspath(path)
-		self.BasePath = path.rstrip("/")
-
-		L.info("is connected.", struct_data={'path': path})
-		if set_ready:
-			self.App.TaskService.schedule(self._set_ready())
-
-		if inotify_init is not None:
-			init = inotify_init()
-			if init == -1:
-				L.warning(
-					"Subscribing to library changes in filesystem provider is not available. Inotify was not initialized.")
-				self.FD = None
-			else:
-				self.FD = init
-				self.App.Loop.add_reader(self.FD, self._on_inotify_read)
-				self.AggrTimer = Timer(self.App, self._on_aggr_timer)
-		else:
-			self.FD = None
-
+		# Set up disabled file path
 		self.DisabledFilePath = os.path.join(self.BasePath, '.disabled.yaml')
 
-		self.AggrEvents = []
-		self.WDs = {}  # wd -> (subscribed_path, child_path)
-
-
-	async def finalize(self, app):
-		if self.FD is not None:
-			self.App.Loop.remove_reader(self.FD)
-			os.close(self.FD)
+		if set_ready:
+			self.App.TaskService.schedule(self._set_ready())
 
 
 	def _current_tenant_id(self):
@@ -96,6 +383,7 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 			return Tenant.get()
 		except LookupError:
 			return None
+
 
 	def _current_credentials_id(self):
 		try:
@@ -162,21 +450,6 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 					continue
 				scopes.append((tenant, cred))
 		return scopes
-
-
-	def _validate_read_path(self, path: str) -> None:
-		"""
-		Validate a library item path for read().
-
-		Enforces:
-			- absolute path (starts with '/')
-			- file extension present
-			- no double slashes
-		"""
-		assert path[:1] == '/', "File path must start with '/' (e.g. /library/Templates/file.json)"
-		assert len(
-			os.path.splitext(path)[1]) > 0, "File path must end with an extension (e.g. /library/Templates/item.json)"
-		assert '//' not in path, "File path cannot contain double slashes (//)"
 
 
 	def build_path(self, path, tenant_specific=False, tenant=None):
@@ -360,79 +633,6 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 		return items
 
 
-	def _list(self, path: str):
-		node_path = self.BasePath + path
-		exists = os.access(node_path, os.R_OK) and os.path.isdir(node_path)
-		if not exists:
-			raise KeyError("Path '{}' not found by FileSystemLibraryProvider.".format(path))
-
-		items = []
-		for fname in glob.iglob(os.path.join(node_path, "*")):
-			fstat = os.stat(fname)
-
-			assert fname.startswith(self.BasePath)
-			fname = fname[len(self.BasePath):]
-
-			if stat.S_ISREG(fstat.st_mode):
-				ftype = "item"
-				size = fstat.st_size
-			elif stat.S_ISDIR(fstat.st_mode):
-				ftype = "dir"
-				fname += '/'
-				size = None
-			else:
-				ftype = "?"
-				size = None
-
-			if any(x.startswith('.') for x in fname.split('/')):
-				continue
-
-			items.append(LibraryItem(
-				name=fname,
-				type=ftype,
-				layers=[self.Layer],
-				providers=[self],
-				size=size,
-			))
-
-		return items
-
-
-	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
-		"""
-		Subscribe to filesystem changes under `path`.
-
-		Note:
-			`target` is accepted for API compatibility; current filesystem implementation
-			watches the resolved path without target-specific scoping.
-		"""
-		if not os.path.isdir(self.BasePath + path):
-			return
-		if self.FD is None:
-			L.warning("Cannot subscribe to changes in the filesystem layer of the library: '{}'".format(self.BasePath))
-			return
-		self._subscribe_recursive(path, path)
-
-
-	def _subscribe_recursive(self, subscribed_path, path_to_be_listed):
-		binary = (self.BasePath + path_to_be_listed).encode()
-		wd = inotify_add_watch(self.FD, binary, IN_ALL_EVENTS)
-		if wd == -1:
-			L.error("Error in inotify_add_watch")
-			return
-		self.WDs[wd] = (subscribed_path, path_to_be_listed)
-
-		try:
-			items = self._list(path_to_be_listed)
-		except KeyError:
-			# subscribing to non-existing directory is silent
-			return
-
-		for item in items:
-			if item.type == "dir":
-				self._subscribe_recursive(subscribed_path, item.name)
-
-
 	def _on_inotify_read(self):
 		data = os.read(self.FD, 64 * 1024)
 
@@ -458,64 +658,3 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 				self.App.TaskService.schedule(self.Library._read_disabled(publish_changes=True))
 
 		self.AggrTimer.restart(0.2)
-
-
-	async def _on_aggr_timer(self):
-		to_advertise = set()
-		for wd, mask, cookie, name in self.AggrEvents:
-			# When wathed directory is being removed, more than one inotify events are being produced.
-			# When IN_IGNORED event occurs, respective wd is removed from self.WDs,
-			# but some other events (like IN_DELETE_SELF) get to this point, without having its reference in self.WDs.
-			subscribed_path, _ = self.WDs.get(wd, (None, None))
-			to_advertise.add(subscribed_path)
-		self.AggrEvents.clear()
-
-		for path in to_advertise:
-			if path is None:
-				continue
-			self.App.PubSub.publish("Library.change!", self, path)
-
-
-	async def find(self, filename: str) -> list:
-		"""
-		Recursively search for files ending with a specific name in the file system, starting from the base path.
-
-		:param filename: The filename to search for (e.g., '.setup.yaml')
-		:return: A list of LibraryItem objects for files ending with the specified name,
-				or an empty list if no matching files were found.
-		"""
-		results = []
-		self._recursive_find(self.BasePath, filename, results)
-		return results
-
-
-	def _recursive_find(self, path, filename, results):
-		"""
-		The recursive part of the find method.
-
-		:param path: The current path to search
-		:param filename: The filename to search for
-		:param results: The list where results are accumulated
-		"""
-		if not os.path.exists(path):
-			return
-
-		if os.path.isfile(path) and path.endswith(filename):
-			item = LibraryItem(
-				name=path[len(self.BasePath):],  # Store relative path
-				type="item",  # or "dir" if applicable
-				layers=[self.Layer],
-				providers=[self],
-			)
-			results.append(item)
-			return
-
-		if os.path.isdir(path):
-			for entry in os.listdir(path):
-				full_path = os.path.join(path, entry)
-
-				# Skip dotted dirs except internal ones ending with .io or .d
-				if os.path.isdir(full_path) and '.' in entry and not entry.endswith(('.io', '.d')):
-					continue
-
-				self._recursive_find(full_path, filename, results)

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -519,4 +519,3 @@ class FileSystemLibraryProvider(LibraryProviderABC):
 					continue
 
 				self._recursive_find(full_path, filename, results)
-

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -68,7 +68,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		ssh_passphrase=<optional passphrase for SSH key>
 		verify_ssh_fingerprint=yes|no (default: no - auto-accepts host keys)
 	"""
-	def __init__(self, library, path, layer):
+	def __init__(self, library, path, layer, *, repodir=None):
 
 		# Initialize attributes to avoid attribute errors
 		self.URLScheme = ""
@@ -87,7 +87,8 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		self._parse_url(path)
 		self.Branch = self.Branch if self.Branch != "" else None  # pygit2 expects None for default branch
 
-		repodir = Config.get("library:git", "repodir", fallback=None)
+		if repodir is None:
+			repodir = Config.get("library:git", "repodir", fallback=None)
 		if repodir is not None:
 			self.RepoPath = os.path.abspath(repodir)
 		else:
@@ -453,6 +454,8 @@ class GitLibraryProvider(FileSystemLibraryProvider):
 		# If everything went fine, set the provider as ready
 		# This has to be atomic. There must be no other code between the init task and setting the library ready.
 		await self._set_ready()
+		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
+			f.write("yes")
 
 
 	def _do_fetch(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -453,9 +453,9 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 
 		# If everything went fine, set the provider as ready
 		# This has to be atomic. There must be no other code between the init task and setting the library ready.
-		await self._set_ready()
 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")
+		await self._set_ready()
 
 
 	def _do_fetch(self):

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -6,7 +6,7 @@ import hashlib
 import re
 import typing
 
-from .filesystem import FileSystemLibraryProvider
+from .filesystem import SimpleFileSystemLibraryProvider
 from ...config import Config
 from ...utils import convert_to_seconds
 
@@ -39,7 +39,7 @@ except AttributeError:
 				GIT_CREDTYPE_SSH_KEY = 2  # Standard value across libgit2 versions
 
 
-class GitLibraryProvider(FileSystemLibraryProvider):
+class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 	"""
 	Read-only git provider to read from remote repository.
 	It clones a remote git repository to a temporary directory and then uses the

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -472,7 +472,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
- 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
+		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")
 		await self._set_ready()
 

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -12,7 +12,7 @@ import urllib.parse
 
 import aiohttp
 
-from .filesystem import FileSystemLibraryProvider
+from .filesystem import SimpleFileSystemLibraryProvider
 from ..dirsync import synchronize_dirs
 from ...utils import convert_to_seconds
 
@@ -23,7 +23,7 @@ L = logging.getLogger(__name__)
 #
 
 
-class LibsRegLibraryProvider(FileSystemLibraryProvider):
+class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 	"""
 	Read-only provider to read from remote "library repository".
 

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -60,7 +60,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 	"""
 
 
-	def __init__(self, library, path, layer):
+	def __init__(self, library, path, layer, *, repodir=None):
 
 		url = urllib.parse.urlparse(path)
 		assert url.scheme.startswith("libsreg+")
@@ -100,18 +100,20 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 		# TODO: Read this for `[general]` config
 		self.TrustEnv = True
 
-		tempdir = tempfile.gettempdir()
-		self.RootPath = os.path.join(
-			tempdir,
-			"asab.library.libsreg",
-			hashlib.sha256(path.encode("utf-8")).hexdigest()
-		)
+		if repodir is None:
+			tempdir = tempfile.gettempdir()
+			self.RootPath = os.path.join(
+				tempdir,
+				"asab.library.libsreg",
+				hashlib.sha256(path.encode("utf-8")).hexdigest()
+			)
+		else:
+			self.RootPath = repodir
 
 		self.RepoPath = os.path.join(
 			self.RootPath,
 			"content"
 		)
-
 
 		os.makedirs(os.path.join(self.RepoPath), exist_ok=True)
 
@@ -145,6 +147,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 		async with self.PullLock:
 			await self._do_pull()
 			self.LastPull = self.App.time()
+
 
 	async def _do_pull(self):
 		headers = {}
@@ -231,6 +234,8 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 							# Synchronize the temp_extract_dir into the library
 							synchronize_dirs(self.RepoPath, temp_extract_dir)
 							if not self.IsReady:
+								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
+									f.write("yes")
 								await self._set_ready()
 
 							if etag_incoming is not None:
@@ -251,6 +256,8 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 						elif response.status == 304:
 							# The repository has not changed ...
 							if not self.IsReady:
+								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
+									f.write("yes")
 								await self._set_ready()
 
 							return  # We are done, leaving the loop
@@ -269,6 +276,7 @@ class LibsRegLibraryProvider(FileSystemLibraryProvider):
 
 			except Exception:
 				L.exception("Error when fetching the library content from a registry")
+
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):
 		self.SubscribedPaths.add(path)

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -3,6 +3,7 @@ import io
 import time
 import os.path
 import typing
+import hashlib
 import tarfile
 import asyncio
 import logging
@@ -62,7 +63,7 @@ class LibraryService(Service):
 		self,
 		app: Application,
 		service_name: str,
-		paths: typing.Union[str, typing.List[str], None] = None
+		paths: typing.Union[str, typing.List[str], None] = None,
 	):
 		"""
 		Initialize the LibraryService.
@@ -86,8 +87,8 @@ class LibraryService(Service):
 		self.DisabledPaths: list = []
 		self.Favorites: dict = {}
 		self.FavoritePaths: list = []
+		self.CacheDir = Config.get("library", "cache_dir", fallback="")
 		self.__is_ready_last = False  # This is to ensure edge "not ready" -> "ready" to be published during initialization.
-
 
 		if paths is None:
 			# load them from configuration
@@ -123,8 +124,10 @@ class LibraryService(Service):
 		await self._read_disabled()
 		await self._read_favorites()
 
+
 	def _create_library(self, path, layer):
 		library_provider = None
+
 		if path.startswith('zk://') or path.startswith('zookeeper://'):
 			from .providers.zookeeper import ZooKeeperLibraryProvider
 			library_provider = ZooKeeperLibraryProvider(self, path, layer)
@@ -138,12 +141,22 @@ class LibraryService(Service):
 			library_provider = AzureStorageLibraryProvider(self, path, layer)
 
 		elif path.startswith('git+'):
-			from .providers.git import GitLibraryProvider
-			library_provider = GitLibraryProvider(self, path, layer)
+			if len(self.CacheDir) > 0:
+				repodir = self._get_repodir(path)
+				from .providers.cache import CacheLibraryProvider
+				library_provider = CacheLibraryProvider(self, path, layer, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
+			else:
+				from .providers.git import GitLibraryProvider
+				library_provider = GitLibraryProvider(self, path, layer)
 
 		elif path.startswith('libsreg+'):
-			from .providers.libsreg import LibsRegLibraryProvider
-			library_provider = LibsRegLibraryProvider(self, path, layer)
+			if len(self.CacheDir) > 0:
+				repodir = self._get_repodir(path)
+				from .providers.cache import CacheLibraryProvider
+				library_provider = CacheLibraryProvider(self, path, layer, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
+			else:
+				from .providers.libsreg import LibsRegLibraryProvider
+				library_provider = LibsRegLibraryProvider(self, path, layer)
 
 		elif path == '' or path.startswith("#") or path.startswith(";"):
 			# This is empty or commented line
@@ -154,6 +167,7 @@ class LibraryService(Service):
 			raise SystemExit("Exit due to a critical configuration error.")
 
 		self.Libraries.append(library_provider)
+
 
 	def is_ready(self) -> bool:
 		"""
@@ -985,6 +999,9 @@ class LibraryService(Service):
 
 			for provider in self.Libraries:
 				await provider.subscribe(path, target)
+
+	def _get_repodir(self, path: str) -> str:
+		return os.path.join(self.CacheDir, hashlib.sha256(path.encode('utf-8')).hexdigest())
 
 
 def _validate_path_item(path: str) -> None:

--- a/examples/library.py
+++ b/examples/library.py
@@ -8,8 +8,7 @@ import asab.zookeeper
 
 asab.Config.add_defaults({
 	"zookeeper": {
-		# "servers": "zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181",
-		"servers": "zookeeper-1:2181"
+		"servers": "zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181",
 	},
 
 	"library": {
@@ -27,8 +26,9 @@ class MyApplication(asab.Application):
 		# Specify a locations of the default library
 		asab.Config["library"]["providers"] = '\n'.join([
 			os.path.join(os.path.dirname(__file__), "library"),
-			# "zk:///library",
-			"git+https://github.com/TeskaLabs/asab.git",
+			"zk:///library",
+			"git+https://github.com/TeskaLabs/asab-maestro-library.git",
+			"libsreg+https://libsreg.z6.web.core.windows.net,libsreg-secondary.z6.web.core.windows.net/lmio-common-library#v25.01.01",
 		])
 
 		self.LibraryService = asab.library.LibraryService(


### PR DESCRIPTION
# Library Cache Implementation

## Overview

This post describes the cache support implementation across both `asab-library` (writer/manager) and `asab` (reader).
The cache enables efficient, coordinated access to remote library providers (git and libsreg) by maintaining a local synchronized copy of the library content.

## Architecture

The cache implementation follows a **writer-reader pattern**:

- **asab-library** (Writer/Manager): Manages the cache by populating it with content from remote providers. It is responsible for downloading content from `git` repositories and `libsreg` sources, storing them in a local cache directory, and signaling when the cache is ready for use.

- **asab** (Reader): Reads from the pre-populated cache, waiting for it to be ready before access. Instead of directly connecting to remote sources, it reads from the local filesystem cache that the writer maintains.


## Components

### 1. ASAB Library (Writer) - `asablibrary/library/service.py`

The writer service extends the base ASAB LibraryService and adds cache-aware provider creation.
It introduces a default configuration for the cache directory at `./var/cache`.

The key modification is in how library providers are created for additional layers (any layer beyond the primary writable layer).
When the writer encounters git or libsreg providers in non-primary positions and a cache directory is configured, it creates these providers with a specific repository directory parameter.
This parameter points to a unique subdirectory within the cache, generated by hashing the provider's path using SHA256.
This ensures each remote source gets its own isolated cache location.

The writer inherits the cache directory configuration from the base ASAB library service.
For the primary layer (layer 0), it continues to use read-write providers like ZooKeeper or FileSystem.
For additional layers, it configures `git` and `libsreg` providers to write their content directly into the cache directory structure.

### 2. ASAB (Reader) - asab/library/service.py

The reader service wraps remote providers with a cache-aware provider when a cache directory is configured.
This is controlled by the `cache_dir` configuration option in the library section.

When creating library providers, the reader checks if the provider is a `git` or `libsreg` type and if a cache directory is configured.
If both conditions are met, it instantiates a CacheLibraryProvider instead of the direct remote provider.
This cache provider is configured with two key paths: the repository directory (where the cached content lives) and a ready file path (used to signal cache readiness).

The repository directory is computed the same way as in the writer - by taking the SHA256 hash of the provider path and using it as a subdirectory name within the cache directory.
For git providers, the ready file is placed directly in the repository directory.
For libsreg providers, which have a content subdirectory, the ready file sits at the parent level while the actual content is in a `content` subdirectory.

### 3. Cache Provider - asab/library/providers/cache.py

The CacheLibraryProvider is a specialized filesystem provider designed specifically for reading cached library content.
It extends the `SimpleFileSystemLibraryProvider`, which provides basic filesystem read capabilities without multi-tenancy features.

The critical behavior of this provider is its readiness mechanism.
Unlike standard providers that become ready immediately upon initialization, the cache provider waits for a signal from the writer.
It continuously polls for the existence of a `.ready` file in the cache directory.
Only when this file exists does the provider mark itself as ready and begin serving content.
This prevents readers from accessing partially written or incomplete cache data.

The polling is done asynchronously with a one-second interval, minimizing resource usage while still providing reasonable responsiveness when the cache becomes available.

### 4. FileSystem Provider Split - asab/library/providers/filesystem.py

To support the cache use case, the filesystem provider was architecturally split into two classes with different responsibilities.

The `SimpleFileSystemLibraryProvider` serves as the base class and provides fundamental filesystem access with support for global paths only.
It handles basic operations like reading files and listing directories, and includes inotify-based subscription support for detecting filesystem changes.
This simpler provider is ideal for cache reading since cached content only needs global path access.

The `FileSystemLibraryProvider` extends the simple provider and adds multi-tenancy support.
It implements a three-tier path resolution system for personal, tenant, and global scopes, with reading precedence in that order.
When reading a file, it first checks the personal scope, then the tenant scope, and finally falls back to the global scope.
This extended provider is used for primary writable layers that need to support multiple tenant contexts.


## Cache Flow

### Writer (asab-library) Flow:

The writer begins by reading the cache directory configuration during initialization.
For each library provider configured beyond the primary layer, it checks if the provider is a `git` or `libsreg` type.
When these conditions are met, it computes a unique cache subdirectory by hashing the provider's connection path.

The `git` or `libsreg` providers are then configured with this cache directory as their repository directory.
These providers perform their normal operations - cloning repositories or downloading and extracting archives - but instead of using temporary locations, they write directly into the designated cache subdirectory.

After the initial content population completes successfully, the writer creates a `.ready` file in the cache directory.
This signals to any readers that the cache is now safe to access.
The writer continues running periodic pull operations to keep the cache synchronized with remote sources.

### Reader (asab) Flow:

The reader also reads the cache directory configuration during startup.
For each configured provider that would normally connect to a remote source, it instead creates a CacheLibraryProvider.
This provider points to the same cache directory that the writer maintains - the access for a reader can be (and SHOULD BE) read-only.

Upon initialization, the CacheLibraryProvider immediately begins polling for the `.ready` file.
During this time, the library service reports itself as "not ready" to the application, preventing any read operations. This ensures that applications wait for complete, consistent cache data before proceeding.

Once the `.ready` file appears, the CacheLibraryProvider marks itself as ready, and the library service becomes available.
All subsequent read operations are served directly from the local filesystem cache, providing fast access without any remote network dependencies.

## Configuration Examples

### asab-library (Writer)

The writer configuration specifies a cache directory and lists providers. The primary provider (first in the list) is typically a writable store like ZooKeeper. Additional providers are remote sources that will be cached.

```ini
[library]
cache_dir = ./var/cache
providers=
    zk:///library                    ; Primary writable layer (ZooKeeper)
    git+https://github.com/org/lib.git   ; Cached layer - writes to cache_dir
    libsreg+https://libsreg.example.com/common-lib#v25.01  ; Cached layer
```

### asab (Reader)

The reader uses the same cache directory and lists the same remote providers, but will read from the cache rather than directly from the remote sources.

```ini
[library]
cache_dir = ./var/cache
providers=
    git+https://github.com/org/lib.git   ; Reads from cache_dir, waits for .ready
    libsreg+https://libsreg.example.com/common-lib#v25.01  ; Reads from cache_dir
```

## Cache Directory Structure

The cache directory organizes content by provider, with each provider getting a uniquely named subdirectory based on a hash of its path.

For git providers, the structure includes the full git repository with its `.git` directory, plus the working tree content. The `.ready` file sits at the root level to signal completion.

For libsreg providers, which download pre-packaged archives, the structure separates the content into a dedicated subdirectory with the `.ready` file at the parent level.

```
var/cache/
├── <sha256(git-url)>/           ; Git provider cache
│   ├── .git/                    ; Git repository
│   ├── Templates/
│   ├── Items/
│   └── .ready                   ; Signal file (created by writer)
│
└── <sha256(libsreg-url)>/       ; LibsReg provider cache
    ├── content/                 ; Extracted archive content
    │   ├── Templates/
    │   └── Items/
    └── .ready                   ; Signal file (created by writer)
```


## Provider Compatibility

The following table summarizes which providers support caching:

| Provider   | Cache Support | Notes                                    |
|------------|---------------|------------------------------------------|
| Git        | Yes           | Clones to cache directory, creates .ready file when clone is complete |
| LibsReg    | Yes           | Extracts archive to cache/content subdirectory, creates .ready file at parent level |
| ZooKeeper  | No (primary)  | Used as primary writable layer, does not use caching |
| FileSystem | No            | Already local paths, no remote source to cache |
| Azure      | No            | Not yet implemented for caching |

## Migration Notes

Existing configurations that do not specify a `cache_dir` continue to work exactly as before - providers connect directly to their remote sources. Adding a `cache_dir` configuration option enables caching for all compatible providers in that configuration.

The `.ready` file mechanism ensures backward compatibility during transitions. If a writer has not yet created the cache or the `.ready` file, readers simply wait rather than failing or reading partial data. This allows for gradual rollouts and safe updates in production environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable caching via a new library.cache_dir setting.
  * Git and registry providers can use per-path cache directories when caching is enabled.
  * Added a cache-backed provider that waits for a readiness marker file before exposing content.

* **Refactor**
  * Consolidated filesystem/provider logic into a shared base to centralize filesystem and change-notification behavior.

* **Examples**
  * Updated example configuration to show multi-server and registry providers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/asab/pull/758)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->