### PR TITLE
Write provider URL into library cache metadata

### DIFF
--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -143,6 +143,7 @@ class LibraryService(Service):
 		elif path.startswith('git+'):
 			if len(self.CacheDir) > 0:
 				repodir = self._get_repodir(path)
+				self._write_cache_url(repodir, path)
 				from .providers.cache import CacheLibraryProvider
 				library_provider = CacheLibraryProvider(self, path, layer, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
 			else:
@@ -152,6 +153,7 @@ class LibraryService(Service):
 		elif path.startswith('libsreg+'):
 			if len(self.CacheDir) > 0:
 				repodir = self._get_repodir(path)
+				self._write_cache_url(repodir, path)
 				from .providers.cache import CacheLibraryProvider
 				library_provider = CacheLibraryProvider(self, path, layer, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
 			else:
@@ -1002,6 +1004,11 @@ class LibraryService(Service):
 
 	def _get_repodir(self, path: str) -> str:
 		return os.path.join(self.CacheDir, hashlib.sha256(path.encode('utf-8')).hexdigest())
+
+	def _write_cache_url(self, repodir: str, path: str) -> None:
+		os.makedirs(repodir, exist_ok=True)
+		with open(os.path.join(repodir, ".url"), "w") as f:
+			f.write(path)
 
 
 def _validate_path_item(path: str) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cache directory management for provider sources with improved metadata tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->