### PR TITLE
Fix WebSocket authentication and auth failure logging

### DIFF
--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -7,7 +7,12 @@ import asab
 
 from .abc import AuthProviderABC
 from .key_providers import PublicKeyProviderABC
-from ..utils import get_bearer_token_from_authorization_header, get_bearer_token_from_websocket_request, get_id_token_claims
+from ..utils import (
+	get_bearer_token_from_authorization_header,
+	get_bearer_token_from_websocket_request,
+	get_id_token_claims,
+	is_websocket_request,
+)
 from ..authorization import Authorization
 from ....exceptions import NotAuthenticatedError
 
@@ -53,21 +58,15 @@ class IdTokenAuthProvider(AuthProviderABC):
 				message="No public key providers registered",
 			)
 
-		token = None
-		# Try to extract the token from the WebSocket protocol header (if it's a WebSocket request)
-		# TODO: This may be unnecessary since the websocket request has passed the introspection and has been enriched
-		#  with Authorization header
-		if connection_header := request.headers.get(aiohttp.hdrs.CONNECTION):
-			for value in connection_header.casefold().split(","):
-				if value.strip() == "upgrade":
-					# Verify it's actually a WebSocket upgrade by checking the Upgrade header
-					upgrade_header = request.headers.get(aiohttp.hdrs.UPGRADE, "").casefold()
-					if upgrade_header == "websocket":
-						token = get_bearer_token_from_websocket_request(request)
-						break
 
-		if token is None:
-			# Try to extract the token from the Authorization header
+		if is_websocket_request(request):
+			try:
+				# Post-introspection WS request has an Authorization header
+				token = get_bearer_token_from_authorization_header(request)
+			except NotAuthenticatedError as e:
+				# Internal network WS request
+				token = get_bearer_token_from_websocket_request(request)
+		else:
 			token = get_bearer_token_from_authorization_header(request)
 
 		try:

--- a/asab/web/auth/providers/id_token.py
+++ b/asab/web/auth/providers/id_token.py
@@ -63,9 +63,11 @@ class IdTokenAuthProvider(AuthProviderABC):
 			try:
 				# Post-introspection WS request has an Authorization header
 				token = get_bearer_token_from_authorization_header(request)
-			except NotAuthenticatedError as e:
+			except NotAuthenticatedError:
 				# Internal network WS request
 				token = get_bearer_token_from_websocket_request(request)
+			if token is None:
+				raise NotAuthenticatedError(message="WebSocket authentication failed")
 		else:
 			token = get_bearer_token_from_authorization_header(request)
 

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -152,11 +152,7 @@ class AuthService(Service):
 
 		L.warning(
 			"Request authentication failed: All authorization providers rejected the request.",
-			struct_data={
-				"path": request.path,
-				"method": request.method,
-				**failure_reasons
-			},
+			struct_data=failure_reasons,
 		)
 		if auth_error:
 			# Re-raise the last error, preserve the original error response headers

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -138,24 +138,24 @@ class AuthService(Service):
 		Raises:
 			NotAuthenticatedError: When no provider is able to authorize the request
 		"""
-		failures = []
+		failure_reasons = {}
 		auth_error = None
 		for provider in self.Providers:
 			try:
 				return await provider.authorize(request)
 			except NotAuthenticatedError as e:
-				failures.append({provider.Type: _authentication_failure_reason(e)})
+				failure_reasons["reason_" + provider.Type] = _authentication_failure_reason(e)
 				auth_error = e
 			except Exception as e:
-				failures.append({provider.Type: "{}: {}".format(e.__class__.__name__, e)})
+				failure_reasons["reason_" + provider.Type] = "{}: {}".format(e.__class__.__name__, e)
 				L.exception("Request authentication failed.", struct_data={"provider_type": provider.Type})
 
 		L.warning(
 			"Request authentication failed: All authorization providers rejected the request.",
 			struct_data={
-				"reason": failures,
 				"path": request.path,
 				"method": request.method,
+				**failure_reasons
 			},
 		)
 		if auth_error:

--- a/asab/web/auth/utils.py
+++ b/asab/web/auth/utils.py
@@ -114,3 +114,18 @@ def get_id_token_claims(bearer_token: str, auth_server_public_key: jwcrypto.jwk.
 		raise NotAuthenticatedError(message="ID token claims are not valid JSON")
 
 	return token_claims
+
+
+def is_websocket_request(request) -> bool:
+	if request.headers.get(aiohttp.hdrs.UPGRADE, "").casefold() != "websocket":
+		return False
+
+	connection_header = request.headers.get(aiohttp.hdrs.CONNECTION)
+	if not connection_header:
+		return False
+
+	for value in connection_header.casefold().split(","):
+		if value.strip() == "upgrade":
+			return True
+
+	return False


### PR DESCRIPTION
# Issue
WebSocket authentication in prod mode is broken, the request is rejected. This bug was introduced in #788

# Changes
- Fix WebSocket authentication flow and make the code more clear.
- Improve the auth failure logging by flattening the reason format.

New format:
`23-Jul-2026 14:19:01.300034 WARNING asab.web.auth.service [sd reason_id_token="Invalid JWT object" reason_access_token="Access token introspection failed"] Request authentication failed: All authorization providers rejected the request.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication for WebSocket connections by supporting bearer tokens in request headers, with fallback handling for tokens provided through the WebSocket request.
  * Enhanced detection of WebSocket handshakes across different header formats.
  * Improved authorization failure reporting by clearly identifying the authentication provider and failure reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->