### PR TITLE
Log authentication failure reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Authenticate websocket requests with multivalued Upgrade header (#748)
 
 ### Features
+- Log authentication failure reasons (#788)
 - Support ApiKey tokens in development auth mode (#759)
 
 ---

--- a/asab/exceptions.py
+++ b/asab/exceptions.py
@@ -59,6 +59,7 @@ class NotAuthenticatedError(_WWWAuthenticateMixin, aiohttp.web.HTTPUnauthorized)
 		error_description: typing.Optional[str] = None,
 		error_uri: typing.Optional[str] = None,
 		resource_metadata: typing.Optional[str] = None,
+		message: typing.Optional[str] = None,
 		**kwargs
 	):
 		"""
@@ -69,8 +70,10 @@ class NotAuthenticatedError(_WWWAuthenticateMixin, aiohttp.web.HTTPUnauthorized)
 			error: ASCII error code (RFC6750)
 			error_description: Human-readable UTF-8 encoded text providing additional error information (RFC6750)
 			resource_metadata: The URL of the protected resource metadata (RFC9728)
+			message: Internal message for logging and debugging; not exposed in the HTTP response
 			**kwargs:
 		"""
+		self.Message = message
 		super().__init__(*args, **kwargs)
 		self.WWWAuthenticate = {}
 		self.update_www_authenticate(
@@ -96,6 +99,7 @@ class AccessDeniedError(_WWWAuthenticateMixin, aiohttp.web.HTTPForbidden):
 		error_description: typing.Optional[str] = None,
 		error_uri: typing.Optional[str] = None,
 		resource_metadata: typing.Optional[str] = None,
+		message: typing.Optional[str] = None,
 		**kwargs
 	):
 		"""
@@ -106,8 +110,10 @@ class AccessDeniedError(_WWWAuthenticateMixin, aiohttp.web.HTTPForbidden):
 			error: ASCII error code (RFC6750)
 			error_description: Human-readable UTF-8 encoded text providing additional error information (RFC6750)
 			resource_metadata: The URL of the protected resource metadata (RFC9728)
+			message: Internal message for logging and debugging; not exposed in the HTTP response
 			**kwargs:
 		"""
+		self.Message = message
 		super().__init__(*args, **kwargs)
 		self.WWWAuthenticate = {}
 		self.update_www_authenticate(

--- a/asab/web/auth/authorization.py
+++ b/asab/web/auth/authorization.py
@@ -49,13 +49,13 @@ class Authorization:
 			self.IssuedAt = datetime.datetime.fromtimestamp(int(self._Claims["iat"]), datetime.timezone.utc)
 		except KeyError:
 			L.error("ID token is missing the required 'iat' (issued-at) claim.")
-			raise NotAuthenticatedError()
+			raise NotAuthenticatedError(message="ID token missing 'iat' claim")
 
 		try:
 			self.Expiration = datetime.datetime.fromtimestamp(int(self._Claims["exp"]), datetime.timezone.utc)
 		except KeyError:
 			L.error("ID token is missing the required 'exp' (expiration) claim.")
-			raise NotAuthenticatedError()
+			raise NotAuthenticatedError(message="ID token missing 'exp' claim")
 
 		self.IdToken = id_token
 
@@ -163,7 +163,7 @@ class Authorization:
 		if not self.is_valid():
 			L.warning("Authorization expired.", struct_data={
 				"cid": self.CredentialsId, "exp": self.Expiration.isoformat()})
-			raise NotAuthenticatedError()
+			raise NotAuthenticatedError(message="Authorization expired")
 
 
 	def require_superuser_access(self):
@@ -184,7 +184,7 @@ class Authorization:
 		if not is_superuser(self._Resources):
 			L.warning("Superuser authorization required.", struct_data={
 				"cid": self.CredentialsId})
-			raise AccessDeniedError()
+			raise AccessDeniedError(message="Superuser access required")
 
 
 	def require_resource_access(self, *resources: str, match: typing.Literal["all", "any"] = "all"):
@@ -211,7 +211,7 @@ class Authorization:
 				"resource": resources, "cid": self.CredentialsId})
 			scope = set()
 			_add_tenant_scope(scope)
-			raise AccessDeniedError(scope=scope)
+			raise AccessDeniedError(scope=scope, message="Missing required resources: {}".format(", ".join(resources)))
 
 
 	def require_tenant_access(self, tenant=None):
@@ -252,7 +252,7 @@ class Authorization:
 				"tenant": tenant, "cid": self.CredentialsId})
 			scope = set()
 			_add_tenant_scope(scope)
-			raise AccessDeniedError(scope=scope)
+			raise AccessDeniedError(scope=scope, message="Missing tenant access: {}".format(tenant))
 
 
 	def user_info(self) -> typing.Dict[str, typing.Any]:

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -35,7 +35,7 @@ def require(*resources):
 		async def _require_resource_access_wrapper(*args, **kwargs):
 			authz = Authz.get()
 			if authz is None:
-				raise AccessDeniedError()
+				raise AccessDeniedError(message="Authorization context is not set")
 
 			authz.require_resource_access(*resources)
 
@@ -64,7 +64,7 @@ def require_superuser(handler):
 	async def _require_superuser_access_wrapper(*args, **kwargs):
 		authz = Authz.get()
 		if authz is None:
-			raise AccessDeniedError()
+			raise AccessDeniedError(message="Authorization context is not set")
 
 		authz.require_superuser_access()
 

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -61,9 +61,7 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 				"Unsupported Authorization header scheme; only Bearer or ApiKey is accepted.",
 				struct_data={"scheme": auth_scheme},
 			)
-			raise NotAuthenticatedError()
-
-		# Try if the access token is already known
+			raise NotAuthenticatedError(message="Unsupported Authorization scheme (expected Bearer or ApiKey)")
 		authz = self.Authorizations.get(token)
 		if authz is not None:
 			try:
@@ -81,16 +79,14 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 						"Access token introspection rejected the token.",
 						struct_data={"introspection_url": self.IntrospectionUrl},
 					)
-					raise NotAuthenticatedError()
+					raise NotAuthenticatedError(message="Access token introspection failed")
 				auth_scheme, id_token = get_bearer_token_from_authorization_header(response)
 				if auth_scheme != "bearer":
 					L.warning(
 						"Unsupported Authorization header scheme; only Bearer is accepted.",
 						struct_data={"scheme": auth_scheme},
 					)
-					raise NotAuthenticatedError()
-
-		# Create a new Authorization object and store it
+					raise NotAuthenticatedError(message="Introspection response has unsupported Authorization scheme")
 		claims = await self._get_claims_from_id_token(id_token)
 		authz = Authorization(claims, id_token=id_token)
 

--- a/asab/web/auth/providers/access_token.py
+++ b/asab/web/auth/providers/access_token.py
@@ -57,7 +57,7 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 
 		auth_scheme, token_value = token
 		if auth_scheme not in {"bearer", "apikey"}:
-			L.warning(
+			L.debug(
 				"Unsupported Authorization header scheme; only Bearer or ApiKey is accepted.",
 				struct_data={"scheme": auth_scheme},
 			)
@@ -75,14 +75,14 @@ class AccessTokenAuthProvider(IdTokenAuthProvider):
 		async with aiohttp.ClientSession() as session:
 			async with session.post(self.IntrospectionUrl, headers=request.headers) as response:
 				if response.status != 200:
-					L.warning(
+					L.debug(
 						"Access token introspection rejected the token.",
 						struct_data={"introspection_url": self.IntrospectionUrl},
 					)
 					raise NotAuthenticatedError(message="Access token introspection failed")
 				auth_scheme, id_token = get_bearer_token_from_authorization_header(response)
 				if auth_scheme != "bearer":
-					L.warning(
+					L.debug(
 						"Unsupported Authorization header scheme; only Bearer is accepted.",
 						struct_data={"scheme": auth_scheme},
 					)

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -48,15 +48,12 @@ class IdTokenAuthProvider(AuthProviderABC):
 	async def authorize(self, request: aiohttp.web.Request) -> Authorization:
 		if not self._KeyProviders:
 			L.warning("No public key providers are registered; ID token authentication cannot verify signatures.")
-			raise NotAuthenticatedError(resource_metadata=self.ResourceMatadataUrl)
+			raise NotAuthenticatedError(
+				resource_metadata=self.ResourceMatadataUrl,
+				message="No public key providers registered",
+			)
 
-		# First, try to extract the token from the Authorization header
-		try:
-			token = get_bearer_token_from_authorization_header(request)
-		except NotAuthenticatedError:
-			token = None
-
-		# If there is none, try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
+		# Try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
 		# TODO: This may be unnecessary since the websocket request has passed the introspection and has been enriched
 		#  with Authorization header
 		if token is None and (connection_header := request.headers.get(aiohttp.hdrs.CONNECTION)):
@@ -69,7 +66,8 @@ class IdTokenAuthProvider(AuthProviderABC):
 						break
 
 		if token is None:
-			raise NotAuthenticatedError(error="invalid_token", error_description="Token not found", resource_metadata=self.ResourceMatadataUrl)
+			# Try to extract the token from the Authorization header
+			token = get_bearer_token_from_authorization_header(request)
 
 		try:
 			authz = await self._build_authorization(token)
@@ -115,7 +113,7 @@ class IdTokenAuthProvider(AuthProviderABC):
 				"Unsupported Authorization header scheme for ID token authentication.",
 				struct_data={"scheme": auth_scheme},
 			)
-			raise NotAuthenticatedError()
+			raise NotAuthenticatedError(message="Unsupported Authorization scheme (expected Bearer)")
 
 		# Try if the object already exists
 		authz = self.Authorizations.get(token)
@@ -149,7 +147,7 @@ class IdTokenAuthProvider(AuthProviderABC):
 			return get_id_token_claims(id_token, self.TrustedJwkSet)
 		except (jwcrypto.jws.InvalidJWSSignature, jwcrypto.jwt.JWTMissingKey) as e:
 			L.debug("Cannot authenticate request: {}".format(str(e)))
-			raise NotAuthenticatedError()
+			raise NotAuthenticatedError(message="ID token signature verification failed")
 
 
 	def _delete_invalid_authorizations(self, *args, **kwargs):

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -47,16 +47,17 @@ class IdTokenAuthProvider(AuthProviderABC):
 
 	async def authorize(self, request: aiohttp.web.Request) -> Authorization:
 		if not self._KeyProviders:
-			L.warning("No public key providers are registered; ID token authentication cannot verify signatures.")
+			L.debug("No public key providers are registered; ID token authentication cannot verify signatures.")
 			raise NotAuthenticatedError(
 				resource_metadata=self.ResourceMatadataUrl,
 				message="No public key providers registered",
 			)
 
+		token = None
 		# Try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
 		# TODO: This may be unnecessary since the websocket request has passed the introspection and has been enriched
 		#  with Authorization header
-		if token is None and (connection_header := request.headers.get(aiohttp.hdrs.CONNECTION)):
+		if connection_header := request.headers.get(aiohttp.hdrs.CONNECTION):
 			for value in connection_header.casefold().split(","):
 				if value.strip() == "upgrade":
 					# Verify it's actually a WebSocket upgrade by checking the Upgrade header
@@ -109,7 +110,7 @@ class IdTokenAuthProvider(AuthProviderABC):
 		"""
 		auth_scheme, token_value = token
 		if auth_scheme != "bearer":
-			L.warning(
+			L.debug(
 				"Unsupported Authorization header scheme for ID token authentication.",
 				struct_data={"scheme": auth_scheme},
 			)

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -152,7 +152,11 @@ class AuthService(Service):
 
 		L.warning(
 			"Request authentication failed: All authorization providers rejected the request.",
-			struct_data={"reason": failures},
+			struct_data={
+				"reason": failures,
+				"path": request.path,
+				"method": request.method,
+			},
 		)
 		if auth_error:
 			# Re-raise the last error, preserve the original error response headers

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -150,9 +150,8 @@ class AuthService(Service):
 				failures.append({provider.Type: "{}: {}".format(e.__class__.__name__, e)})
 				L.exception("Request authentication failed.", struct_data={"provider_type": provider.Type})
 
-		provider_types = ", ".join(failures.keys())
 		L.warning(
-			"Request authentication failed: All authorization providers rejected the request ({}).".format(provider_types),
+			"Request authentication failed: All authorization providers rejected the request.",
 			struct_data={"reason": failures},
 		)
 		if auth_error:

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -26,6 +26,12 @@ from .authorization import Authorization
 L = logging.getLogger(__name__)
 
 
+def _authentication_failure_reason(error: NotAuthenticatedError) -> str:
+	if message := getattr(error, "Message", None):
+		return message
+	return "authentication failed"
+
+
 class AuthService(Service):
 	"""
 	Provides authentication and authorization of incoming requests.
@@ -132,23 +138,28 @@ class AuthService(Service):
 		Raises:
 			NotAuthenticatedError: When no provider is able to authorize the request
 		"""
-		error = None
+		failures = []
+		auth_error = None
 		for provider in self.Providers:
 			try:
 				return await provider.authorize(request)
 			except NotAuthenticatedError as e:
-				# Provider was unable to authenticate request
-				# L.debug("Authorization failed.", struct_data={"auth_provider": provider.Type})
-				error = e
+				failures.append({provider.Type: _authentication_failure_reason(e)})
+				auth_error = e
+			except Exception as e:
+				failures.append({provider.Type: "{}: {}".format(e.__class__.__name__, e)})
+				L.exception("Request authentication failed.", struct_data={"provider_type": provider.Type})
 
+		provider_types = ", ".join(failures.keys())
 		L.warning(
-			"No authorization provider accepted the request; authentication failed.",
+			"Request authentication failed: All authorization providers rejected the request ({}).".format(provider_types),
+			struct_data={"reason": failures},
 		)
-		if error:
+		if auth_error:
 			# Re-raise the last error, preserve the original error response headers
-			raise error
+			raise auth_error
 
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="No authorization provider accepted the request")
 
 
 	def _set_up_providers(self):

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -36,14 +36,12 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 	except ValueError:
 		L.debug(
 			"Authorization header is present but malformed; expected '<scheme> <token>'.",
-			struct_data={"path": request.path},
 		)
 		raise NotAuthenticatedError(message="Malformed Authorization header") from None
 
 	if not token_value:
 		L.debug(
 			"Authorization header is present but contains no token value.",
-			struct_data={"path": request.path},
 		)
 		raise NotAuthenticatedError(message="Authorization header has no token value")
 

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -34,14 +34,14 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 	try:
 		auth_scheme, token_value = authorization_header.split(None, 1)
 	except ValueError:
-		L.warning(
+		L.debug(
 			"Authorization header is present but malformed; expected '<scheme> <token>'.",
 			struct_data={"path": request.path},
 		)
 		raise NotAuthenticatedError(message="Malformed Authorization header") from None
 
 	if not token_value:
-		L.warning(
+		L.debug(
 			"Authorization header is present but contains no token value.",
 			struct_data={"path": request.path},
 		)
@@ -92,7 +92,7 @@ def get_id_token_claims(bearer_token: str, auth_server_public_key: jwcrypto.jwk.
 	try:
 		token = jwcrypto.jwt.JWT(jwt=bearer_token, key=auth_server_public_key)
 	except jwcrypto.jwt.JWTExpired:
-		L.warning("ID token has expired; request authentication rejected.")
+		L.debug("ID token has expired; request authentication rejected.")
 		raise NotAuthenticatedError(message="ID token expired")
 	except jwcrypto.jwt.JWTMissingKey as e:
 		raise e
@@ -112,7 +112,7 @@ def get_id_token_claims(bearer_token: str, auth_server_public_key: jwcrypto.jwk.
 	try:
 		token_claims = json.loads(token.claims)
 	except Exception:
-		L.error("ID token claims could not be decoded as JSON; token may be corrupted.")
+		L.debug("ID token claims could not be decoded as JSON; token may be corrupted.")
 		raise NotAuthenticatedError(message="ID token claims are not valid JSON")
 
 	return token_claims

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -29,7 +29,7 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 	authorization_header = request.headers.get(aiohttp.hdrs.AUTHORIZATION)
 	if authorization_header is None:
 		L.debug("No Authorization header.")
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="Missing Authorization header")
 
 	try:
 		auth_scheme, token_value = authorization_header.split(None, 1)
@@ -38,14 +38,14 @@ def get_bearer_token_from_authorization_header(request: aiohttp.web.Request) -> 
 			"Authorization header is present but malformed; expected '<scheme> <token>'.",
 			struct_data={"path": request.path},
 		)
-		raise NotAuthenticatedError() from None
+		raise NotAuthenticatedError(message="Malformed Authorization header") from None
 
 	if not token_value:
 		L.warning(
 			"Authorization header is present but contains no token value.",
 			struct_data={"path": request.path},
 		)
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="Authorization header has no token value")
 
 	return auth_scheme.casefold(), token_value
 
@@ -93,26 +93,26 @@ def get_id_token_claims(bearer_token: str, auth_server_public_key: jwcrypto.jwk.
 		token = jwcrypto.jwt.JWT(jwt=bearer_token, key=auth_server_public_key)
 	except jwcrypto.jwt.JWTExpired:
 		L.warning("ID token has expired; request authentication rejected.")
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="ID token expired")
 	except jwcrypto.jwt.JWTMissingKey as e:
 		raise e
 	except jwcrypto.jws.InvalidJWSSignature as e:
 		raise e
 	except ValueError:
 		L.debug("Authentication failed: Bearer token is likely not a JWT ID token.")
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="Bearer token is not a JWT")
 	except jwcrypto.jws.InvalidJWSObject:
 		L.debug("Authentication failed: Bearer token contains an invalid JWT object.")
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="Invalid JWT object")
 	except Exception as e:
 		L.debug(
 			"Failed to parse JWT ID token ({}). Please check if the Authorization header contains ID token.".format(e))
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="Failed to parse JWT ID token")
 
 	try:
 		token_claims = json.loads(token.claims)
 	except Exception:
 		L.error("ID token claims could not be decoded as JSON; token may be corrupted.")
-		raise NotAuthenticatedError()
+		raise NotAuthenticatedError(message="ID token claims are not valid JSON")
 
 	return token_claims


### PR DESCRIPTION
# Summary
Collect auth failure reasons from all auth providers and log them if the authentication fails in all providers. Replace the current warning `No authorization provider accepted the request; authentication failed.`.

# Examples

> ```15-Jul-2026 13:43:48.400310 WARNING asab.web.auth.service [sd reason="[{'seacat_auth': 'authentication failed'}, {'id_token': 'Unsupported Authorization scheme (expected Bearer)'}]"] Request authentication failed: All authorization providers rejected the request.```

> ```15-Jul-2026 13:48:12.142674 WARNING asab.web.auth.service [sd reason="[{'id_token': 'Unsupported Authorization scheme (expected Bearer)'}, {'access_token': 'Unsupported Authorization scheme (expected Bearer or ApiKey)'}]"] Request authentication failed: All authorization providers rejected the request.```