### PR TITLE
Feature: Include auth and tenant info in access log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Authenticate websocket requests with multivalued Upgrade header (#748)
 
 ### Features
+- Include auth and tenant info in access log (#792)
 - Log authentication failure reasons (#788)
 - Support ApiKey tokens in development auth mode (#759)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Authenticate websocket requests with multivalued Upgrade header (#748)
 
 ### Features
+- Log authentication failure reasons (#788)
 - Support ApiKey tokens in development auth mode (#759)
 
 ---

--- a/asab/web/accesslog.py
+++ b/asab/web/accesslog.py
@@ -2,6 +2,7 @@ import aiohttp.abc
 
 from ..log import LOG_NOTICE
 from .. import Config
+from ..contextvars import Tenant, Authz
 
 
 class AccessLogger(aiohttp.abc.AbstractAccessLogger):
@@ -39,6 +40,17 @@ class AccessLogger(aiohttp.abc.AbstractAccessLogger):
 			# TODO: Sanitize xfwd
 			# In nginx, use "proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;"
 			struct_data['Ix'] = xfwd[:128]
+
+		if tenant := request.get("t"):
+			struct_data["t"] = tenant
+
+		if cid := request.get("az.cid"):
+			struct_data["az.cid"] = cid
+
+		if sid := request.get("az.sid"):
+			struct_data["az.sid"] = sid
+
+		print(dict(request))
 
 		self.logger.log(LOG_NOTICE, '', struct_data=struct_data)
 

--- a/asab/web/accesslog.py
+++ b/asab/web/accesslog.py
@@ -49,8 +49,6 @@ class AccessLogger(aiohttp.abc.AbstractAccessLogger):
 		if sid := request.get("az.sid"):
 			struct_data["az.sid"] = sid
 
-		print(dict(request))
-
 		self.logger.log(LOG_NOTICE, '', struct_data=struct_data)
 
 		# Metrics

--- a/asab/web/accesslog.py
+++ b/asab/web/accesslog.py
@@ -2,7 +2,6 @@ import aiohttp.abc
 
 from ..log import LOG_NOTICE
 from .. import Config
-from ..contextvars import Tenant, Authz
 
 
 class AccessLogger(aiohttp.abc.AbstractAccessLogger):

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -223,6 +223,10 @@ class AuthService(Service):
 			# Authenticate and authorize request with first valid provider
 			authz = await self.authorize_request(request)
 
+			# Enrich the request for access log
+			request["az.cid"] = authz.CredentialsId
+			request["az.sid"] = authz.SessionId
+
 			# Authorize tenant context
 			tenant = Tenant.get(None)
 			if tenant is not None:

--- a/asab/web/tenant/installer.py
+++ b/asab/web/tenant/installer.py
@@ -115,6 +115,8 @@ class TenantWebWrapperInstaller:
 		async def _tenant_context_from_url_query_wrapper(*args, **kwargs):
 			request = args[-1]
 			tenant = request.query.get("tenant")
+
+			# Enrich the request for access log
 			request["t"] = tenant
 
 			if tenant is None:
@@ -154,6 +156,8 @@ class TenantWebWrapperInstaller:
 		async def _tenant_context_from_url_path_wrapper(*args, **kwargs):
 			request = args[-1]
 			tenant = request.match_info["tenant"]
+
+			# Enrich the request for access log
 			request["t"] = tenant
 
 			if "tenant" in request.query:

--- a/asab/web/tenant/installer.py
+++ b/asab/web/tenant/installer.py
@@ -115,6 +115,7 @@ class TenantWebWrapperInstaller:
 		async def _tenant_context_from_url_query_wrapper(*args, **kwargs):
 			request = args[-1]
 			tenant = request.query.get("tenant")
+			request["t"] = tenant
 
 			if tenant is None:
 				if not (hasattr(handler, "AllowNoTenant") and handler.AllowNoTenant is True):
@@ -153,6 +154,7 @@ class TenantWebWrapperInstaller:
 		async def _tenant_context_from_url_path_wrapper(*args, **kwargs):
 			request = args[-1]
 			tenant = request.match_info["tenant"]
+			request["t"] = tenant
 
 			if "tenant" in request.query:
 				L.warning(


### PR DESCRIPTION
# Summary
Extend the access log with the following items if available:
- Credentials ID of the caller `az.cid`
- Session ID of the caller `az.sid`
- Tenant context of the request `t`

## Example log
`16-Jul-2026 16:25:39.877337 NOTICE asab.web.al [sd I="127.0.0.1" al.m="GET" al.p="/system/datasources" al.c="200" D="0.0008828259997244459" al.b="2146" al.A="Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0" t="system" az.cid="mongodb:default:b9975137b2bc1be9b251ba9a" az.sid="6a58e366ad921de14105ca77"]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Enhancements**
  * Access logs can now capture additional request identifiers (tenant, client, and session) when available.
  * Tenant context is recorded consistently whether provided via URL query parameter or path.
  * After successful authorization, access logs are enriched with authorization-derived client and session identifiers for better traceability.

* **Documentation**
  * Updated the release candidate changelog to note logging authentication failure reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->