### PR TITLE
ZooKeeperLibraryProvider: Add error message when ZK module is not initialized

### DIFF
--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -146,6 +146,14 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 		# Initialize ZooKeeper client
 		zksvc = self.App.get_service("asab.ZooKeeperService")
+		if zksvc is None:
+			L.critical(
+				"ZooKeeper library provider requires asab.zookeeper.Module to be initialized; "
+				"add asab.zookeeper.Module to Application modules.",
+				struct_data={"provider_url": path},
+			)
+			raise SystemExit("Exit due to a critical configuration error.")
+
 		self.ZookeeperContainer = ZooKeeperContainer(
 			zksvc,
 			config_section_name=config_section_name,


### PR DESCRIPTION
Added a readable error when you try to use ZooKeeper provider without `asab.zookeeper.Module` initialized in the application.

### Application

```python
class MyApplication(asab.Application):

	def __init__(self):
		super().__init__()  # Without asab.zookeeper.Module initialized
		self.LibraryService = asab.library.LibraryService(self, "LibraryService")
```

with 

```
[zookeeper]
servers=myzk:2181

[library]
providers=
  zk:///library
```

### Old behavior

```
Traceback (most recent call last):
  File "/home/mir/Work/TeskaLabs/Workspace/asab/examples/library.py", line 64, in <module>
    app = MyApplication()
          ^^^^^^^^^^^^^^^
  File "/home/mir/Work/TeskaLabs/Workspace/asab/asab/abc/singleton.py", line 14, in __call__
    cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mir/Work/TeskaLabs/Workspace/asab/examples/library.py", line 35, in __init__
    self.LibraryService = asab.library.LibraryService(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mir/Work/TeskaLabs/Workspace/asab/asab/library/service.py", line 109, in __init__
    self._create_library(path, layer)
  File "/home/mir/Work/TeskaLabs/Workspace/asab/asab/library/service.py", line 135, in _create_library
    library_provider = ZooKeeperLibraryProvider(self, path, layer)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mir/Work/TeskaLabs/Workspace/asab/asab/library/providers/zookeeper.py", line 149, in __init__
    self.ZookeeperContainer = ZooKeeperContainer(
                              ^^^^^^^^^^^^^^^^^^^
  File "/home/mir/Work/TeskaLabs/Workspace/asab/asab/zookeeper/container.py", line 50, in __init__
    self.App = zookeeper_service.App
               ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'App'
```

### New behavior

```
27-Jul-2026 09:59:33.800281 CRITICAL asab.library.providers.zookeeper [sd provider_url="zk:///library"] ZooKeeper library provider requires asab.zookeeper.Module to be initialized; add asab.zookeeper.Module to Application modules.
Exit due to a critical configuration error.
```