### PR TITLE
Python 3.14 support - Fix asyncio initialization

### DIFF
--- a/asab/application.py
+++ b/asab/application.py
@@ -124,8 +124,12 @@ class Application(metaclass=Singleton):
 		random.seed()
 
 		# Obtain the event loop
-		self.Loop = asyncio.get_event_loop()
-		if self.Loop.is_closed():
+		try:
+			self.Loop = asyncio.get_event_loop()
+		except RuntimeError:
+			self.Loop = None
+
+		if self.Loop is None or self.Loop.is_closed():
 			self.Loop = asyncio.new_event_loop()
 			asyncio.set_event_loop(self.Loop)
 


### PR DESCRIPTION
# Issue 
In python 3.14 `asyncio.get_event_loop` no longer creates a loop for you when none is set; it now raises RuntimeError instead.
```
  File "/home/robin/teskalabs/asab/asab/application.py", line 128, in __init__
    self.Loop = asyncio.get_event_loop()
                ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
                       % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.
```

# Solution
Catch the error and create a new event loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event loop initialization to robustly handle edge cases in certain runtime environments. The application now gracefully manages situations where default event loop acquisition fails, automatically creating a new event loop as needed. This enhancement improves application stability and compatibility across diverse system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->