### PR TITLE
Zookeeper-driven election of leader/follower.

### DIFF
--- a/asab/zookeeper/__init__.py
+++ b/asab/zookeeper/__init__.py
@@ -1,5 +1,6 @@
 from .container import ZooKeeperContainer
 from ..abc.module import Module
+from .leader_svc import LeaderService
 
 
 class Module(Module):
@@ -14,4 +15,5 @@ class Module(Module):
 __all__ = [
 	"ZooKeeperContainer",
 	"Module",
+	"LeaderService",
 ]

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -102,6 +102,8 @@ class LeaderService(Service):
 				ephemeral=True,  # We want this to disappear when the instance is stopped
 			)
 		except kazoo.exceptions.NodeExistsError:
+			# If we lost the election due to our own node,
+			# The on-tick recovery process will try to become leader again.
 			self._leader_status = False
 			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
 		else:

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -53,7 +53,10 @@ class LeaderService(Service):
 			# Start the election thread to become leader or follower
 			self._election_thread()
 
-		self._leader_status = None
+		if self._leader_status is not None:
+			self._leader_status = None
+			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
+
 		zkcontainer.ProactorService.schedule(setup)
 
 
@@ -64,6 +67,7 @@ class LeaderService(Service):
 			return
 
 		self._leader_status = None
+		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.LeaderName)
 
 
 	def _on_change_zookeeper_thread(self, event):

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -43,7 +43,7 @@ class LeaderService(Service):
 			return
 
 		def setup():
-			zkcontainer.ZooKeeper.Client.ensure_path_async(self.ElectionPath)
+			zkcontainer.ZooKeeper.Client.ensure_path(self.ElectionPath)
 			zkcontainer.ZooKeeper.Client.add_watch(
 				self.ElectionPath,
 				self._on_change_zookeeper_thread,

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -17,17 +17,21 @@ class LeaderService(Service):
 	"""
 	ZooKeeper-based leader election service.
 
-	Creates an ephemeral znode under `{zkcontainer.Path}/election/{leader_name}`.
+	Creates an ephemeral znode under `{zkcontainer.Path}/election/{scope}`.
 	The instance that successfully creates the node becomes the leader; others
 	become followers. Leadership is released automatically when the ZooKeeper
 	session ends (process stop, disconnect, or session expiry).
+
+	Different `scope` values allow multiple LeaderService instances to run in
+	parallel on the same ZooKeeper container, each electing a leader within its
+	own election namespace.
 
 	PubSub events:
 
 	- `LeaderService.state/LEADER!` — this instance became the leader.
 	- `LeaderService.state/FOLLOWER!` — this instance is (or became) a follower.
 
-	Both events carry `leader_name` as the sole argument after the event name.
+	Both events carry `scope` as the sole argument after the event name.
 	`LeaderInfo` holds the current leader znode payload (bytes), typically
 	lines with `instance_id`, `service_id`, and/or `node_id` from the environment.
 
@@ -42,7 +46,7 @@ class LeaderService(Service):
 	```
 	"""
 
-	def __init__(self, app, zkcontainer, leader_name):
+	def __init__(self, app, zkcontainer, scope):
 		"""
 		Register the service and subscribe to ZooKeeper connectivity events.
 
@@ -50,24 +54,25 @@ class LeaderService(Service):
 			app (asab.Application): Reference to the ASAB application.
 			zkcontainer (asab.zookeeper.ZooKeeperContainer): ZooKeeper container
 				used for the election path and client.
-			leader_name (str): Election identity; must be a non-empty string
-				and must not contain `/`.
-				Registered as service name `asab.LeaderService:{leader_name}`.
+			scope (str): Election namespace; must be a non-empty string
+				and must not contain `/`. Distinct scopes elect leaders
+				independently.
+				Registered as service name `asab.LeaderService:{scope}`.
 
 		Raises:
-			ValueError: If `leader_name` is not a non-empty string or contains `/`.
+			ValueError: If `scope` is not a non-empty string or contains `/`.
 		"""
-		if not isinstance(leader_name, str):
-			raise ValueError("Leader name must be a string")
-		if not leader_name:
-			raise ValueError("Leader name must not be empty")
-		if "/" in leader_name:
-			raise ValueError("Leader name must not contain '/' character")
+		if not isinstance(scope, str):
+			raise ValueError("Scope must be a string")
+		if not scope:
+			raise ValueError("Scope must not be empty")
+		if "/" in scope:
+			raise ValueError("Scope must not contain '/' character")
 
-		super().__init__(app, "asab.LeaderService:{}".format(leader_name))
+		super().__init__(app, "asab.LeaderService:{}".format(scope))
 		self.ZkContainer = zkcontainer
 		self.ElectionPath = zkcontainer.Path + "/election"
-		self.LeaderName = leader_name
+		self.Scope = scope
 
 		# Subscribe to the event that indicated the successful connection to the Zookeeper server(s)
 		app.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_ready)
@@ -151,7 +156,7 @@ class LeaderService(Service):
 		self._election_key = None
 		self._leader_zxid = None
 		self.LeaderInfo = None
-		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.LeaderName)
+		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.Scope)
 
 
 	def _on_change_zookeeper_thread(self, event):
@@ -187,13 +192,13 @@ class LeaderService(Service):
 			# Try to become leader
 			try:
 				_, stats = self.ZkContainer.ZooKeeper.Client.create(
-					self.ElectionPath + "/" + self.LeaderName,
+					self.ElectionPath + "/" + self.Scope,
 					leader_data,
 					ephemeral=True,  # We want this to disappear when the instance is stopped
 					include_data=True,
 				)
 			except kazoo.exceptions.NodeExistsError:
-				leader_data, stats = self.ZkContainer.ZooKeeper.Client.get(self.ElectionPath + "/" + self.LeaderName)
+				leader_data, stats = self.ZkContainer.ZooKeeper.Client.get(self.ElectionPath + "/" + self.Scope)
 				if self._election_key != election_key:
 					# Session was lost/invalidated while we ran; do not overwrite state.
 					return
@@ -202,12 +207,12 @@ class LeaderService(Service):
 					return
 				self._leader_zxid = None
 				self.LeaderInfo = leader_data
-				self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
+				self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.Scope)
 			else:
 				if self._election_key != election_key:
 					# Stale election result (e.g. session lost): become follower without
 					# overwriting LeaderInfo / _leader_zxid already cleared by LOST.
-					self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
+					self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.Scope)
 					return
 				self._leader_zxid = stats.czxid
 				self.LeaderInfo = leader_data
@@ -216,4 +221,4 @@ class LeaderService(Service):
 					self._leader_zxid = None
 					self.LeaderInfo = None
 					return
-				self.App.PubSub.publish_threadsafe("LeaderService.state/LEADER!", self.LeaderName)
+				self.App.PubSub.publish_threadsafe("LeaderService.state/LEADER!", self.Scope)

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -1,0 +1,105 @@
+import os
+import logging
+
+import kazoo.protocol.states
+
+from ..abc.service import Service
+
+#
+
+L = logging.getLogger(__name__)
+
+#
+
+
+class LeaderService(Service):
+
+	def __init__(self, app, zkcontainer, leader_name):
+		super().__init__(app, "asab.LeaderService:{}".format(leader_name))
+		self.ZkContainer = zkcontainer
+		self.ElectionPath = zkcontainer.Path + "/election/"
+
+		assert "/" not in leader_name, "Leader name must not contain '/' character"
+		self.LeaderName = leader_name
+
+		# Subscribe to the event that indicated the successful connection to the Zookeeper server(s)
+		app.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_ready)
+		app.PubSub.subscribe("ZooKeeperContainer.state/LOST!", self._on_zk_lost)
+		app.PubSub.subscribe("Application.tick60!", self._on_tick60)
+
+		self._leader_status = None  # Can be True, False or None (for initialization)
+
+
+	def IsLeader(self):
+		if self._leader_status is None:
+			return False
+		return self._leader_status
+
+
+	async def _on_zk_ready(self, event_name, zkcontainer):
+		# If there is more than one ZooKeeper Container being initialized, this method is called at every Container initialization.
+		# Then you need to check whether the specific ZK Container has been initialized.
+		if zkcontainer != self.ZkContainer:
+			return
+
+		def setup():
+			zkcontainer.ZooKeeper.Client.ensure_path_async(self.ElectionPath)
+			zkcontainer.ZooKeeper.Client.add_watch(
+				self.ElectionPath,
+				self._on_change_zookeeper_thread,
+				kazoo.protocol.states.AddWatchMode.PERSISTENT_RECURSIVE
+			)
+
+			# Start the election thread to become leader or follower
+			self._election_thread()
+
+		self._leader_status = None
+		zkcontainer.ProactorService.schedule(setup)
+
+
+	async def _on_zk_lost(self, event_name, zkcontainer):
+		# If there is more than one ZooKeeper Container being initialized, this method is called at every Container initialization.
+		# Then you need to check whether the specific ZK Container has been initialized.
+		if zkcontainer != self.ZkContainer:
+			return
+
+		self._leader_status = None
+
+
+	def _on_change_zookeeper_thread(self, event):
+		if not self.IsLeader():
+			self._election_thread()
+
+
+	def _on_tick60(self, event_name):
+		if not self.IsLeader():
+			# Speculatively run the election thread to become leader - this is a last resort recovery mechanism
+			return self.ZkContainer.ProactorService.schedule(self._election_thread)
+
+
+	def _election_thread(self):
+		instance_id = os.environ.get("INSTANCE_ID")
+		service_id = os.environ.get("SERVICE_ID")
+		node_id = os.environ.get("NODE_ID")
+
+		leader_data = b""
+		if instance_id is not None:
+			leader_data += (f"instance_id: {instance_id}\n").encode("utf-8")
+		if service_id is not None:
+			leader_data += (f"service_id: {service_id}\n").encode("utf-8")
+		if node_id is not None:
+			leader_data += (f"node_id: {node_id}\n").encode("utf-8")
+
+		# Try to become leader
+		try:
+			self.ZkContainer.ZooKeeper.Client.create(
+				self.ElectionPath + "/" + self.LeaderName,
+				leader_data,
+				ephemeral=True,  # We want this to disappear when the instance is stopped
+			)
+		except kazoo.exceptions.NodeExistsError:
+			self._leader_status = False
+			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
+		else:
+			self._leader_status = True
+			self.App.PubSub.publish_threadsafe("LeaderService.state/LEADER!", self.LeaderName)

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -54,13 +54,10 @@ class LeaderService(Service):
 		"""
 		super().__init__(app, "asab.LeaderService:{}".format(leader_name))
 		self.ZkContainer = zkcontainer
-		"""ZooKeeper container used for election."""
 		self.ElectionPath = zkcontainer.Path + "/election"
-		"""Parent path of election znodes (`{Path}/election`)."""
 
 		assert "/" not in leader_name, "Leader name must not contain '/' character"
 		self.LeaderName = leader_name
-		"""Election identity; also the ephemeral znode name under `ElectionPath`."""
 
 		# Subscribe to the event that indicated the successful connection to the Zookeeper server(s)
 		app.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_ready)
@@ -69,7 +66,6 @@ class LeaderService(Service):
 
 		self._leader_zxid = None  # Can be True, False or None (for initialization)
 		self.LeaderInfo = None
-		"""Payload of the current leader znode (`bytes`), or `None` if unknown."""
 
 
 	def IsLeader(self):

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import threading
 
 import kazoo.protocol.states
 
@@ -77,6 +78,13 @@ class LeaderService(Service):
 		self._leader_zxid = None  # Can be True, False or None (for initialization)
 		self.LeaderInfo = None
 
+		# Serializes CONNECTED / watch / tick election attempts. LOST (and
+		# SUSPENDED for in-flight attempts) invalidate `_election_key` without
+		# acquiring this lock (avoids blocking the event loop on ZooKeeper I/O);
+		# in-flight elections observe the stale key before publishing LEADER!.
+		self._election_lock = threading.Lock()
+		self._election_key = None
+
 
 	def IsLeader(self):
 		"""
@@ -89,6 +97,15 @@ class LeaderService(Service):
 		if self._leader_zxid is None:
 			return False
 		return True
+
+
+	def _capture_election_key(self):
+		"""Return (session_id, last_zxid) for the current ZK connection, or None."""
+		client = self.ZkContainer.ZooKeeper.Client
+		client_id = client.client_id
+		if client_id is None:
+			return None
+		return (client_id[0], client.last_zxid)
 
 
 	async def _on_zk_ready(self, event_name, zkcontainer):
@@ -108,11 +125,9 @@ class LeaderService(Service):
 			# Start the election thread to become leader or follower
 			self._election_thread()
 
-		if self._leader_zxid is not None:
-			self._leader_zxid = None
-			self.LeaderInfo = None
-			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
-
+		# Keep `_leader_zxid` / LeaderInfo across reconnect: a still-valid
+		# session retains the ephemeral election node, and NodeExistsError
+		# handling must compare stats.czxid with the prior zxid.
 		zkcontainer.ProactorService.schedule(setup)
 
 
@@ -120,10 +135,10 @@ class LeaderService(Service):
 		if zkcontainer != self.ZkContainer:
 			return
 
-		self._leader_zxid = None
-		self.LeaderInfo = None
-		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.LeaderName)
-		L.warning("ZooKeeper connection suspended. Leader service will become follower. THIS MUST BE TESTED!")
+		# Connection is down but the session may still be valid; do not clear
+		# leadership identity. Only invalidate in-flight elections.
+		self._election_key = None
+		L.warning("ZooKeeper connection suspended; leadership state preserved until session is lost.")
 
 
 	async def _on_zk_lost(self, event_name, zkcontainer):
@@ -132,6 +147,8 @@ class LeaderService(Service):
 		if zkcontainer != self.ZkContainer:
 			return
 
+		# Confirmed session loss: invalidate in-flight elections and clear leadership.
+		self._election_key = None
 		self._leader_zxid = None
 		self.LeaderInfo = None
 		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.LeaderName)
@@ -149,35 +166,54 @@ class LeaderService(Service):
 
 
 	def _election_thread(self):
-		instance_id = os.environ.get("INSTANCE_ID")
-		service_id = os.environ.get("SERVICE_ID")
-		node_id = os.environ.get("NODE_ID")
-
-		leader_data = b""
-		if instance_id is not None:
-			leader_data += (f"instance_id: {instance_id}\n").encode("utf-8")
-		if service_id is not None:
-			leader_data += (f"service_id: {service_id}\n").encode("utf-8")
-		if node_id is not None:
-			leader_data += (f"node_id: {node_id}\n").encode("utf-8")
-
-		# Try to become leader
-		try:
-			_, stats = self.ZkContainer.ZooKeeper.Client.create(
-				self.ElectionPath + "/" + self.LeaderName,
-				leader_data,
-				ephemeral=True,  # We want this to disappear when the instance is stopped
-				include_data=True,
-			)
-		except kazoo.exceptions.NodeExistsError:
-			leader_data, stats = self.ZkContainer.ZooKeeper.Client.get(self.ElectionPath + "/" + self.LeaderName)
-			if stats.czxid == self._leader_zxid:
-				# I'm still the leader, no need to become leader again.
+		with self._election_lock:
+			election_key = self._capture_election_key()
+			if election_key is None:
 				return
-			self._leader_zxid = None
-			self.LeaderInfo = leader_data
-			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
-		else:
-			self._leader_zxid = stats.czxid
-			self.LeaderInfo = leader_data
-			self.App.PubSub.publish_threadsafe("LeaderService.state/LEADER!", self.LeaderName)
+			self._election_key = election_key
+
+			instance_id = os.environ.get("INSTANCE_ID")
+			service_id = os.environ.get("SERVICE_ID")
+			node_id = os.environ.get("NODE_ID")
+
+			leader_data = b""
+			if instance_id is not None:
+				leader_data += (f"instance_id: {instance_id}\n").encode("utf-8")
+			if service_id is not None:
+				leader_data += (f"service_id: {service_id}\n").encode("utf-8")
+			if node_id is not None:
+				leader_data += (f"node_id: {node_id}\n").encode("utf-8")
+
+			# Try to become leader
+			try:
+				_, stats = self.ZkContainer.ZooKeeper.Client.create(
+					self.ElectionPath + "/" + self.LeaderName,
+					leader_data,
+					ephemeral=True,  # We want this to disappear when the instance is stopped
+					include_data=True,
+				)
+			except kazoo.exceptions.NodeExistsError:
+				leader_data, stats = self.ZkContainer.ZooKeeper.Client.get(self.ElectionPath + "/" + self.LeaderName)
+				if self._election_key != election_key:
+					# Session was lost/invalidated while we ran; do not overwrite state.
+					return
+				if stats.czxid == self._leader_zxid:
+					# I'm still the leader, no need to become leader again.
+					return
+				self._leader_zxid = None
+				self.LeaderInfo = leader_data
+				self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
+			else:
+				if self._election_key != election_key:
+					# Stale election result (e.g. session lost): become follower without
+					# overwriting LeaderInfo / _leader_zxid already cleared by LOST.
+					self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
+					return
+				self._leader_zxid = stats.czxid
+				self.LeaderInfo = leader_data
+				# Re-check after writing: LOST may have invalidated concurrently.
+				if self._election_key != election_key:
+					self._leader_zxid = None
+					self.LeaderInfo = None
+					return
+				self.App.PubSub.publish_threadsafe("LeaderService.state/LEADER!", self.LeaderName)

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -75,7 +75,7 @@ class LeaderService(Service):
 		app.PubSub.subscribe("ZooKeeperContainer.state/LOST!", self._on_zk_lost)
 		app.PubSub.subscribe("Application.tick60!", self._on_tick60)
 
-		self._leader_zxid = None  # Can be True, False or None (for initialization)
+		self._leader_zxid = None
 		self.LeaderInfo = None
 
 		# Serializes CONNECTED / watch / tick election attempts. LOST (and

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -27,13 +27,14 @@ class LeaderService(Service):
 		app.PubSub.subscribe("ZooKeeperContainer.state/LOST!", self._on_zk_lost)
 		app.PubSub.subscribe("Application.tick60!", self._on_tick60)
 
-		self._leader_status = None  # Can be True, False or None (for initialization)
+		self._leader_zxid = None  # Can be True, False or None (for initialization)
+		self.LeaderInfo = None
 
 
 	def IsLeader(self):
-		if self._leader_status is None:
+		if self._leader_zxid is None:
 			return False
-		return self._leader_status
+		return True
 
 
 	async def _on_zk_ready(self, event_name, zkcontainer):
@@ -53,8 +54,9 @@ class LeaderService(Service):
 			# Start the election thread to become leader or follower
 			self._election_thread()
 
-		if self._leader_status is not None:
-			self._leader_status = None
+		if self._leader_zxid is not None:
+			self._leader_zxid = None
+			self.LeaderInfo = None
 			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
 
 		zkcontainer.ProactorService.schedule(setup)
@@ -66,7 +68,8 @@ class LeaderService(Service):
 		if zkcontainer != self.ZkContainer:
 			return
 
-		self._leader_status = None
+		self._leader_zxid = None
+		self.LeaderInfo = None
 		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.LeaderName)
 
 
@@ -96,16 +99,21 @@ class LeaderService(Service):
 
 		# Try to become leader
 		try:
-			self.ZkContainer.ZooKeeper.Client.create(
+			_, stats = self.ZkContainer.ZooKeeper.Client.create(
 				self.ElectionPath + "/" + self.LeaderName,
 				leader_data,
 				ephemeral=True,  # We want this to disappear when the instance is stopped
+				include_data=True,
 			)
 		except kazoo.exceptions.NodeExistsError:
-			# If we lost the election due to our own node,
-			# The on-tick recovery process will try to become leader again.
-			self._leader_status = False
+			leader_data, stats = self.ZkContainer.ZooKeeper.Client.get(self.ElectionPath + "/" + self.LeaderName)
+			if stats.czxid == self._leader_zxid:
+				# I'm still the leader, no need to become leader again.
+				return
+			self._leader_zxid = None
+			self.LeaderInfo = leader_data
 			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
 		else:
-			self._leader_status = True
+			self._leader_zxid = stats.czxid
+			self.LeaderInfo = leader_data
 			self.App.PubSub.publish_threadsafe("LeaderService.state/LEADER!", self.LeaderName)

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -13,14 +13,54 @@ L = logging.getLogger(__name__)
 
 
 class LeaderService(Service):
+	"""
+	ZooKeeper-based leader election service.
+
+	Creates an ephemeral znode under `{zkcontainer.Path}/election/{leader_name}`.
+	The instance that successfully creates the node becomes the leader; others
+	become followers. Leadership is released automatically when the ZooKeeper
+	session ends (process stop, disconnect, or session expiry).
+
+	PubSub events:
+
+	- `LeaderService.state/LEADER!` — this instance became the leader.
+	- `LeaderService.state/FOLLOWER!` — this instance is (or became) a follower.
+
+	Both events carry `leader_name` as the sole argument after the event name.
+	`LeaderInfo` holds the current leader znode payload (bytes), typically
+	lines with `instance_id`, `service_id`, and/or `node_id` from the environment.
+
+	Examples:
+
+	```python
+	self.LeaderService = asab.zookeeper.LeaderService(
+		self, self.ZkContainer, "example-leader"
+	)
+	self.PubSub.subscribe("LeaderService.state/LEADER!", self._on_leader)
+	self.PubSub.subscribe("LeaderService.state/FOLLOWER!", self._on_follower)
+	```
+	"""
 
 	def __init__(self, app, zkcontainer, leader_name):
+		"""
+		Register the service and subscribe to ZooKeeper connectivity events.
+
+		Args:
+			app (asab.Application): Reference to the ASAB application.
+			zkcontainer (asab.zookeeper.ZooKeeperContainer): ZooKeeper container
+				used for the election path and client.
+			leader_name (str): Election identity; must not contain `/`.
+				Registered as service name `asab.LeaderService:{leader_name}`.
+		"""
 		super().__init__(app, "asab.LeaderService:{}".format(leader_name))
 		self.ZkContainer = zkcontainer
+		"""ZooKeeper container used for election."""
 		self.ElectionPath = zkcontainer.Path + "/election"
+		"""Parent path of election znodes (`{Path}/election`)."""
 
 		assert "/" not in leader_name, "Leader name must not contain '/' character"
 		self.LeaderName = leader_name
+		"""Election identity; also the ephemeral znode name under `ElectionPath`."""
 
 		# Subscribe to the event that indicated the successful connection to the Zookeeper server(s)
 		app.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_ready)
@@ -29,9 +69,17 @@ class LeaderService(Service):
 
 		self._leader_zxid = None  # Can be True, False or None (for initialization)
 		self.LeaderInfo = None
+		"""Payload of the current leader znode (`bytes`), or `None` if unknown."""
 
 
 	def IsLeader(self):
+		"""
+		Return whether this instance currently holds leadership.
+
+		Returns:
+			bool: `True` if this instance is the leader, otherwise `False`
+				(including while leadership is unknown after connect/loss).
+		"""
 		if self._leader_zxid is None:
 			return False
 		return True

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -17,7 +17,7 @@ class LeaderService(Service):
 	def __init__(self, app, zkcontainer, leader_name):
 		super().__init__(app, "asab.LeaderService:{}".format(leader_name))
 		self.ZkContainer = zkcontainer
-		self.ElectionPath = zkcontainer.Path + "/election/"
+		self.ElectionPath = zkcontainer.Path + "/election"
 
 		assert "/" not in leader_name, "Leader name must not contain '/' character"
 		self.LeaderName = leader_name

--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -49,18 +49,28 @@ class LeaderService(Service):
 			app (asab.Application): Reference to the ASAB application.
 			zkcontainer (asab.zookeeper.ZooKeeperContainer): ZooKeeper container
 				used for the election path and client.
-			leader_name (str): Election identity; must not contain `/`.
+			leader_name (str): Election identity; must be a non-empty string
+				and must not contain `/`.
 				Registered as service name `asab.LeaderService:{leader_name}`.
+
+		Raises:
+			ValueError: If `leader_name` is not a non-empty string or contains `/`.
 		"""
+		if not isinstance(leader_name, str):
+			raise ValueError("Leader name must be a string")
+		if not leader_name:
+			raise ValueError("Leader name must not be empty")
+		if "/" in leader_name:
+			raise ValueError("Leader name must not contain '/' character")
+
 		super().__init__(app, "asab.LeaderService:{}".format(leader_name))
 		self.ZkContainer = zkcontainer
 		self.ElectionPath = zkcontainer.Path + "/election"
-
-		assert "/" not in leader_name, "Leader name must not contain '/' character"
 		self.LeaderName = leader_name
 
 		# Subscribe to the event that indicated the successful connection to the Zookeeper server(s)
 		app.PubSub.subscribe("ZooKeeperContainer.state/CONNECTED!", self._on_zk_ready)
+		app.PubSub.subscribe("ZooKeeperContainer.state/SUSPENDED!", self._on_zk_suspended)
 		app.PubSub.subscribe("ZooKeeperContainer.state/LOST!", self._on_zk_lost)
 		app.PubSub.subscribe("Application.tick60!", self._on_tick60)
 
@@ -104,6 +114,16 @@ class LeaderService(Service):
 			self.App.PubSub.publish_threadsafe("LeaderService.state/FOLLOWER!", self.LeaderName)
 
 		zkcontainer.ProactorService.schedule(setup)
+
+
+	def _on_zk_suspended(self, event_name, zkcontainer):
+		if zkcontainer != self.ZkContainer:
+			return
+
+		self._leader_zxid = None
+		self.LeaderInfo = None
+		self.App.PubSub.publish("LeaderService.state/FOLLOWER!", self.LeaderName)
+		L.warning("ZooKeeper connection suspended. Leader service will become follower. THIS MUST BE TESTED!")
 
 
 	async def _on_zk_lost(self, event_name, zkcontainer):

--- a/examples/zookeeper-leader.py
+++ b/examples/zookeeper-leader.py
@@ -37,12 +37,12 @@ class MyApplication(asab.Application):
 		self.PubSub.subscribe("LeaderService.state/FOLLOWER!", self._on_follower)
 
 
-	def _on_leader(self, event_name, leader_name):
-		print("I am the leader at {} election".format(leader_name))
+	def _on_leader(self, event_name, scope):
+		print("I am the leader at {} election".format(scope))
 		print("Leader info: {}".format(self.LeaderService.LeaderInfo))
 
-	def _on_follower(self, event_name, leader_name):
-		print("I am a follower at '{}' election".format(leader_name))
+	def _on_follower(self, event_name, scope):
+		print("I am a follower at '{}' election".format(scope))
 		print("Leader info: {}".format(self.LeaderService.LeaderInfo))
 
 

--- a/examples/zookeeper-leader.py
+++ b/examples/zookeeper-leader.py
@@ -39,10 +39,11 @@ class MyApplication(asab.Application):
 
 	def _on_leader(self, event_name, leader_name):
 		print("I am the leader at {} election".format(leader_name))
+		print("Leader info: {}".format(self.LeaderService.LeaderInfo))
 
 	def _on_follower(self, event_name, leader_name):
 		print("I am a follower at '{}' election".format(leader_name))
-
+		print("Leader info: {}".format(self.LeaderService.LeaderInfo))
 
 
 if __name__ == '__main__':

--- a/examples/zookeeper-leader.py
+++ b/examples/zookeeper-leader.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import asab
+import asab.zookeeper
+
+# Specify a default configuration
+asab.Config.add_defaults(
+	{
+		"my:zk": {
+			# specify "servers": "..." here to provide addresses of Zookeeper servers
+			"servers": "fu01:2181,fu02:2181,fu03:2181",
+			"path": "ateska2607",
+			"timeout": "30",
+		},
+	}
+)
+
+
+class MyApplication(asab.Application):
+
+
+	def __init__(self):
+		super().__init__()
+
+		# Loading the ASAB Zookeeper module
+		self.add_module(asab.zookeeper.Module)
+
+		# Locate the Zookeeper service
+		zksvc = self.get_service("asab.ZooKeeperService")
+
+		# Create the Zookeeper container
+		self.ZkContainer = asab.zookeeper.ZooKeeperContainer(zksvc, 'my:zk')
+
+		self.LeaderService = asab.zookeeper.LeaderService(self, self.ZkContainer, 'example-leader')
+
+		# Subscribe to the event that indicated the successful connection to the Zookeeper server(s)
+		self.PubSub.subscribe("LeaderService.state/LEADER!", self._on_leader)
+		self.PubSub.subscribe("LeaderService.state/FOLLOWER!", self._on_follower)
+
+
+	def _on_leader(self, event_name, leader_name):
+		print("I am the leader at {} election".format(leader_name))
+
+	def _on_follower(self, event_name, leader_name):
+		print("I am a follower at '{}' election".format(leader_name))
+
+
+
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `LeaderService` enabling ZooKeeper-based leader election.
  * Applications can determine whether they are currently the leader.
  * Leadership role changes are published via application role/state events.
  * Included a runnable example demonstrating leader election and leader/follower notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->