### PR TITLE
Fix error message for nested base schema paths

### DIFF
--- a/asab/library/schema.py
+++ b/asab/library/schema.py
@@ -187,7 +187,7 @@ def _schema_path(schema: str) -> tuple[str, str, str]:
 	directory, filename = os.path.split(path)
 	if directory != "/Schemas":
 		raise LibraryInvalidPathError(
-			message="Schema path must be under '/Schemas/'.",
+			message="Base schema path must match '/Schemas/<name>.yaml'.",
 			path=path,
 		)
 

--- a/test/test_library/test_library_schema_validation.py
+++ b/test/test_library/test_library_schema_validation.py
@@ -142,7 +142,10 @@ class TestLibrarySchemaValidation(unittest.IsolatedAsyncioTestCase):
 		with tempfile.TemporaryDirectory() as root:
 			service = make_schema_service(make_filesystem_provider(root))
 
-			with self.assertRaises(LibraryInvalidPathError):
+			with self.assertRaisesRegex(
+				LibraryInvalidPathError,
+				"Base schema path must match '/Schemas/<name>.yaml'.",
+			):
 				await service.read_schema("/Schemas/Extensions/CFM.yaml")
 
 	async def test_base_schema_only_returns_base_schema(self):

--- a/test/test_library/test_library_schema_validation.py
+++ b/test/test_library/test_library_schema_validation.py
@@ -142,11 +142,14 @@ class TestLibrarySchemaValidation(unittest.IsolatedAsyncioTestCase):
 		with tempfile.TemporaryDirectory() as root:
 			service = make_schema_service(make_filesystem_provider(root))
 
-			with self.assertRaisesRegex(
-				LibraryInvalidPathError,
-				"Base schema path must match '/Schemas/<name>.yaml'.",
-			):
+			with self.assertRaises(LibraryInvalidPathError) as context:
 				await service.read_schema("/Schemas/Extensions/CFM.yaml")
+
+			self.assertEqual(
+				str(context.exception),
+				"Invalid Library path '/Schemas/Extensions/CFM.yaml': "
+				"Base schema path must match '/Schemas/<name>.yaml'.",
+			)
 
 	async def test_base_schema_only_returns_base_schema(self):
 		"""When no extensions exist, the effective schema contains only base fields."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message for invalid base-schema paths to clearly require the `/Schemas/<name>.yaml` format.
  * Added validation coverage to confirm the detailed error message is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->