### PR TITLE
Improve logging in `asab.metrics`

### DIFF
--- a/asab/metrics/http.py
+++ b/asab/metrics/http.py
@@ -20,8 +20,26 @@ class HTTPTarget(asab.Configurable):
 
 	async def process(self, metrics, now):
 		metrics_to_send = copy.deepcopy(metrics)
-		async with aiohttp.ClientSession() as session:
-			async with session.post(self.URL, json=metrics_to_send) as resp:
-				response = await resp.text()
-				if resp.status != 200:
-					L.warning("Error when sending metrics by HTTPTarget: {}\n{}".format(resp.status, response))
+		try:
+			async with aiohttp.ClientSession() as session:
+				async with session.post(self.URL, json=metrics_to_send) as resp:
+					response = await resp.text()
+					if resp.status != 200:
+						L.warning(
+							"HTTP metrics target rejected the metrics write request.",
+							struct_data={
+								"url": self.URL,
+								"status": resp.status,
+								"response": response,
+							},
+						)
+		except aiohttp.client_exceptions.ClientConnectorError:
+			L.error(
+				"Cannot reach HTTP metrics target; metrics were not delivered.",
+				struct_data={"url": self.URL},
+			)
+		except Exception:
+			L.exception(
+				"Unexpected error while sending metrics to HTTP target.",
+				struct_data={"url": self.URL},
+			)

--- a/asab/metrics/influxdb.py
+++ b/asab/metrics/influxdb.py
@@ -120,13 +120,23 @@ class InfluxDBTarget(asab.Configurable):
 						response = await resp.text()
 						if resp.status != 204:
 							L.warning(
-								"Error when sending metrics to Influx: {}\n{}".format(resp.status, response),
-								struct_data={"url": self.BaseURL}
+								"InfluxDB rejected the metrics write request.",
+								struct_data={
+									"url": self.BaseURL,
+									"status": resp.status,
+									"response": response,
+								},
 							)
 			except aiohttp.client_exceptions.ClientConnectorError:
-				L.error("Failed to connect to InfluxDB.", struct_data={"url": self.BaseURL})
-			except Exception as err:
-				L.exception("Failed to send metrics to InfluxDB: {}".format(err), struct_data={"url": self.BaseURL})
+				L.error(
+					"InfluxDB connection error; metrics were not delivered.",
+					struct_data={"url": self.BaseURL},
+				)
+			except Exception:
+				L.exception(
+					"Unexpected error while sending metrics to InfluxDB.",
+					struct_data={"url": self.BaseURL},
+				)
 
 
 	def _worker_upload(self, m_tree, rb):
@@ -139,22 +149,40 @@ class InfluxDBTarget(asab.Configurable):
 			conn.request("POST", self.WriteRequest, rb, self.Headers)
 			response = conn.getresponse()
 			if response.status != 204:
-				L.warning("Failed to send metrics to InfluxDB.", struct_data={"url": self.BaseURL, "response.status": response.status, "response": response.read().decode("utf-8")})
+				L.warning(
+					"InfluxDB rejected the metrics write request.",
+					struct_data={
+						"url": self.BaseURL,
+						"status": response.status,
+						"response": response.read().decode("utf-8"),
+					},
+				)
 		except http.client.RemoteDisconnected:
-			L.error("Failed to send metrics to InfluxDB: Remote end closed connection without response.", struct_data={"url": self.BaseURL})
+			L.error(
+				"InfluxDB closed the connection before responding; metrics were not delivered.",
+				struct_data={"url": self.BaseURL},
+			)
 			return
 		except (ConnectionError, socket.gaierror):
-			L.error("Failed to connect to InfluxDB.", struct_data={"url": self.BaseURL})
+			L.error(
+				"Cannot reach InfluxDB; metrics were not delivered.",
+				struct_data={"url": self.BaseURL},
+			)
 			return
-		except Exception as err:
-			L.exception("Failed to send metrics to InfluxDB: {}".format(err), struct_data={"url": self.BaseURL})
+		except Exception:
+			L.exception(
+				"Unexpected error while sending metrics to InfluxDB.",
+				struct_data={"url": self.BaseURL},
+			)
 			return
 		finally:
 			try:
 				conn.close()
 			except Exception as e:
-				# TODO: If this is too noisy, we can make it a debug log instead of warning
-				L.warning("Exception while closing InfluxDB connection: {}".format(e))
+				L.warning(
+					"Failed to close InfluxDB HTTP connection cleanly.",
+					struct_data={"url": self.BaseURL, "error": str(e)},
+				)
 
 
 def get_field(fk, fv):

--- a/asab/metrics/native.py
+++ b/asab/metrics/native.py
@@ -19,6 +19,7 @@ class NativeMetrics(Service):
 
 	def __init__(self, app, metrics_svc):
 		self.MemoryGauge = metrics_svc.create_gauge("memory")
+		self._MemoryMetricsAvailable = True
 
 		# Injecting logging metrics into MetricsHandler and MetricsHandler into Root Logger
 		self.MetricsLoggingHandler = MetricsLoggingHandler()
@@ -30,6 +31,9 @@ class NativeMetrics(Service):
 
 
 	def _on_flushing_event(self, event_name=None):
+		if not self._MemoryMetricsAvailable:
+			return
+
 		try:
 			with open("/proc/self/status", "r") as file:
 				proc_status = file.read()
@@ -45,8 +49,12 @@ class NativeMetrics(Service):
 							pass
 
 		except FileNotFoundError:
-			pass
-			# L.warning("File '/proc/self/status' was not found, skipping reading native metrics.")
+			# Typical on non-Linux platforms; log once to avoid spam on every flush.
+			self._MemoryMetricsAvailable = False
+			L.warning(
+				"Native memory metrics are unavailable because '/proc/self/status' was not found; skipping memory gauge updates.",
+				struct_data={"path": "/proc/self/status"},
+			)
 
 
 class MetricsLoggingHandler(logging.Handler):

--- a/asab/metrics/service.py
+++ b/asab/metrics/service.py
@@ -75,6 +75,10 @@ class MetricsService(Service):
 					target = HTTPTarget(self, 'asab:metrics:{}'.format(target))
 
 				else:
+					L.error(
+						"Unknown metrics target type in configuration.",
+						struct_data={"target": target, "target_type": target_type},
+					)
 					raise RuntimeError("Unknown target type {}".format(target_type))
 
 				self.Targets.append(target)
@@ -116,7 +120,10 @@ class MetricsService(Service):
 			try:
 				metric.flush(now)
 			except Exception:
-				L.exception("Exception during metric.flush()")
+				L.exception(
+					"Metric flush failed; this metric may be missing from the next export.",
+					struct_data={"metric": type(metric).__name__},
+				)
 
 		return now
 
@@ -131,6 +138,19 @@ class MetricsService(Service):
 			await self._on_flushing_event()
 
 
+	async def _send_to_target(self, target, now):
+		try:
+			await target.process(self.Storage.Metrics, now)
+		except Exception:
+			L.exception(
+				"Metrics flush to a target failed; metrics for this interval may be missing on that target.",
+				struct_data={
+					"target_type": type(target).__name__,
+					"url": getattr(target, "URL", None) or getattr(target, "BaseURL", None),
+				},
+			)
+
+
 	async def _on_flushing_event(self, event_type=None):
 		if len(self.Metrics) == 0:
 			return
@@ -140,7 +160,7 @@ class MetricsService(Service):
 		pending = set()
 		for target in self.Targets:
 			pending.add(
-				asyncio.ensure_future(target.process(self.Storage.Metrics, now))
+				asyncio.ensure_future(self._send_to_target(target, now))
 			)
 
 		while len(pending) > 0:

--- a/asab/metrics/storage.py
+++ b/asab/metrics/storage.py
@@ -41,7 +41,10 @@ class Storage(object):
 			# It means that the existing metrics will diapear from output and will be replaced by a new one.
 			# It is designed to support e.g. dynamic prebuilds of the classes with the same metrics.
 			# In other cases, this path should be avoided by e.g. creation of metrics in init time, not during runtime
-			L.debug("The metrics storage '{}/{}' is overriden".format(metric_name, tags))
+			L.debug(
+				"Existing metrics storage entry is being overridden.",
+				struct_data={"metric": metric_name, "tags": tags},
+			)
 			del self.Metrics[i]
 
 		metric = dict()


### PR DESCRIPTION
Logging messages in `asab.metrics` are more readable. Variables are moved to `struct_data`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of metrics delivery failures, including unreachable targets, rejected requests, and unexpected errors.
  * Added clearer diagnostic details when metric exports fail.
  * Prevented repeated attempts to collect native memory metrics when system support is unavailable.
  * Improved reporting when metrics storage entries are overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->