### PR TITLE
fix(zookeeper): cache session id and node for disconnect logs (#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release candidate
 
 ### Fixes
+- Cache ZooKeeper session id and connected node for structured logging when the client is suspended or lost (#775)
 - Fix the order of WebSocket authentication (#770)
 - Treat HTTP authentication scheme as case-insensitive (#759)
 - Authenticate websocket requests with multivalued Upgrade header (#748)

--- a/asab/zookeeper/container.py
+++ b/asab/zookeeper/container.py
@@ -106,6 +106,10 @@ class ZooKeeperContainer(Configurable):
 		self.Advertisments = dict()
 		self.AdvertismentsLock = threading.Lock()
 
+		# Last known session id and ZooKeeper node for structured logging when disconnected.
+		self._last_session_id = None
+		self._last_connected_node = None
+
 		self.App.PubSub.subscribe("Application.tick/300!", self._on_tick300)
 		self.App.PubSub.subscribe("Application.tick/60!", self._on_tick60)
 
@@ -165,6 +169,17 @@ class ZooKeeperContainer(Configurable):
 			except (OSError, AttributeError):
 				# Socket is not connected, has been closed, or no longer exposes getpeername
 				pass
+
+		if state == kazoo.protocol.states.KazooState.CONNECTED:
+			if session_id is not None:
+				self._last_session_id = session_id
+			if connected_node is not None:
+				self._last_connected_node = connected_node
+		else:
+			if session_id is None:
+				session_id = self._last_session_id
+			if connected_node is None:
+				connected_node = self._last_connected_node
 
 		if state == kazoo.protocol.states.KazooState.CONNECTED:
 			self.ProactorService.schedule_threadsafe(self._on_connected_at_proactor_thread)

--- a/test/test_zookeeper/test_container_listener.py
+++ b/test/test_zookeeper/test_container_listener.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest import mock
+
+import kazoo.protocol.states
+
+from asab.zookeeper.container import ZooKeeperContainer
+
+
+class _SockPeer:
+
+	def getpeername(self):
+		return ("10.17.211.99", 2181)
+
+
+class _Conn:
+
+	def __init__(self, sock):
+		self._socket = sock
+
+
+class TestZooKeeperContainerListener(unittest.TestCase):
+
+	def _make_container(self, client_id=None, sock=None):
+		container = ZooKeeperContainer.__new__(ZooKeeperContainer)
+		container._last_session_id = None
+		container._last_connected_node = None
+		container.ZooKeeper = mock.Mock()
+		container.ZooKeeper.Stopped = False
+		container.ZooKeeper.Client = mock.Mock()
+		container.ZooKeeper.Client.client_id = client_id
+		conn = _Conn(sock) if sock is not None else None
+		container.ZooKeeper.Client._connection = conn
+		container.ProactorService = mock.Mock()
+		container.App = mock.Mock()
+		return container
+
+	def test_connected_caches_session_and_node(self):
+		container = self._make_container(
+			client_id=(0x1038DD926CA0153, b""),
+			sock=_SockPeer(),
+		)
+		with mock.patch.object(ZooKeeperContainer, "_on_connected_at_proactor_thread"):
+			with mock.patch("asab.zookeeper.container.L") as log_mock:
+				container._listener(kazoo.protocol.states.KazooState.CONNECTED)
+
+		self.assertEqual(container._last_session_id, "0x1038dd926ca0153")
+		self.assertEqual(container._last_connected_node, "10.17.211.99:2181")
+		log_mock.log.assert_called_once()
+		struct_data = log_mock.log.call_args.kwargs["struct_data"]
+		self.assertEqual(struct_data["session_id"], "0x1038dd926ca0153")
+		self.assertEqual(struct_data["node"], "10.17.211.99:2181")
+
+	def test_suspended_reuses_cached_session_and_node(self):
+		container = self._make_container()
+		container._last_session_id = "0x1038dd926ca0153"
+		container._last_connected_node = "10.17.211.99:2181"
+		container.ZooKeeper.Client.client_id = None
+		container.ZooKeeper.Client._connection = None
+
+		with mock.patch("asab.zookeeper.container.L") as log_mock:
+			container._listener(kazoo.protocol.states.KazooState.SUSPENDED)
+
+		log_mock.warning.assert_called_once()
+		struct_data = log_mock.warning.call_args.kwargs["struct_data"]
+		self.assertEqual(struct_data["session_id"], "0x1038dd926ca0153")
+		self.assertEqual(struct_data["node"], "10.17.211.99:2181")
+		self.assertEqual(struct_data["state"], str(kazoo.protocol.states.KazooState.SUSPENDED))
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- Cache `_last_session_id` and `_last_connected_node` when state is `CONNECTED`.
- For other states, fall back to cached values when live lookup returns `None`.

Closes #775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZooKeeper logging so the last known session ID and connected node are preserved during suspended or lost connections.
  * Structured logs now keep connection context across state changes, making incidents easier to trace.
* **Tests**
  * Added coverage for connected and suspended listener behavior to verify cached connection details are reused correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->