### PR TITLE
Make sure the stacktrace mentions the route where OpenAPI build failed

### DIFF
--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -89,11 +89,17 @@ class DocWebHandler(object):
 				# TODO: once/if there is graphql, its method name is probably `*`
 				continue
 
+			route_path = self.get_route_path(route)
+			try:
+				route_data = self.parse_route_data(route)
+			except Exception as e:
+				raise ValueError("Failed to parse OpenAPI data for {} {}".format(route.method, route_path)) from e
+
 			# Determine which routes are asab-based
-			if re.search("(asab|doc|oauth2-redirect.html|bspump)", self.get_route_path(route)):
-				asab_routes.append(self.parse_route_data(route))
+			if re.search("(asab|doc|oauth2-redirect.html|bspump)", route_path):
+				asab_routes.append(route_data)
 			else:
-				routes.append(self.parse_route_data(route))
+				routes.append(route_data)
 
 		routes.sort(key=get_first_tag)
 


### PR DESCRIPTION
When `parse_route_data` fails during OpenAPI build, the stacktrace now includes where the fail happened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling in API documentation generation with clearer error messages indicating the HTTP method and route path when parsing issues occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/asab/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->