### PR TITLE
Library: Git: Try to pull immediately after init if existing library content is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ doc/env
 
 # macOS supplementary file
 .DS_Store
+.cursor/

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -375,8 +375,19 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 				)
 			else:
 				# For existing repository, just open it
-				# Do NOT pull here - pull happens via _periodic_pull
 				self.GitRepository = pygit2.Repository(self.RepoPath)
+				try:
+					self._do_pull()
+				except pygit2.GitError:
+					L.error(
+						"Git pull failed during repository initialization. Library is ready but may not be up to date.",
+						struct_data={"layer": self.Layer, "url": self.URLPath, "branch": self.Branch},
+					)
+				except Exception:
+					L.error(
+						"Git pull failed during repository initialization. Library is ready but may not be up to date.",
+						struct_data={"layer": self.Layer, "url": self.URLPath, "branch": self.Branch},
+					)
 
 		try:
 			await self.ProactorService.execute(init_task)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Cached Git repositories are now refreshed immediately when the library initializes, providing more up-to-date content without waiting for the scheduled refresh.
  - Initialization can complete successfully even if the initial repository refresh encounters an error; the issue is recorded for troubleshooting.

- **Chores**
  - Added the local editor configuration directory to ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->