### PR TITLE
Print the full stack trace during task execution

### DIFF
--- a/asab/task.py
+++ b/asab/task.py
@@ -159,11 +159,9 @@ class TaskService(asab.Service):
 				for task in done:
 					try:
 						await task
-					except Exception as e:
-						msg = str(e)
-						if len(msg) == 0:
-							msg = e.__class__.__name__
-						L.exception("Error '{}' during task:".format(msg))
+					except Exception:
+						exc = task.exception()
+						L.exception("Error during task:", exc_info=exc)
 					self.App.PubSub.publish("TaskService.task_done!", task)
 
 


### PR DESCRIPTION
Adding the full stacktrace to the exception raised during task execution.



```
============================================================
Testing TaskService exception logging
============================================================

2026-06-04 10:37:00,801 ERROR asab.task Error during task:
Traceback (most recent call last):
  File "/home/mir/Work/TeskaLabs/Workspace/asab/asab/task.py", line 161, in main
    await task
  File "/home/mir/Work/TeskaLabs/Workspace/asab/test_task_traceback.py", line 43, in task_with_deep_stack
    await self.middle_function()
  File "/home/mir/Work/TeskaLabs/Workspace/asab/test_task_traceback.py", line 47, in middle_function
    await self.inner_function()
  File "/home/mir/Work/TeskaLabs/Workspace/asab/test_task_traceback.py", line 53, in inner_function
    raise FileNotFoundError(
FileNotFoundError: No such file or directory: '/data/hot/received.system.kafka/ablagi.part'

============================================================
Test complete - check the log output above.
You should see a full stack trace showing:
  1. inner_function
  2. middle_function
  3. task_with_deep_stack
============================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exception logging for task failures to ensure complete error information is captured and reported in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->