### PR TITLE
Reintroduce stable source IDs for ASAB library providers

### DIFF
--- a/asab/library/__init__.py
+++ b/asab/library/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 from ..config import Config
 from .service import LibraryService
+from ..utils import get_source_id
 
 #
 
@@ -19,4 +20,5 @@ Config.add_defaults(
 
 __all__ = [
 	"LibraryService",
+	"get_source_id",
 ]

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -1,14 +1,17 @@
+import hashlib
 import typing
 
 
 class LibraryProviderABC(object):
 
 
-	def __init__(self, library, layer):
+	def __init__(self, library, layer, source):
 		super().__init__()
 		self.App = library.App
 		self.Library = library
 		self.Layer = layer
+		self.Source = source
+		self.ID = hashlib.sha256(source.encode("utf-8")).hexdigest()
 		self.IsReady = False
 
 

--- a/asab/library/providers/abc.py
+++ b/asab/library/providers/abc.py
@@ -1,5 +1,6 @@
-import hashlib
 import typing
+
+from ...utils import get_source_id
 
 
 class LibraryProviderABC(object):
@@ -11,7 +12,7 @@ class LibraryProviderABC(object):
 		self.Library = library
 		self.Layer = layer
 		self.Source = source
-		self.ID = hashlib.sha256(source.encode("utf-8")).hexdigest()
+		self.ID = get_source_id(source)
 		self.IsReady = False
 
 

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -39,12 +39,12 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 
 	'''
 
-	def __init__(self, library, path, layer):
-		super().__init__(library, layer)
+	def __init__(self, library, path, layer, *, source):
+		super().__init__(library, layer, source)
 		assert path[:6] == "azure+"
+		self.Path = path
 		self.URL = urllib.parse.urlparse(path[6:])
 		self.Model = None  # Will be set by `_load_model` method
-		self.Path = path
 
 		self.CacheDir = Config.get("library", "azure_cache")
 		if self.CacheDir == 'false':

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -12,7 +12,6 @@ import aiohttp
 
 from ...config import Config
 from ..item import LibraryItem
-from ...utils import get_source_id
 from .abc import LibraryProviderABC
 
 #
@@ -51,7 +50,7 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 		if self.CacheDir == 'false':
 			self.CacheDir = None
 		elif self.CacheDir == 'true':
-			self.CacheDir = os.path.join(tempfile.gettempdir(), "asab.library.azure.{}".format(get_source_id(path)))
+			self.CacheDir = os.path.join(tempfile.gettempdir(), "asab.library.azure.{}".format(self.ID))
 
 		# Ensure that the case directory exists
 		if self.CacheDir is not None:

--- a/asab/library/providers/azurestorage.py
+++ b/asab/library/providers/azurestorage.py
@@ -12,6 +12,7 @@ import aiohttp
 
 from ...config import Config
 from ..item import LibraryItem
+from ...utils import get_source_id
 from .abc import LibraryProviderABC
 
 #
@@ -50,7 +51,7 @@ class AzureStorageLibraryProvider(LibraryProviderABC):
 		if self.CacheDir == 'false':
 			self.CacheDir = None
 		elif self.CacheDir == 'true':
-			self.CacheDir = os.path.join(tempfile.gettempdir(), "asab.library.azure.{}".format(hashlib.sha256(path.encode('utf-8')).hexdigest()))
+			self.CacheDir = os.path.join(tempfile.gettempdir(), "asab.library.azure.{}".format(get_source_id(path)))
 
 		# Ensure that the case directory exists
 		if self.CacheDir is not None:

--- a/asab/library/providers/cache.py
+++ b/asab/library/providers/cache.py
@@ -9,9 +9,9 @@ L = logging.getLogger(__name__)
 
 class CacheLibraryProvider(SimpleFileSystemLibraryProvider):
 
-	def __init__(self, library, path, layer, *, repodir, ready_file):
+	def __init__(self, library, path, layer, *, source, repodir, ready_file):
 		self.ReadyFile = ready_file
-		super().__init__(library, repodir, layer, set_ready=False)
+		super().__init__(library, repodir, layer, source=source, set_ready=False)
 
 		# Wait for the ready file to be created by the asab-library service, indicating that the cache folder is ready.
 		self.App.TaskService.schedule(self.wait_for_ready())

--- a/asab/library/providers/filesystem.py
+++ b/asab/library/providers/filesystem.py
@@ -41,8 +41,8 @@ class SimpleFileSystemLibraryProvider(LibraryProviderABC):
 	- global path: <BasePath>/<path>
 	"""
 
-	def __init__(self, library, path, layer, *, set_ready=True):
-		super().__init__(library, layer)
+	def __init__(self, library, path, layer, *, source, set_ready=True):
+		super().__init__(library, layer, source)
 
 		# Check for `file://` prefix and strip it if present
 		if path.startswith('file://'):
@@ -378,8 +378,8 @@ class FileSystemLibraryProvider(SimpleFileSystemLibraryProvider):
 		("personal", "<cred>") -> watch one personal credential scope
 	"""
 
-	def __init__(self, library, path, layer, *, set_ready=True):
-		super().__init__(library, path, layer, set_ready=False)
+	def __init__(self, library, path, layer, *, source, set_ready=True):
+		super().__init__(library, path, layer, source=source, set_ready=False)
 
 		# Set up disabled file path
 		self.DisabledFilePath = os.path.join(self.BasePath, '.disabled.yaml')

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -2,13 +2,12 @@ import asyncio
 import os
 import tempfile
 import logging
-import hashlib
 import re
 import typing
 
 from .filesystem import SimpleFileSystemLibraryProvider
 from ...config import Config
-from ...utils import convert_to_seconds
+from ...utils import convert_to_seconds, get_source_id
 
 #
 
@@ -98,7 +97,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.RepoPath = os.path.join(
 				tempdir,
 				"asab.library.git",
-				hashlib.sha256(path.encode('utf-8')).hexdigest()
+				get_source_id(path)
 			)
 
 		super().__init__(library, self.RepoPath, layer, source=source, set_ready=False)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -70,7 +70,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 		ssh_passphrase=<optional passphrase for SSH key>
 		verify_ssh_fingerprint=yes|no (default: no - auto-accepts host keys)
 	"""
-	def __init__(self, library, path, layer, *, repodir=None):
+	def __init__(self, library, path, layer, *, source, repodir=None):
 
 		# Initialize attributes to avoid attribute errors
 		self.URLScheme = ""
@@ -101,7 +101,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 				hashlib.sha256(path.encode('utf-8')).hexdigest()
 			)
 
-		super().__init__(library, self.RepoPath, layer, set_ready=False)
+		super().__init__(library, self.RepoPath, layer, source=source, set_ready=False)
 
 		# Set custom SSL certificate locations if specified
 		cert_file = Config.get("library:git", "cert_file", fallback=None)

--- a/asab/library/providers/git.py
+++ b/asab/library/providers/git.py
@@ -70,6 +70,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 		verify_ssh_fingerprint=yes|no (default: no - auto-accepts host keys)
 	"""
 	def __init__(self, library, path, layer, *, source, repodir=None):
+		self.ID = get_source_id(source)
 
 		# Initialize attributes to avoid attribute errors
 		self.URLScheme = ""
@@ -97,7 +98,7 @@ class GitLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.RepoPath = os.path.join(
 				tempdir,
 				"asab.library.git",
-				get_source_id(path)
+				self.ID
 			)
 
 		super().__init__(library, self.RepoPath, layer, source=source, set_ready=False)

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -60,6 +60,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 
 
 	def __init__(self, library, path, layer, *, source, repodir=None):
+		self.ID = get_source_id(source)
 
 		url = urllib.parse.urlparse(path)
 		assert url.scheme.startswith("libsreg+")
@@ -104,7 +105,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.RootPath = os.path.join(
 				tempdir,
 				"asab.library.libsreg",
-				get_source_id(path)
+				self.ID
 			)
 		else:
 			self.RootPath = repodir

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -1,7 +1,6 @@
 import os.path
 import lzma
 import logging
-import hashlib
 import random
 import tarfile
 import asyncio
@@ -14,7 +13,7 @@ import aiohttp
 
 from .filesystem import SimpleFileSystemLibraryProvider
 from ..dirsync import synchronize_dirs
-from ...utils import convert_to_seconds
+from ...utils import convert_to_seconds, get_source_id
 
 #
 
@@ -105,7 +104,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 			self.RootPath = os.path.join(
 				tempdir,
 				"asab.library.libsreg",
-				hashlib.sha256(path.encode("utf-8")).hexdigest()
+				get_source_id(path)
 			)
 		else:
 			self.RootPath = repodir

--- a/asab/library/providers/libsreg.py
+++ b/asab/library/providers/libsreg.py
@@ -60,7 +60,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 	"""
 
 
-	def __init__(self, library, path, layer, *, repodir=None):
+	def __init__(self, library, path, layer, *, source, repodir=None):
 
 		url = urllib.parse.urlparse(path)
 		assert url.scheme.startswith("libsreg+")
@@ -117,7 +117,7 @@ class LibsRegLibraryProvider(SimpleFileSystemLibraryProvider):
 
 		os.makedirs(os.path.join(self.RepoPath), exist_ok=True)
 
-		super().__init__(library, self.RepoPath, layer, set_ready=False)
+		super().__init__(library, self.RepoPath, layer, source=source, set_ready=False)
 
 		self.PullLock = asyncio.Lock()
 		self.LastPull = None

--- a/asab/library/providers/zookeeper.py
+++ b/asab/library/providers/zookeeper.py
@@ -123,8 +123,8 @@ class ZooKeeperLibraryProvider(LibraryProviderABC):
 
 	"""
 
-	def __init__(self, library, path, layer):
-		super().__init__(library, layer)
+	def __init__(self, library, path, layer, *, source):
+		super().__init__(library, layer, source)
 
 		url_pieces = urllib.parse.urlparse(path)
 

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -132,33 +132,33 @@ class LibraryService(Service):
 
 		if path.startswith('zk://') or path.startswith('zookeeper://'):
 			from .providers.zookeeper import ZooKeeperLibraryProvider
-			library_provider = ZooKeeperLibraryProvider(self, path, layer)
+			library_provider = ZooKeeperLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('./') or path.startswith('/') or path.startswith('file://'):
 			from .providers.filesystem import FileSystemLibraryProvider
-			library_provider = FileSystemLibraryProvider(self, path, layer)
+			library_provider = FileSystemLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('azure+https://'):
 			from .providers.azurestorage import AzureStorageLibraryProvider
-			library_provider = AzureStorageLibraryProvider(self, path, layer)
+			library_provider = AzureStorageLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('git+'):
 			if len(self.CacheDir) > 0:
 				repodir = self._get_repodir(path)
 				from .providers.cache import CacheLibraryProvider
-				library_provider = CacheLibraryProvider(self, path, layer, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
+				library_provider = CacheLibraryProvider(self, path, layer, source=path, repodir=repodir, ready_file=os.path.join(repodir, ".ready"))
 			else:
 				from .providers.git import GitLibraryProvider
-				library_provider = GitLibraryProvider(self, path, layer)
+				library_provider = GitLibraryProvider(self, path, layer, source=path)
 
 		elif path.startswith('libsreg+'):
 			if len(self.CacheDir) > 0:
 				repodir = self._get_repodir(path)
 				from .providers.cache import CacheLibraryProvider
-				library_provider = CacheLibraryProvider(self, path, layer, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
+				library_provider = CacheLibraryProvider(self, path, layer, source=path, repodir=os.path.join(repodir, "content"), ready_file=os.path.join(repodir, ".ready"))
 			else:
 				from .providers.libsreg import LibsRegLibraryProvider
-				library_provider = LibsRegLibraryProvider(self, path, layer)
+				library_provider = LibsRegLibraryProvider(self, path, layer, source=path)
 
 		elif path == '' or path.startswith("#") or path.startswith(";"):
 			# This is empty or commented line

--- a/asab/library/service.py
+++ b/asab/library/service.py
@@ -3,7 +3,6 @@ import io
 import time
 import os.path
 import typing
-import hashlib
 import tarfile
 import asyncio
 import logging
@@ -18,6 +17,7 @@ from ..config import Config
 from ..log import LOG_NOTICE
 from .item import LibraryItem
 from ..application import Application
+from ..utils import get_source_id
 from .providers.abc import LibraryProviderABC
 from ..exceptions import LibraryInvalidPathError, LibraryNotReadyError
 from ..contextvars import Tenant
@@ -1027,7 +1027,7 @@ class LibraryService(Service):
 				await provider.subscribe(path, target)
 
 	def _get_repodir(self, path: str) -> str:
-		return os.path.join(self.CacheDir, hashlib.sha256(path.encode('utf-8')).hexdigest())
+		return os.path.join(self.CacheDir, get_source_id(path))
 
 
 def _validate_path_item(path: str) -> None:

--- a/asab/utils.py
+++ b/asab/utils.py
@@ -1,7 +1,13 @@
 import os
+import hashlib
 import urllib.parse
 import configparser
 import typing
+
+
+def get_source_id(source: str) -> str:
+	"""Return the stable identifier used for a library provider source."""
+	return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
 
 def convert_to_seconds(value: str) -> float:

--- a/examples/library-provider-sources.py
+++ b/examples/library-provider-sources.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import os.path
+
+import asab
+import asab.library
+
+
+class MyApplication(asab.Application):
+
+	def __init__(self):
+		super().__init__()
+
+		asab.Config["library"]["providers"] = "\n".join([
+			os.path.join(os.path.dirname(__file__), "library"),
+			"git+https://github.com/TeskaLabs/asab.git",
+		])
+
+		self.LibraryService = asab.library.LibraryService(
+			self,
+			"LibraryService",
+		)
+
+	async def main(self):
+		print("# Library provider sources\n")
+		for provider in self.LibraryService.Libraries:
+			print("{} source ID '{}' for source '{}'".format(
+				provider.__class__.__name__,
+				provider.ID,
+				provider.Source,
+			))
+
+		self.stop()
+
+
+if __name__ == '__main__':
+	app = MyApplication()
+	app.run()


### PR DESCRIPTION
This reverts commit 750a9596f84e85b2bf5b3837ee466cc3f2e580dd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library providers now expose consistent source information and identifiers.
  * Added an example demonstrating local and Git-based library provider configuration.
  * Added a utility for generating stable source identifiers.

* **Improvements**
  * Temporary and cached library locations now use consistent source-based identifiers.

* **API Changes**
  * Provider setup now requires specifying the provider source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->