### PR TITLE
Fix OpenAPI tags for wrapped methods; Improve ASAB API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release candidate
 
 ### Fixes
+- Fix OpenAPI tags for wrapped methods (#796)
 - Fix the order of WebSocket authentication (#770)
 - Treat HTTP authentication scheme as case-insensitive (#759)
 - Authenticate websocket requests with multivalued Upgrade header (#748)

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -226,9 +226,11 @@ class DocWebHandler(object):
 	# This is the web request handler
 	async def doc(self, request):
 		"""
-		Access the API documentation using a browser.
+		Browse interactive API documentation
+
+		Opens Swagger UI for exploring and trying the service REST API.
 		---
-		tags: ['asab.doc']
+		tags: ["ASAB"]
 		"""
 
 		swagger_js_url: str = "https://unpkg.com/swagger-ui-dist@4/swagger-ui-bundle.js"
@@ -249,9 +251,11 @@ class DocWebHandler(object):
 	@noauth
 	async def oauth2_redirect(self, request):
 		"""
-		Required for the authorization to work.
+		Complete OAuth2 login for the API documentation UI
+
+		Redirect target used by Swagger UI after authorization.
 		---
-		tags: ['asab.doc']
+		tags: ["ASAB"]
 		"""
 
 		return aiohttp.web.Response(text=SWAGGER_OAUTH_PAGE, content_type="text/html")
@@ -260,9 +264,11 @@ class DocWebHandler(object):
 	@noauth
 	async def openapi(self, request):
 		"""
-		Download OpenAPI (version 3) API documentation (aka Swagger) in YAML.
+		Download the OpenAPI 3 specification
+
+		Returns the generated API specification as YAML.
 		---
-		tags: ['asab.doc']
+		tags: ["ASAB"]
 		externalDocs:
 			description: OpenAPI Specification
 			url: https://swagger.io/specification/

--- a/asab/api/doc.py
+++ b/asab/api/doc.py
@@ -315,26 +315,53 @@ def get_path_parameters(route) -> list:
 	return parameters
 
 
+def unwrap_route_handler(handler):
+	"""
+	Walk the ``__wrapped__`` chain produced by ``@functools.wraps``.
+
+	Auth and tenant installers replace bound methods on routes with plain
+	wrapper functions. The original bound method (if any) remains reachable
+	via ``__wrapped__`` and is preferred for introspection.
+	"""
+	seen = set()
+	bound_method = None
+	while True:
+		if inspect.ismethod(handler):
+			bound_method = handler
+		wrapped = getattr(handler, "__wrapped__", None)
+		if wrapped is None or id(handler) in seen:
+			break
+		seen.add(id(handler))
+		handler = wrapped
+	return bound_method if bound_method is not None else handler
+
+
 def get_handler_name(route) -> str:
-	if inspect.ismethod(route.handler):
-		handler_name = "{}.{}()".format(route.handler.__self__.__class__.__name__, route.handler.__name__)
+	handler = unwrap_route_handler(route.handler)
+	if inspect.ismethod(handler):
+		handler_name = "{}.{}()".format(handler.__self__.__class__.__name__, handler.__name__)
 	else:
-		handler_name = "{}()".format(route.handler.__qualname__)
+		handler_name = "{}()".format(handler.__qualname__)
 	return handler_name
 
 
 def get_class_name(route) -> str:
-	if inspect.ismethod(route.handler):
-		class_name = str(route.handler.__self__.__class__.__name__)
+	handler = unwrap_route_handler(route.handler)
+	if inspect.ismethod(handler):
+		class_name = str(handler.__self__.__class__.__name__)
 	else:
-		class_name = str(route.handler.__qualname__.split(".")[0])
+		class_name = str(handler.__qualname__.split(".")[0])
 	return class_name
 
 
 def get_class_tags(route) -> typing.Optional[list]:
-	if not inspect.ismethod(route.handler):
+	handler = unwrap_route_handler(route.handler)
+	if not inspect.ismethod(handler):
 		return None
-	return get_docstring_yaml(route.handler.__self__.__class__).get("tags")
+	doc = get_docstring_yaml(handler.__self__.__class__)
+	if not doc:
+		return None
+	return doc.get("tags")
 
 
 def get_module_name(route) -> str:
@@ -343,13 +370,19 @@ def get_module_name(route) -> str:
 
 def get_json_schema(route) -> dict:
 		method_dict = {}
-		try:
-			json_schema = route.handler.__getattribute__("json_schema")
+		handler = route.handler
+		json_schema = None
+		seen = set()
+		while handler is not None and id(handler) not in seen:
+			seen.add(id(handler))
+			json_schema = getattr(handler, "json_schema", None)
+			if json_schema is not None:
+				break
+			handler = getattr(handler, "__wrapped__", None)
+		if json_schema is not None:
 			method_dict["requestBody"] = {
 				"content": {"application/json": {"schema": json_schema}},
 			}
-		except AttributeError:
-			pass
 		return method_dict
 
 

--- a/asab/api/log.py
+++ b/asab/api/log.py
@@ -91,9 +91,11 @@ class WebApiLoggingHandler(logging.Handler):
 	@allow_no_tenant
 	async def get_logs(self, request):
 		"""
-		Get logs.
+		Get recent application logs
+
+		Returns a JSON array of buffered log entries.
 		---
-		tags: ['asab.log']
+		tags: ["ASAB"]
 
 		responses:
 			"200":
@@ -142,9 +144,10 @@ class WebApiLoggingHandler(logging.Handler):
 	@allow_no_tenant
 	async def ws(self, request):
 		'''
-		# Live feed of logs over websocket
+		Stream application logs over WebSocket
 
-		Usable with e.g. with React Lazylog
+		Sends historical buffered logs first, then live log entries as they occur.
+		Compatible with React Lazylog.
 
 		```
 		<LazyLog
@@ -168,7 +171,7 @@ class WebApiLoggingHandler(logging.Handler):
 		```
 
 		---
-		tags: ['asab.log']
+		tags: ["ASAB"]
 		externalDocs:
 			description: React Lazylog
 			url: https://github.com/mozilla-frontend-infra/react-lazylog#readme

--- a/asab/api/web_handler.py
+++ b/asab/api/web_handler.py
@@ -30,9 +30,11 @@ class APIWebHandler(object):
 	@noauth
 	async def changelog(self, request):
 		"""
-		Get changelog file.
+		Get the application changelog
+
+		Returns the changelog file as Markdown when available.
 		---
-		tags: ['asab.api']
+		tags: ["ASAB"]
 		"""
 
 		if self.ApiService.ChangeLog is None:
@@ -47,14 +49,12 @@ class APIWebHandler(object):
 	@noauth
 	async def manifest(self, request):
 		"""
-		Get manifest of the ASAB service.
+		Get the application build manifest
 
-		The manifest is a JSON object loaded from `MANIFEST.json` file.
-		The manifest contains the creation (build) time and the version of the ASAB service.
-		The `MANIFEST.json` is produced during the creation of docker image by `asab-manifest.py` script.
+		Returns creation time and version from `MANIFEST.json` when available.
 
 		---
-		tags: ['asab.api']
+		tags: ["ASAB"]
 
 		responses:
 			"200":
@@ -81,12 +81,12 @@ class APIWebHandler(object):
 	@require_superuser
 	async def environ(self, request):
 		"""
-		Get environment variables.
+		Get process environment variables.
 
-		Get JSON response containing the contents of the environment variables.
+		Returns the current environment as JSON. Requires superuser access.
 
 		---
-		tags: ['asab.api']
+		tags: ["ASAB"]
 
 		responses:
 			"200":
@@ -112,11 +112,9 @@ class APIWebHandler(object):
 	@require_superuser
 	async def config(self, request):
 		"""
-		Get configuration of the service.
+		Get the application configuration.
 
-		Return configuration of the ASAB service in JSON format.
-
-		**IMPORTANT: All passwords are erased.**
+		Returns configuration as JSON with password values redacted. Requires superuser access.
 
 		Example:
 
@@ -136,7 +134,7 @@ class APIWebHandler(object):
 		```
 
 		---
-		tags: ['asab.api']
+		tags: ["ASAB"]
 
 		responses:
 			"200":

--- a/asab/metrics/web_handler.py
+++ b/asab/metrics/web_handler.py
@@ -28,9 +28,9 @@ class MetricWebHandler(object):
 	@allow_no_tenant
 	async def metrics_json(self, request):
 		'''
-		Get metrics in a JSON.
+		Get application metrics as JSON
 		---
-		tags: ['asab.metrics']
+		tags: ["ASAB"]
 		'''
 		metrics_to_send = copy.deepcopy(self.MetricsService.Storage.Metrics)
 		return json_response(request, metrics_to_send)
@@ -40,9 +40,11 @@ class MetricWebHandler(object):
 	@allow_no_tenant
 	async def metrics(self, request):
 		'''
-		Produce the OpenMetrics output.
+		Get application metrics in OpenMetrics format
+
+		Suitable for Prometheus and other OpenMetrics scrapers.
 		---
-		tags: ['asab.metrics']
+		tags: ["ASAB"]
 		'''
 		lines = []
 
@@ -67,7 +69,9 @@ class MetricWebHandler(object):
 	@allow_no_tenant
 	async def watch(self, request):
 		"""
-		Endpoint to list ASAB metrics in the command line.
+		Watch application metrics as a text table
+
+		Useful from the command line with tools like `watch` and `curl`.
 
 		Example commands:
 		* watch curl localhost:8080/asab/v1/watch_metrics -> all metrics
@@ -87,7 +91,7 @@ class MetricWebHandler(object):
 		* watch curl localhost:8080/asab/v1/watch_metrics?filter=-*web* -> metrics that contain "web"
 
 		---
-		tags: ['asab.metrics']
+		tags: ["ASAB"]
 		"""
 
 		filter = request.query.get("filter")

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -92,10 +92,8 @@ def noauth(handler):
 		if arg in args:
 			raise Exception(
 				"{}(): Handler with @noauth cannot have {!r} in its arguments.".format(handler.__qualname__, arg))
+	# Mark the handler in place — no wrapper needed. Extra wraps would turn a
+	# later bound method into a plain function once auth/tenant installers wrap
+	# the route again, breaking inspect.ismethod() in OpenAPI generation.
 	handler.NoAuth = True
-
-	@functools.wraps(handler)
-	async def _noauth_wrapper(*args, **kwargs):
-		return await handler(*args, **kwargs)
-
-	return _noauth_wrapper
+	return handler

--- a/asab/web/auth/decorator.py
+++ b/asab/web/auth/decorator.py
@@ -92,8 +92,6 @@ def noauth(handler):
 		if arg in args:
 			raise Exception(
 				"{}(): Handler with @noauth cannot have {!r} in its arguments.".format(handler.__qualname__, arg))
-	# Mark the handler in place — no wrapper needed. Extra wraps would turn a
-	# later bound method into a plain function once auth/tenant installers wrap
-	# the route again, breaking inspect.ismethod() in OpenAPI generation.
+
 	handler.NoAuth = True
 	return handler

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -274,22 +274,18 @@ class AuthService(Service):
 		"""
 		Inspect handler and apply suitable auth wrappers.
 		"""
-		# Extract the actual unwrapped handler method for signature inspection
+		# Unwrap decorator chain for signature inspection; also detect @noauth on any layer.
+		# NOTE: Decorators that participate in this chain should use @functools.wraps().
 		handler_method = route.handler
-
-		# Exclude endpoints with @noauth decorator (attribute may sit on any wrap layer)
-		probe = handler_method
 		seen = set()
-		while probe is not None and id(probe) not in seen:
-			seen.add(id(probe))
-			if getattr(probe, "NoAuth", False) is True:
+		while handler_method is not None and id(handler_method) not in seen:
+			seen.add(id(handler_method))
+			if getattr(handler_method, "NoAuth", False) is True:
 				return
-			probe = getattr(probe, "__wrapped__", None)
-
-		while hasattr(handler_method, "__wrapped__"):
-			# While loop unwraps handlers wrapped in multiple decorators.
-			# NOTE: This requires all the decorators to use @functools.wraps().
-			handler_method = handler_method.__wrapped__
+			wrapped = getattr(handler_method, "__wrapped__", None)
+			if wrapped is None:
+				break
+			handler_method = wrapped
 
 		if hasattr(handler_method, "__func__"):
 			handler_method = handler_method.__func__

--- a/asab/web/auth/service.py
+++ b/asab/web/auth/service.py
@@ -277,9 +277,14 @@ class AuthService(Service):
 		# Extract the actual unwrapped handler method for signature inspection
 		handler_method = route.handler
 
-		# Exclude endpoints with @noauth decorator
-		if hasattr(handler_method, "NoAuth") and handler_method.NoAuth is True:
-			return
+		# Exclude endpoints with @noauth decorator (attribute may sit on any wrap layer)
+		probe = handler_method
+		seen = set()
+		while probe is not None and id(probe) not in seen:
+			seen.add(id(probe))
+			if getattr(probe, "NoAuth", False) is True:
+				return
+			probe = getattr(probe, "__wrapped__", None)
 
 		while hasattr(handler_method, "__wrapped__"):
 			# While loop unwraps handlers wrapped in multiple decorators.

--- a/asab/web/tenant/decorator.py
+++ b/asab/web/tenant/decorator.py
@@ -1,6 +1,3 @@
-import functools
-
-
 def allow_no_tenant(handler):
 	"""
 	Allow receiving requests without tenant parameter.
@@ -9,7 +6,7 @@ def allow_no_tenant(handler):
 		handler: Web handler method
 
 	Returns:
-		Wrapped web handler that allows requests with undefined tenant.
+		The same handler, marked so tenant middleware permits missing tenant.
 
 	Examples:
 		>>> import asab.web.rest
@@ -25,9 +22,4 @@ def allow_no_tenant(handler):
 		>>> 		print("The request has tenant {!r}.".format(tenant))
 	"""
 	handler.AllowNoTenant = True
-
-	@functools.wraps(handler)
-	async def _allow_no_tenant_wrapper(*args, **kwargs):
-		return await handler(*args, **kwargs)
-
-	return _allow_no_tenant_wrapper
+	return handler


### PR DESCRIPTION
# Issue
Handler methods wrapped in auth and tenant wrappers are not properly enriched by their class tags.

# Changes
- Simplify the redundant wrapping logic on the decorators.
- Unwrap the methods properly at OpenAPI generation time.
- Improve ASAB API docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Swagger documentation for wrapped route handlers, including more accurate names, class information, tags, and request body schemas.
  * Fixed authentication bypass detection when handlers use multiple decorators or wrappers.
  * Improved handling of endpoints that allow unauthenticated access or do not require tenant information.
  * Added protection against decorator wrapper cycles during route inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->