### PR TITLE
Allow ApiKey tokens in dev auth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## Release candidate
 
 ### Fixes
+- Treat HTTP authentication scheme as case-insensitive (#759)
 - Authenticate websocket requests with multivalued Upgrade header (#748)
+
+### Features
+- Support ApiKey tokens in development auth mode (#759)
 
 ---
 

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -55,9 +55,9 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 		if token is None:
 			token = get_bearer_token_from_authorization_header(request)
 
-		token_type, token_value = token
-		if token_type not in {"bearer", "apikey"}:
-			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+		auth_scheme, token_value = token
+		if auth_scheme not in {"bearer", "apikey"}:
+			L.warning("Unsupported Authorization header scheme: {!r}".format(auth_scheme))
 			raise NotAuthenticatedError()
 
 		# Try if the access token is already known
@@ -76,9 +76,9 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 				if response.status != 200:
 					L.warning("Access token introspection failed.")
 					raise NotAuthenticatedError()
-				token_type, id_token = get_bearer_token_from_authorization_header(response)
-				if token_type != "bearer":
-					L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+				auth_scheme, id_token = get_bearer_token_from_authorization_header(response)
+				if auth_scheme != "bearer":
+					L.warning("Unsupported Authorization header scheme: {!r}".format(auth_scheme))
 					raise NotAuthenticatedError()
 
 		# Create a new Authorization object and store it

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -56,7 +56,7 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 			token = get_bearer_token_from_authorization_header(request)
 
 		token_type, token_value = token
-		if token_type.casefold() not in {"bearer", "apikey"}:
+		if token_type not in {"bearer", "apikey"}:
 			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
 			raise NotAuthenticatedError()
 
@@ -77,7 +77,7 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 					L.warning("Access token introspection failed.")
 					raise NotAuthenticatedError()
 				token_type, id_token = get_bearer_token_from_authorization_header(response)
-				if token_type.casefold() != "bearer":
+				if token_type != "bearer":
 					L.warning("Unsupported Authorization header type: {!r}".format(token_type))
 					raise NotAuthenticatedError()
 

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -40,25 +40,30 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 
 
 	async def _authorize(self, request: aiohttp.web.Request) -> Authorization:
-		access_token = None
+		token = None
 
 		# First, try to extract the access token from the WebSocket protocol header (if it's a WebSocket request)
 		if connection_header := request.headers.get(aiohttp.hdrs.CONNECTION):
 			for value in connection_header.casefold().split(","):
 				if value.strip() == "upgrade":
-					access_token = get_bearer_token_from_websocket_request(request)
+					token = get_bearer_token_from_websocket_request(request)
 					break
 
-		if access_token is None:
-			access_token = get_bearer_token_from_authorization_header(request)
+		if token is None:
+			token = get_bearer_token_from_authorization_header(request)
+
+		token_type, token_value = token
+		if token_type.casefold() not in {"bearer", "apikey"}:
+			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+			raise NotAuthenticatedError()
 
 		# Try if the access token is already known
-		authz = self.Authorizations.get(access_token)
+		authz = self.Authorizations.get(token)
 		if authz is not None:
 			try:
 				authz.require_valid()
 			except NotAuthenticatedError as e:
-				del self.Authorizations[access_token]
+				del self.Authorizations[token]
 				raise e
 			return authz
 
@@ -68,11 +73,14 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 				if response.status != 200:
 					L.warning("Access token introspection failed.")
 					raise NotAuthenticatedError()
-				id_token = get_bearer_token_from_authorization_header(response)
+				token_type, id_token = get_bearer_token_from_authorization_header(response)
+				if token_type.casefold() != "bearer":
+					L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+					raise NotAuthenticatedError()
 
 		# Create a new Authorization object and store it
 		claims = await self._get_claims_from_id_token(id_token)
 		authz = Authorization(claims, id_token=id_token)
 
-		self.Authorizations[access_token] = authz
+		self.Authorizations[token] = authz
 		return authz

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -108,7 +108,7 @@ class IdTokenAuthProvider(AuthProviderABC):
 			Valid asab.web.auth.Authorization object
 		"""
 		token_type, token_value = token
-		if token_type.casefold() != "bearer":
+		if token_type != "bearer":
 			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
 			raise NotAuthenticatedError()
 

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -102,14 +102,14 @@ class IdTokenAuthProvider(AuthProviderABC):
 		Build authorization from ID token.
 
 		Args:
-			token: Tuple of token type (must be "Bearer") and token value (Base64-encoded ID token)
+			token: Tuple of authentication scheme (must be Bearer) and token value (Base64-encoded ID token)
 
 		Returns:
 			Valid asab.web.auth.Authorization object
 		"""
-		token_type, token_value = token
-		if token_type != "bearer":
-			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+		auth_scheme, token_value = token
+		if auth_scheme != "bearer":
+			L.warning("Unsupported Authorization header scheme: {!r}".format(auth_scheme))
 			raise NotAuthenticatedError()
 
 		# Try if the object already exists

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -29,7 +29,7 @@ class IdTokenAuthProvider(AuthProviderABC):
 		for provider in public_key_providers:
 			self.register_key_provider(provider)
 
-		self.Authorizations = {}
+		self.Authorizations: typing.Dict[typing.Tuple[str, str], Authorization] = {}
 
 		self.App.PubSub.subscribe("PublicKey.updated!", self.collect_keys)
 		self.App.PubSub.subscribe("Application.housekeeping!", self._delete_invalid_authorizations)
@@ -51,8 +51,8 @@ class IdTokenAuthProvider(AuthProviderABC):
 			raise NotAuthenticatedError(resource_metadata=self.ResourceMatadataUrl)
 
 		try:
-			bearer_token = get_bearer_token_from_authorization_header(request)
-			authz = await self._build_authorization(bearer_token)
+			token = get_bearer_token_from_authorization_header(request)
+			authz = await self._build_authorization(token)
 			return authz
 		except NotAuthenticatedError as e:
 			e.update_www_authenticate(resource_metadata=self.ResourceMatadataUrl)
@@ -79,31 +79,36 @@ class IdTokenAuthProvider(AuthProviderABC):
 		self.collect_keys()
 
 
-	async def _build_authorization(self, id_token: str) -> Authorization:
+	async def _build_authorization(self, token: typing.Tuple[str, str]) -> Authorization:
 		"""
 		Build authorization from ID token.
 
 		Args:
-			id_token: Base64-encoded JWToken from Authorization header
+			token: Tuple of token type (must be "Bearer") and token value (Base64-encoded ID token)
 
 		Returns:
 			Valid asab.web.auth.Authorization object
 		"""
+		token_type, token_value = token
+		if token_type.casefold() != "bearer":
+			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+			raise NotAuthenticatedError()
+
 		# Try if the object already exists
-		authz = self.Authorizations.get(id_token)
+		authz = self.Authorizations.get(token)
 		if authz is not None:
 			try:
 				authz.require_valid()
 			except NotAuthenticatedError as e:
-				del self.Authorizations[id_token]
+				del self.Authorizations[token]
 				raise e
 			return authz
 
 		# Create a new Authorization object and store it
-		claims = await self._get_claims_from_id_token(id_token)
-		authz = Authorization(claims, id_token=id_token)
+		claims = await self._get_claims_from_id_token(token_value)
+		authz = Authorization(claims, id_token=token_value)
 
-		self.Authorizations[id_token] = authz
+		self.Authorizations[token] = authz
 		return authz
 
 

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -35,6 +35,10 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 		auth_scheme, token_value = authorization_header.split(None, 1)
 	except ValueError:
 		L.warning("Cannot parse Authorization header.")
+		raise NotAuthenticatedError() from None
+
+	if not token_value:
+		L.warning("Cannot parse Authorization header.")
 		raise NotAuthenticatedError()
 
 	return auth_scheme.casefold(), token_value

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -14,7 +14,7 @@ L = logging.getLogger(__name__)
 
 def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> typing.Tuple[str, str]:
 	"""
-	Validate the Authorization header and extract the Bearer token value
+	Validate the Authorization header and extract the authentication scheme and token value
 	"""
 	authorization_header = request.headers.get(aiohttp.hdrs.AUTHORIZATION)
 	if authorization_header is None:
@@ -22,21 +22,22 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 		raise NotAuthenticatedError()
 
 	try:
-		auth_type, token_value = authorization_header.split(" ", 1)
+		auth_scheme, token_value = authorization_header.split(" ", 1)
 	except ValueError:
 		L.warning("Cannot parse Authorization header.")
 		raise NotAuthenticatedError()
 
-	if auth_type.casefold() not in {"bearer", "apikey"}:
-		L.warning("Unsupported Authorization header type: {!r}".format(auth_type))
+	auth_scheme = auth_scheme.casefold()
+	if auth_scheme not in {"bearer", "apikey"}:
+		L.warning("Unsupported Authorization header type: {!r}".format(auth_scheme))
 		raise NotAuthenticatedError()
 
-	return auth_type, token_value
+	return auth_scheme, token_value
 
 
 def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> typing.Tuple[str, str] | None:
 	"""
-	Extract the Bearer token from the WebSocket protocol header.
+	Extract the authentication scheme and token value from the WebSocket protocol header.
 	This is a workaround used in ASAB to pass the access token to the WebSocket connection.
 	"""
 	protocol = request.headers.get('sec-websocket-protocol')
@@ -45,7 +46,7 @@ def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> typ
 			p = p.strip()
 			if not p.startswith('access_token_'):
 				continue
-			return "Bearer", p[len('access_token_'):]
+			return "bearer", p[len('access_token_'):]
 	return None
 
 

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -26,7 +26,7 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 		L.warning("Cannot parse Authorization header.")
 		raise NotAuthenticatedError()
 
-	if auth_type != "Bearer":
+	if auth_type not in {"Bearer", "ApiKey"}:
 		L.warning("Unsupported Authorization header type: {!r}".format(auth_type))
 		raise NotAuthenticatedError()
 

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -15,6 +15,16 @@ L = logging.getLogger(__name__)
 def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> typing.Tuple[str, str]:
 	"""
 	Validate the Authorization header and extract the authentication scheme and token value
+
+	Args:
+		request: The aiohttp request object containing the Authorization header.
+
+	Returns:
+		A tuple containing the authentication scheme and the token value.
+
+	Raises:
+		NotAuthenticatedError: If the Authorization header is missing, cannot be parsed,
+			or uses an unsupported authentication scheme.
 	"""
 	authorization_header = request.headers.get(aiohttp.hdrs.AUTHORIZATION)
 	if authorization_header is None:
@@ -27,18 +37,20 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 		L.warning("Cannot parse Authorization header.")
 		raise NotAuthenticatedError()
 
-	auth_scheme = auth_scheme.casefold()
-	if auth_scheme not in {"bearer", "apikey"}:
-		L.warning("Unsupported Authorization header type: {!r}".format(auth_scheme))
-		raise NotAuthenticatedError()
-
-	return auth_scheme, token_value
+	return auth_scheme.casefold(), token_value
 
 
 def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> typing.Tuple[str, str] | None:
 	"""
 	Extract the authentication scheme and token value from the WebSocket protocol header.
 	This is a workaround used in ASAB to pass the access token to the WebSocket connection.
+
+	Args:
+		request: The aiohttp request object containing the WebSocket protocol header.
+
+	Returns:
+		A tuple containing the authentication scheme ("bearer") and the token value,
+		or None if no access token protocol is found.
 	"""
 	protocol = request.headers.get('sec-websocket-protocol')
 	if protocol is not None:
@@ -53,6 +65,18 @@ def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> typ
 def get_id_token_claims(bearer_token: str, auth_server_public_key: jwcrypto.jwk.JWKSet):
 	"""
 	Parse and validate JWT ID token and extract the claims (user info)
+
+	Args:
+		bearer_token: The JWT token string to parse and validate.
+		auth_server_public_key: The JWKSet containing the public key used to verify the token signature.
+
+	Returns:
+		A dictionary containing the token claims (user information).
+
+	Raises:
+		NotAuthenticatedError: If the token is expired, cannot be parsed, or signature verification fails.
+		JWTMissingKey: If the key required to verify the token is missing from the JWKSet.
+		InvalidJWSSignature: If the token signature is invalid.
 	"""
 	assert jwcrypto is not None
 	try:

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -32,7 +32,7 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 		raise NotAuthenticatedError()
 
 	try:
-		auth_scheme, token_value = authorization_header.split(" ", 1)
+		auth_scheme, token_value = authorization_header.split(None, 1)
 	except ValueError:
 		L.warning("Cannot parse Authorization header.")
 		raise NotAuthenticatedError()

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -1,3 +1,4 @@
+import typing
 import aiohttp
 import aiohttp.web
 import jwcrypto.jwk
@@ -11,7 +12,7 @@ from ...exceptions import NotAuthenticatedError
 L = logging.getLogger(__name__)
 
 
-def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> str:
+def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> typing.Tuple[str, str]:
 	"""
 	Validate the Authorization header and extract the Bearer token value
 	"""
@@ -26,14 +27,14 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 		L.warning("Cannot parse Authorization header.")
 		raise NotAuthenticatedError()
 
-	if auth_type not in {"Bearer", "ApiKey"}:
+	if auth_type.casefold() not in {"bearer", "apikey"}:
 		L.warning("Unsupported Authorization header type: {!r}".format(auth_type))
 		raise NotAuthenticatedError()
 
-	return token_value
+	return auth_type, token_value
 
 
-def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> str:
+def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> typing.Tuple[str, str] | None:
 	"""
 	Extract the Bearer token from the WebSocket protocol header.
 	This is a workaround used in ASAB to pass the access token to the WebSocket connection.
@@ -44,7 +45,7 @@ def get_bearer_token_from_websocket_request(request: aiohttp.web.Request) -> str
 			p = p.strip()
 			if not p.startswith('access_token_'):
 				continue
-			return p[len('access_token_'):]
+			return "Bearer", p[len('access_token_'):]
 	return None
 
 


### PR DESCRIPTION
# Summary
- Auth mode `development` now introspects tokens with `apikey` authentication scheme.
- Authentication scheme in the HTTP Authorization header is now treated as case-insensitive, as per https://datatracker.ietf.org/doc/html/rfc7235#section-2.1. This should also resolve the issue of Bruno OpenAPI support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ApiKey token support for development authentication scenarios.
  * Enhanced WebSocket authentication to handle multivalued Upgrade headers.

* **Bug Fixes**
  * HTTP authentication scheme handling is now case-insensitive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/asab/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->