### PR TITLE
JSONFormatter: Convert "asctime" timestamp to ISO8601 format

### DIFF
--- a/asab/log.py
+++ b/asab/log.py
@@ -454,6 +454,11 @@ class JSONFormatter(logging.Formatter):
 	def format(self, record):
 		r_copy = record.__dict__.copy()
 		r_copy.update(self.Enricher)
+
+		# Emit UTC ISO8601 timestamp (e.g. 2026-08-07T12:20:25.598569Z)
+		ct = datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
+		r_copy["asctime"] = ct.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
 		return json.dumps(r_copy, default=self._default)
 
 

--- a/asab/log.py
+++ b/asab/log.py
@@ -453,7 +453,7 @@ class LoggingJSONDumper(object):
 		try:
 			return str(o)
 		except Exception:
-			raise TypeError("Error when logging. Object {} of type {} is not JSON serializable.".format(o, type(o)))
+			raise TypeError("Error when logging. Object of type {} is not JSON serializable.".format(type(o)))
 
 
 class JSONFormatter(logging.Formatter):

--- a/asab/log.py
+++ b/asab/log.py
@@ -434,6 +434,11 @@ class LoggingJSONDumper(object):
 	"""
 
 	def __call__(self, obj):
+		# LogRecord.created is a float; convert it to asctime so default() can emit ISO8601.
+		# Without this, only the numeric "created" field would be present.
+		created = obj.get("created")
+		if created is not None:
+			obj["asctime"] = datetime.datetime.fromtimestamp(created, tz=datetime.timezone.utc)
 		return json.dumps(obj, default=self.default)
 
 	def default(self, o):
@@ -477,7 +482,6 @@ class JSONFormatter(logging.Formatter):
 	def format(self, record):
 		r_copy = record.__dict__.copy()
 		r_copy.update(self.Enricher)
-		r_copy["asctime"] = datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
 		return self.Dumper(r_copy)
 
 

--- a/asab/log.py
+++ b/asab/log.py
@@ -427,9 +427,39 @@ class SyslogRFC5424microFormatter(StructuredDataFormatter):
 		self.converter = time.gmtime
 
 
+class LoggingJSONDumper(object):
+	"""
+	JSON serializer for log records.
+	Datetimes are emitted as ISO8601 (UTC with `Z` suffix).
+	"""
+
+	def __call__(self, obj):
+		return json.dumps(obj, default=self.default)
+
+	def default(self, o):
+		if isinstance(o, datetime.datetime):
+			if o.tzinfo == datetime.timezone.utc:
+				# isoformat ends with "+00:00", replace it with "Z"
+				return o.isoformat()[:-6] + "Z"
+			elif o.tzinfo is not None:
+				# The datetime object is timezone-aware but not UTC
+				# NOT WANTED, using non-UTC timestamps is not recommended
+				return o.isoformat()
+			else:
+				# The datetime object is timezone-naive -> interpret it as UTC
+				return o.isoformat() + "Z"
+
+		# If obj is not json serializable, convert it to string
+		try:
+			return str(o)
+		except Exception:
+			raise TypeError("Error when logging. Object {} of type {} is not JSON serializable.".format(o, type(o)))
+
+
 class JSONFormatter(logging.Formatter):
 
 	def __init__(self):
+		self.Dumper = LoggingJSONDumper()
 		self.Enricher = {}
 		instance_id = os.environ.get("INSTANCE_ID")
 		service_id = os.environ.get("SERVICE_ID")
@@ -444,22 +474,11 @@ class JSONFormatter(logging.Formatter):
 		if hostname is not None:
 			self.Enricher["hostname"] = hostname
 
-	def _default(self, obj):
-		# If obj is not json serializable, convert it to string
-		try:
-			return str(obj)
-		except Exception:
-			raise TypeError("Error when logging. Object {} of type {} is not JSON serializable.".format(obj, type(obj)))
-
 	def format(self, record):
 		r_copy = record.__dict__.copy()
 		r_copy.update(self.Enricher)
-
-		# Emit UTC ISO8601 timestamp (e.g. 2026-08-07T12:20:25.598569Z)
-		ct = datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
-		r_copy["asctime"] = ct.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-
-		return json.dumps(r_copy, default=self._default)
+		r_copy["asctime"] = datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
+		return self.Dumper(r_copy)
 
 
 class FormatingDatagramHandler(logging.handlers.DatagramHandler):


### PR DESCRIPTION
`JSONFormatter` emits timestamps in ISO8601 format.

Before:

```json
{
  "name": "asab.web.al",
  "levelname": "NOTICE",
  "asctime": "07-Aug-2026 14:50:12.315891",
  "instance_id": "seacat-auth-1",
  "service_id": "seacat-auth",
  "node_id": "lmio-hawk",
  "hostname": "tux"
}
```

after:

```json
{
  "name": "asab.web.al",
  "levelname": "NOTICE",
  "asctime": "2026-08-07T12:54:41.579459Z",
  "instance_id": "seacat-auth-1",
  "service_id": "seacat-auth",
  "node_id": "lmio-hawk",
  "hostname": "tux"
}
```

This is a breaking change, but the parser in Common Library for ASAB microservices will be updated to accept both formats. See http://gitlab.teskalabs.int/lmio/lmio-common-library/-/merge_requests/1739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Log records include UTC timestamps in ISO 8601 format with microsecond precision and a trailing `Z`.
  * Datetime values are serialized consistently for both timezone-aware and timezone-naive values.
  * Supported non-serializable values appear as readable strings in structured logs.
  * Serialization failures remain clearly reported when values cannot be converted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->