### PR TITLE
Add stable source IDs to ASAB library providers

### DIFF
--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -10,6 +10,7 @@ class LibraryProviderABC(object):
 		self.App = library.App
 		self.Library = library
 		self.Layer = layer
+		self.Path = source
 		self.Source = source
 		self.ID = hashlib.sha256(source.encode("utf-8")).hexdigest() if source is not None else None
 		self.IsReady = False

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -1,19 +1,30 @@
+import hashlib
+import os
 import typing
 
 
 class LibraryProviderABC(object):
 
 
-	def __init__(self, library, layer):
+	def __init__(self, library, layer, source=None):
 		super().__init__()
 		self.App = library.App
 		self.Library = library
 		self.Layer = layer
+		self.Source = source
+		self.ID = hashlib.sha256(source.encode("utf-8")).hexdigest() if source is not None else None
 		self.IsReady = False
 
 
 	async def finalize(self, app):
 		pass
+
+
+	def _write_cache_source(self, path):
+		if self.Source is None:
+			return
+		with open(os.path.join(path, ".url"), "w") as f:
+			f.write(self.Source)
 
 
 	async def read(self, path: str) -> typing.IO:

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -1,5 +1,4 @@
 import hashlib
-import os
 import typing
 
 
@@ -18,13 +17,6 @@ class LibraryProviderABC(object):
 
 	async def finalize(self, app):
 		pass
-
-
-	def _write_cache_source(self, path):
-		if self.Source is None:
-			return
-		with open(os.path.join(path, ".url"), "w") as f:
-			f.write(self.Source)
 
 
 	async def read(self, path: str) -> typing.IO:

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -5,14 +5,13 @@ import typing
 class LibraryProviderABC(object):
 
 
-	def __init__(self, library, layer, source=None):
+	def __init__(self, library, layer, source):
 		super().__init__()
 		self.App = library.App
 		self.Library = library
 		self.Layer = layer
-		self.Path = source
 		self.Source = source
-		self.ID = hashlib.sha256(source.encode("utf-8")).hexdigest() if source is not None else None
+		self.ID = hashlib.sha256(source.encode("utf-8")).hexdigest()
 		self.IsReady = False
 
 

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -42,6 +42,7 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 	def __init__(self, library, path, layer):
 		super().__init__(library, layer, path)
 		assert path[:6] == "azure+"
+		self.Path = path
 		self.URL = urllib.parse.urlparse(path[6:])
 		self.Model = None  # Will be set by `_load_model` method
 

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -40,11 +40,10 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 	'''
 
 	def __init__(self, library, path, layer):
-		super().__init__(library, layer)
+		super().__init__(library, layer, path)
 		assert path[:6] == "azure+"
 		self.URL = urllib.parse.urlparse(path[6:])
 		self.Model = None  # Will be set by `_load_model` method
-		self.Path = path
 
 		self.CacheDir = Config.get("library", "azure_cache")
 		if self.CacheDir == 'false':

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -39,8 +39,8 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 
 	'''
 
-	def __init__(self, library, path, layer):
-		super().__init__(library, layer, path)
+	def __init__(self, library, path, layer, *, source):
+		super().__init__(library, layer, source)
 		assert path[:6] == "azure+"
 		self.Path = path
 		self.URL = urllib.parse.urlparse(path[6:])

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -12,6 +12,7 @@ class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 	def __init__(self, library, path, layer, *, repodir, ready_file):
 		self.ReadyFile = ready_file
 		super().__init__(library, repodir, layer, set_ready=False)
+		self.Path = None
 		self.Source = None
 		self.ID = None
 

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -12,6 +12,8 @@ class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 	def __init__(self, library, path, layer, *, repodir, ready_file):
 		self.ReadyFile = ready_file
 		super().__init__(library, repodir, layer, set_ready=False)
+		self.Source = None
+		self.ID = None
 
 		# Wait for the ready file to be created by the asab-library service, indicating that the cache folder is ready.
 		self.App.TaskService.schedule(self.wait_for_ready())

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -9,9 +9,9 @@ L = logging.getLogger(__name__)
 
 class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 
-	def __init__(self, library, path, layer, *, repodir, ready_file):
+	def __init__(self, library, path, layer, *, source, repodir, ready_file):
 		self.ReadyFile = ready_file
-		super().__init__(library, repodir, layer, source=path, set_ready=False)
+		super().__init__(library, repodir, layer, source=source, set_ready=False)
 
 		# Wait for the ready file to be created by the asab-library service, indicating that the cache folder is ready.
 		self.App.TaskService.schedule(self.wait_for_ready())

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -11,10 +11,7 @@ class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 
 	def __init__(self, library, path, layer, *, repodir, ready_file):
 		self.ReadyFile = ready_file
-		super().__init__(library, repodir, layer, set_ready=False)
-		self.Path = None
-		self.Source = None
-		self.ID = None
+		super().__init__(library, repodir, layer, source=path, set_ready=False)
 
 		# Wait for the ready file to be created by the asab-library service, indicating that the cache folder is ready.
 		self.App.TaskService.schedule(self.wait_for_ready())

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -41,8 +41,8 @@ class SimpleFileSystemLibraryProvider(LibraryProviderABC):
 	- global path: <BasePath>/<path>
 	"""
 
-	def __init__(self, library, path, layer, *, set_ready=True, provider_source=None):
-		super().__init__(library, layer, path if provider_source is None else provider_source)
+	def __init__(self, library, path, layer, *, source, set_ready=True):
+		super().__init__(library, layer, source)
 
 		# Check for `file://` prefix and strip it if present
 		if path.startswith('file://'):
@@ -368,8 +368,8 @@ class FileSystemLibraryProvider(SimpleFileSystemLibraryProvider):
 		("personal", "<cred>") -> watch one personal credential scope
 	"""
 
-	def __init__(self, library, path, layer, *, set_ready=True, provider_source=None):
-		super().__init__(library, path, layer, set_ready=False, provider_source=provider_source)
+	def __init__(self, library, path, layer, *, source, set_ready=True):
+		super().__init__(library, path, layer, source=source, set_ready=False)
 
 		# Set up disabled file path
 		self.DisabledFilePath = os.path.join(self.BasePath, '.disabled.yaml')

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -41,8 +41,8 @@ class SimpleFileSystemLibraryProvider(LibraryProviderABC):
 	- global path: <BasePath>/<path>
 	"""
 
-	def __init__(self, library, path, layer, *, set_ready=True):
-		super().__init__(library, layer)
+	def __init__(self, library, path, layer, *, set_ready=True, provider_source=None):
+		super().__init__(library, layer, path if provider_source is None else provider_source)
 
 		# Check for `file://` prefix and strip it if present
 		if path.startswith('file://'):
@@ -368,8 +368,8 @@ class FileSystemLibraryProvider(SimpleFileSystemLibraryProvider):
 		("personal", "<cred>") -> watch one personal credential scope
 	"""
 
-	def __init__(self, library, path, layer, *, set_ready=True):
-		super().__init__(library, path, layer, set_ready=False)
+	def __init__(self, library, path, layer, *, set_ready=True, provider_source=None):
+		super().__init__(library, path, layer, set_ready=False, provider_source=provider_source)
 
 		# Set up disabled file path
 		self.DisabledFilePath = os.path.join(self.BasePath, '.disabled.yaml')

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -472,9 +472,9 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
-		if self.Source is not None:
-			with open(os.path.join(self.RepoPath, ".url"), "w") as f:
-				f.write(self.Source)
+
+		with open(os.path.join(self.RepoPath, ".url"), "w") as f:
+			f.write(self.Source)
 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")
 		await self._set_ready()

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -68,7 +68,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 		ssh_passphrase=<optional passphrase for SSH key>
 		verify_ssh_fingerprint=yes|no (default: no - auto-accepts host keys)
 	"""
-	def __init__(self, library, path, layer, *, repodir=None):
+	def __init__(self, library, path, layer, *, source, repodir=None):
 
 		# Initialize attributes to avoid attribute errors
 		self.URLScheme = ""
@@ -99,7 +99,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 				hashlib.sha256(path.encode('utf-8')).hexdigest()
 			)
 
-		super().__init__(library, self.RepoPath, layer, source=path, set_ready=False)
+		super().__init__(library, self.RepoPath, layer, source=source, set_ready=False)
 
 		# Set custom SSL certificate locations if specified
 		cert_file = Config.get("library:git", "cert_file", fallback=None)
@@ -472,8 +472,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
-
-		with open(os.path.join(self.RepoPath, ".url"), "w") as f:
+		with open(os.path.join(self.RepoPath, ".source"), "w") as f:
 			f.write(self.Source)
 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -99,7 +99,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 				hashlib.sha256(path.encode('utf-8')).hexdigest()
 			)
 
-		super().__init__(library, self.RepoPath, layer, set_ready=False, provider_source=path)
+		super().__init__(library, self.RepoPath, layer, source=path, set_ready=False)
 
 		# Set custom SSL certificate locations if specified
 		cert_file = Config.get("library:git", "cert_file", fallback=None)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -472,7 +472,9 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
-		self._write_cache_source(self.RepoPath)
+		if self.Source is not None:
+			with open(os.path.join(self.RepoPath, ".url"), "w") as f:
+				f.write(self.Source)
 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")
 		await self._set_ready()

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -99,7 +99,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 				hashlib.sha256(path.encode('utf-8')).hexdigest()
 			)
 
-		super().__init__(library, self.RepoPath, layer, set_ready=False)
+		super().__init__(library, self.RepoPath, layer, set_ready=False, provider_source=path)
 
 		# Set custom SSL certificate locations if specified
 		cert_file = Config.get("library:git", "cert_file", fallback=None)
@@ -472,6 +472,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
+		self._write_cache_source(self.RepoPath)
 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")
 		await self._set_ready()

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -472,8 +472,6 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.GitRepository = None
 			raise RuntimeError("Git repository working tree is empty - removed for retry")
 
-		with open(os.path.join(self.RepoPath, ".source"), "w") as f:
-			f.write(self.Source)
 		with open(os.path.join(self.RepoPath, ".ready"), "w") as f:
 			f.write("yes")
 		await self._set_ready()

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -234,7 +234,9 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 							# Synchronize the temp_extract_dir into the library
 							synchronize_dirs(self.RepoPath, temp_extract_dir)
 							if not self.IsReady:
-								self._write_cache_source(self.RootPath)
+								if self.Source is not None:
+									with open(os.path.join(self.RootPath, ".url"), "w") as f:
+										f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()
@@ -257,7 +259,9 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 						elif response.status == 304:
 							# The repository has not changed ...
 							if not self.IsReady:
-								self._write_cache_source(self.RootPath)
+								if self.Source is not None:
+									with open(os.path.join(self.RootPath, ".url"), "w") as f:
+										f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -60,7 +60,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 	"""
 
 
-	def __init__(self, library, path, layer, *, repodir=None):
+	def __init__(self, library, path, layer, *, source, repodir=None):
 
 		url = urllib.parse.urlparse(path)
 		assert url.scheme.startswith("libsreg+")
@@ -117,7 +117,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 
 		os.makedirs(os.path.join(self.RepoPath), exist_ok=True)
 
-		super().__init__(library, self.RepoPath, layer, source=path, set_ready=False)
+		super().__init__(library, self.RepoPath, layer, source=source, set_ready=False)
 
 		self.PullLock = asyncio.Lock()
 		self.LastPull = None
@@ -234,7 +234,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 							# Synchronize the temp_extract_dir into the library
 							synchronize_dirs(self.RepoPath, temp_extract_dir)
 							if not self.IsReady:
-								with open(os.path.join(self.RootPath, ".url"), "w") as f:
+								with open(os.path.join(self.RootPath, ".source"), "w") as f:
 									f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
@@ -258,7 +258,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 						elif response.status == 304:
 							# The repository has not changed ...
 							if not self.IsReady:
-								with open(os.path.join(self.RootPath, ".url"), "w") as f:
+								with open(os.path.join(self.RootPath, ".source"), "w") as f:
 									f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -117,7 +117,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 
 		os.makedirs(os.path.join(self.RepoPath), exist_ok=True)
 
-		super().__init__(library, self.RepoPath, layer, set_ready=False)
+		super().__init__(library, self.RepoPath, layer, set_ready=False, provider_source=path)
 
 		self.PullLock = asyncio.Lock()
 		self.LastPull = None
@@ -234,6 +234,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 							# Synchronize the temp_extract_dir into the library
 							synchronize_dirs(self.RepoPath, temp_extract_dir)
 							if not self.IsReady:
+								self._write_cache_source(self.RootPath)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()
@@ -256,6 +257,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 						elif response.status == 304:
 							# The repository has not changed ...
 							if not self.IsReady:
+								self._write_cache_source(self.RootPath)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -234,9 +234,8 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 							# Synchronize the temp_extract_dir into the library
 							synchronize_dirs(self.RepoPath, temp_extract_dir)
 							if not self.IsReady:
-								if self.Source is not None:
-									with open(os.path.join(self.RootPath, ".url"), "w") as f:
-										f.write(self.Source)
+								with open(os.path.join(self.RootPath, ".url"), "w") as f:
+									f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()
@@ -259,9 +258,8 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 						elif response.status == 304:
 							# The repository has not changed ...
 							if not self.IsReady:
-								if self.Source is not None:
-									with open(os.path.join(self.RootPath, ".url"), "w") as f:
-										f.write(self.Source)
+								with open(os.path.join(self.RootPath, ".url"), "w") as f:
+									f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -117,7 +117,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 
 		os.makedirs(os.path.join(self.RepoPath), exist_ok=True)
 
-		super().__init__(library, self.RepoPath, layer, set_ready=False, provider_source=path)
+		super().__init__(library, self.RepoPath, layer, source=path, set_ready=False)
 
 		self.PullLock = asyncio.Lock()
 		self.LastPull = None

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -234,8 +234,6 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 							# Synchronize the temp_extract_dir into the library
 							synchronize_dirs(self.RepoPath, temp_extract_dir)
 							if not self.IsReady:
-								with open(os.path.join(self.RootPath, ".source"), "w") as f:
-									f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()
@@ -258,8 +256,6 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 						elif response.status == 304:
 							# The repository has not changed ...
 							if not self.IsReady:
-								with open(os.path.join(self.RootPath, ".source"), "w") as f:
-									f.write(self.Source)
 								with open(os.path.join(self.RootPath, ".ready"), "w") as f:
 									f.write("yes")
 								await self._set_ready()

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -123,8 +123,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 	"""
 
-	def __init__(self, library, path, layer):
-		super().__init__(library, layer, path)
+	def __init__(self, library, path, layer, *, source):
+		super().__init__(library, layer, source)
 
 		url_pieces = urllib.parse.urlparse(path)
 

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -124,7 +124,7 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 	"""
 
 	def __init__(self, library, path, layer):
-		super().__init__(library, layer)
+		super().__init__(library, layer, path)
 
 		url_pieces = urllib.parse.urlparse(path)
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -130,7 +130,7 @@ class LibraryService(Service):
 
 		if path.startswith('zk://') or path.startswith('zookeeper://'):
 			from .providers.zookeeper import ZooKeeperLibraryProvider
-			library_provider = ZooKeeperLibraryProvider(self, path, layer)
+			library_provider = ZooKeeperLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('./') or path.startswith('/') or path.startswith('file://'):
 			from .providers.filesystem import FileSystemLibraryProvider
@@ -138,7 +138,7 @@ class LibraryService(Service):
 
 		elif path.startswith('azure+https://'):
 			from .providers.azurestorage import AzureStorageLibraryProvider
-			library_provider = AzureStorageLibraryProvider(self, path, layer)
+			library_provider = AzureStorageLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('git+'):
 			if len(self.CacheDir) > 0:
@@ -147,7 +147,7 @@ class LibraryService(Service):
 				library_provider = CacheLibraryProvider(self, path, layer, source=path, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
 			else:
 				from .providers.git import GitLibraryProvider
-				library_provider = GitLibraryProvider(self, path, layer)
+				library_provider = GitLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('libsreg+'):
 			if len(self.CacheDir) > 0:
@@ -156,7 +156,7 @@ class LibraryService(Service):
 				library_provider = CacheLibraryProvider(self, path, layer, source=path, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
 			else:
 				from .providers.libsreg import LibsRegLibraryProvider
-				library_provider = LibsRegLibraryProvider(self, path, layer)
+				library_provider = LibsRegLibraryProvider(self, path, layer, source=path)
 
 		elif path == '' or path.startswith("#") or path.startswith(";"):
 			# This is empty or commented line

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -134,7 +134,7 @@ class LibraryService(Service):
 
 		elif path.startswith('./') or path.startswith('/') or path.startswith('file://'):
 			from .providers.filesystem import FileSystemLibraryProvider
-			library_provider = FileSystemLibraryProvider(self, path, layer)
+			library_provider = FileSystemLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('azure+https://'):
 			from .providers.azurestorage import AzureStorageLibraryProvider
@@ -144,7 +144,7 @@ class LibraryService(Service):
 			if len(self.CacheDir) > 0:
 				repodir = self._get_repodir(path)
 				from .providers.cache import CacheLibraryProvider
-				library_provider = CacheLibraryProvider(self, path, layer, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
+				library_provider = CacheLibraryProvider(self, path, layer, source=path, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
 			else:
 				from .providers.git import GitLibraryProvider
 				library_provider = GitLibraryProvider(self, path, layer)
@@ -153,7 +153,7 @@ class LibraryService(Service):
 			if len(self.CacheDir) > 0:
 				repodir = self._get_repodir(path)
 				from .providers.cache import CacheLibraryProvider
-				library_provider = CacheLibraryProvider(self, path, layer, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
+				library_provider = CacheLibraryProvider(self, path, layer, source=path, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
 			else:
 				from .providers.libsreg import LibsRegLibraryProvider
 				library_provider = LibsRegLibraryProvider(self, path, layer)

--- a/examples/library-provider-sources.py
+++ b/examples/library-provider-sources.py
@@ -10,7 +10,10 @@ class MyApplication(asab.Application):
 	def __init__(self):
 		super().__init__()
 
-		asab.Config["library"]["providers"] = os.path.join(os.path.dirname(__file__), "library")
+		asab.Config["library"]["providers"] = "\n".join([
+			os.path.join(os.path.dirname(__file__), "library"),
+			"git+https://github.com/TeskaLabs/asab.git",
+		])
 
 		self.LibraryService = asab.library.LibraryService(
 			self,

--- a/examples/library-provider-sources.py
+++ b/examples/library-provider-sources.py
@@ -20,7 +20,11 @@ class MyApplication(asab.Application):
 	async def main(self):
 		print("# Library provider sources\n")
 		for provider in self.LibraryService.Libraries:
-			print("{} {}".format(provider.ID, provider.Source))
+			print("{} source ID '{}' for source '{}'".format(
+				provider.__class__.__name__,
+				provider.ID,
+				provider.Source,
+			))
 
 		self.stop()
 

--- a/examples/library-provider-sources.py
+++ b/examples/library-provider-sources.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import os.path
+
+import asab
+import asab.library
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__()
+
+		asab.Config["library"]["providers"] = os.path.join(os.path.dirname(__file__), "library")
+
+		self.LibraryService = asab.library.LibraryService(
+			self,
+			"LibraryService",
+		)
+
+	async def main(self):
+		print("# Library provider sources\n")
+		for provider in self.LibraryService.Libraries:
+			print("{} {}".format(provider.ID, provider.Source))
+
+		self.stop()
+
+
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library providers now persist each library's origin and a stable identifier; an example script shows providers' IDs and sources.

* **Refactor**
  * Provider initialization consistently accepts and propagates source metadata so caches and repository readiness reliably record origin and identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->