### PR TITLE
Fix the order of WebSocket authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release candidate
 
 ### Fixes
+- Fix the order of WebSocket authentication (#770)
 - Treat HTTP authentication scheme as case-insensitive (#759)
 - Authenticate websocket requests with multivalued Upgrade header (#748)
 

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -51,7 +51,10 @@ class IdTokenAuthProvider(AuthProviderABC):
 			raise NotAuthenticatedError(resource_metadata=self.ResourceMatadataUrl)
 
 		# First, try to extract the token from the Authorization header
-		token = get_bearer_token_from_authorization_header(request)
+		try:
+			token = get_bearer_token_from_authorization_header(request)
+		except NotAuthenticatedError:
+			token = None
 
 		# If there is none, try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
 		# TODO: This may be unnecessary since the websocket request has passed the introspection and has been enriched

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -50,10 +50,13 @@ class IdTokenAuthProvider(AuthProviderABC):
 			L.warning("No public key providers registered for ID token authentication.")
 			raise NotAuthenticatedError(resource_metadata=self.ResourceMatadataUrl)
 
-		token = None
+		# First, try to extract the token from the Authorization header
+		token = get_bearer_token_from_authorization_header(request)
 
-		# First, try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
-		if connection_header := request.headers.get(aiohttp.hdrs.CONNECTION):
+		# If there is none, try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
+		# TODO: This may be unnecessary since the websocket request has passed the introspection and has been enriched
+		#  with Authorization header
+		if token is None and (connection_header := request.headers.get(aiohttp.hdrs.CONNECTION)):
 			for value in connection_header.casefold().split(","):
 				if value.strip() == "upgrade":
 					# Verify it's actually a WebSocket upgrade by checking the Upgrade header
@@ -61,10 +64,6 @@ class IdTokenAuthProvider(AuthProviderABC):
 					if upgrade_header == "websocket":
 						token = get_bearer_token_from_websocket_request(request)
 						break
-
-		# If not, try to extract the token from the Authorization header
-		if token is None:
-			token = get_bearer_token_from_authorization_header(request)
 
 		if token is None:
 			raise NotAuthenticatedError(error="invalid_token", error_description="Token not found", resource_metadata=self.ResourceMatadataUrl)


### PR DESCRIPTION
# Issue
WebSocket requests that are past the introspection are not authenticated properly. The ID token is never extracted from the Authorization header because it gets shadowed by extraction from the WS Protocol header, which contains the access token instead.

# Solution
Switch the order of token extraction methods for WS requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved token extraction logic in authentication flow by optimizing the order of header checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->