### PR TITLE
fix: cache ZooKeeper session_id and connected_node for non-CONNECTED log lines

### DIFF
--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -111,6 +111,12 @@ class ZooKeeperContainer(Configurable):
 
 		self.ZooKeeper = KazooWrapper(self, url_netloc, self.Config.getseconds("timeout"))
 
+		# Cache last-known session_id and connected_node so that
+		# SUSPENDED / LOST log lines still carry the identifiers
+		# instead of showing "None".
+		self._cached_session_id = None
+		self._cached_connected_node = None
+
 		zookeeper_service.Containers.append(self)
 		self.ZooKeeper.Client.start_async()
 
@@ -167,15 +173,30 @@ class ZooKeeperContainer(Configurable):
 				pass
 
 		if state == kazoo.protocol.states.KazooState.CONNECTED:
+			# Update cached identifiers on successful connection
+			self._cached_session_id = session_id
+			self._cached_connected_node = connected_node
 			self.ProactorService.schedule_threadsafe(self._on_connected_at_proactor_thread)
 			L.log(LOG_NOTICE, "Connected to ZooKeeper", struct_data={"node": connected_node, "session_id": session_id})
 		else:
+			# Use cached values when the connection is not active, since
+			# client_id and the socket are already gone by the time the
+			# listener fires for SUSPENDED / LOST.
+			if session_id is None:
+				session_id = self._cached_session_id
+			if connected_node is None:
+				connected_node = self._cached_connected_node
+
 			if state == kazoo.protocol.states.KazooState.LOST:
 				if not self.ZooKeeper.Stopped:
 					L.error(
 						"ZooKeeper session lost; client will attempt to reconnect.",
 						struct_data={"node": connected_node, "session_id": session_id},
 					)
+					# Session is gone; clear the cache so the next CONNECTED
+					# starts fresh.
+					self._cached_session_id = None
+					self._cached_connected_node = None
 			else:
 				L.warning(
 					"ZooKeeper connection state changed; ZooKeeper calls may block until the session is restored.",


### PR DESCRIPTION
## What's wrong

When the ZooKeeper connection state changes to SUSPENDED or LOST, the `_listener` method logs `session_id` and `node` as `None` because it computes both values fresh from the now-closed client. The `client_id` attribute returns `None` and the socket is already gone, so the identifiers are lost in the exact log lines where they are most useful for debugging.

## What this does

Caches `session_id` and `connected_node` when the state is CONNECTED (the only time the client is alive and both values resolve). On SUSPENDED/LOST the listener falls back to the cached values so the log lines retain the identifiers. The cache is cleared on LOST so the next CONNECTED starts fresh.

## How to verify

1. Connect to a ZooKeeper cluster and observe the CONNECTED log line — identifiers are present.
2. Kill the ZooKeeper leader (or network-partition the client) to trigger SUSPENDED/LOST — the log lines now show the last-known `session_id` and `node` instead of `None`.
3. Restore connectivity — the new CONNECTED line updates the cache with the current values.

Fixes #775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZooKeeper connection logging so session and node details remain available even when connection state information is temporarily missing.
  * Reset stored connection details after unexpected connection loss, ensuring reconnections start with fresh identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->