### PR TITLE
Publish library.change! when etag changes.

### DIFF
--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -145,6 +145,8 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 
 		async with self.PullLock:
 			changed = await self._do_pull()
+			if changed is None:
+				return
 			self.LastPull = self.App.time()
 			if changed:
 				for path in self.SubscribedPaths:
@@ -294,8 +296,6 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 					"Library registry download failed.",
 					struct_data={"url": url},
 				)
-
-		return False
 
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -122,7 +122,6 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 		self.PullLock = asyncio.Lock()
 		self.LastPull = None
 
-		# TODO: Subscription to changes in the library
 		self.SubscribedPaths = set()
 
 		self.App.TaskService.schedule(self._periodic_pull(None))
@@ -145,12 +144,16 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 			return
 
 		async with self.PullLock:
-			await self._do_pull()
+			changed = await self._do_pull()
 			self.LastPull = self.App.time()
+			if changed:
+				for path in self.SubscribedPaths:
+					self.App.PubSub.publish("Library.change!", self, path)
 
 
 	async def _do_pull(self):
 		headers = {}
+		old_etag = None
 
 		# Check for existing E-Tag
 		etag_fname = os.path.join(self.RootPath, "etag")
@@ -162,8 +165,8 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 			# If less than 5 files, we ignore the E-Tag and re-download everything
 			if file_count > 5:
 				with open(etag_fname, "r") as f:
-					etag = f.read().strip()
-					headers["If-None-Match"] = etag
+					old_etag = f.read().strip()
+					headers["If-None-Match"] = old_etag
 
 		# Prepare a list of URLs to try
 		# Randomize the order of the URLs (there might be more than one server to try)
@@ -254,7 +257,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 								os.remove(newtarfname)
 
 							L.debug("Library updated from remote repository.", struct_data={"url": url, 'size': dwnld_size, 'etag': etag_incoming})
-							return  # We are done, leaving the loop
+							return etag_incoming != old_etag  # We are done, leaving the loop
 
 						elif response.status == 304:
 							# The repository has not changed ...
@@ -263,7 +266,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 									f.write("yes")
 								await self._set_ready()
 
-							return  # We are done, leaving the loop
+							return False  # We are done, leaving the loop
 
 						else:
 							if last_try:
@@ -291,6 +294,8 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 					"Library registry download failed.",
 					struct_data={"url": url},
 				)
+
+		return False
 
 
 	async def subscribe(self, path, target: typing.Union[str, tuple, None] = None):

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -160,15 +160,15 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 		# Check for existing E-Tag
 		etag_fname = os.path.join(self.RootPath, "etag")
 		if os.path.exists(etag_fname):
+			with open(etag_fname, "r") as f:
+				old_etag = f.read().strip()
 
 			# Count number of files in self.RootPath recursively
 			file_count = sum([len(files) for _, _, files in os.walk(self.RootPath)])
 
 			# If less than 5 files, we ignore the E-Tag and re-download everything
 			if file_count > 5:
-				with open(etag_fname, "r") as f:
-					old_etag = f.read().strip()
-					headers["If-None-Match"] = old_etag
+				headers["If-None-Match"] = old_etag
 
 		# Prepare a list of URLs to try
 		# Randomize the order of the URLs (there might be more than one server to try)


### PR DESCRIPTION
Fixes [#778](https://github.com/TeskaLabs/asab/issues/778): LibsRegLibraryProvider.subscribe() stored paths but never emitted Library.change! after a remote pull.

The provider now follows the same notification loop as GitLibraryProvider: _periodic_pull() calls _do_pull(), and on ETag change publishes Library.change! for each subscribed path.

Because libsreg cannot tell which path changed inside the archive, all subscribed paths are notified on any library update (Option C from the issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Library updates are now reported only when remote content has actually changed.
  * Prevents unnecessary change notifications when content is unchanged or the server indicates “not modified”.
  * Improved polling behavior to avoid updating pull timestamps and publishing events when no meaningful change is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->