### PR TITLE
The ASAB REST API accepts now also YAML (next to JSON)

### DIFF
--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -246,6 +246,7 @@ async def JsonExceptionMiddleware(request, handler):
 
 _form_content_types = frozenset(['', 'application/x-www-form-urlencoded', 'multipart/form-data'])
 
+
 def json_schema_handler(json_schema, *_args, **_kwargs):
 
 	"""

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -5,9 +5,18 @@ import datetime
 import functools
 import dataclasses
 
-
 import aiohttp.web
 import fastjsonschema
+
+try:
+	import yaml
+	try:
+		from yaml import CSafeLoader as YamlSafeLoader
+	except ImportError:
+		from yaml import SafeLoader as YamlSafeLoader
+except ImportError:
+	yaml = None
+	YamlSafeLoader = None
 
 from ... import exceptions
 
@@ -293,6 +302,9 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 					data = await request.json()
 				except json.decoder.JSONDecodeError:
 					raise aiohttp.web.HTTPBadRequest(reason="Failed to parse JSON request")
+			elif request.content_type == 'application/x-yaml' and yaml is not None:
+				data = await request.text()
+				data = yaml.load(data, Loader=YamlSafeLoader)
 			elif request.content_type in form_content_types:
 				multi_dict = await request.post()
 				data = {k: v for k, v in multi_dict.items()}

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -244,6 +244,7 @@ async def JsonExceptionMiddleware(request, handler):
 			status=500,
 		)
 
+_form_content_types = frozenset(['', 'application/x-www-form-urlencoded', 'multipart/form-data'])
 
 def json_schema_handler(json_schema, *_args, **_kwargs):
 
@@ -290,13 +291,13 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 				"JSON schema input must be type <class 'dict'> or type <class 'str'>, "
 				"not type {}.".format(type(json_schema)))
 
-		form_content_types = frozenset(['', 'application/x-www-form-urlencoded', 'multipart/form-data'])
 
 		@functools.wraps(func)
 		async def validator(*args, **kwargs):
 			# Initializing fastjsonschema.compile method and generating
 			# the validation function for validating JSON schema
 			request = args[-1]
+
 			if request.content_type == 'application/json':
 				try:
 					data = await request.json()
@@ -308,11 +309,12 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 					data = yaml.load(data, Loader=YamlSafeLoader)
 				except yaml.YAMLError:
 					raise aiohttp.web.HTTPBadRequest(reason="Failed to parse YAML request")
-			elif request.content_type in form_content_types:
+			elif request.content_type in _form_content_types:
 				multi_dict = await request.post()
 				data = {k: v for k, v in multi_dict.items()}
 			else:
 				raise aiohttp.web.HTTPBadRequest(reason="Unsupported content-type {}".format(request.content_type))
+
 			# Checking the validation on JSON data set
 			try:
 				validate(data)

--- a/asab/web/rest/json.py
+++ b/asab/web/rest/json.py
@@ -304,7 +304,10 @@ def json_schema_handler(json_schema, *_args, **_kwargs):
 					raise aiohttp.web.HTTPBadRequest(reason="Failed to parse JSON request")
 			elif request.content_type == 'application/x-yaml' and yaml is not None:
 				data = await request.text()
-				data = yaml.load(data, Loader=YamlSafeLoader)
+				try:
+					data = yaml.load(data, Loader=YamlSafeLoader)
+				except yaml.YAMLError:
+					raise aiohttp.web.HTTPBadRequest(reason="Failed to parse YAML request")
 			elif request.content_type in form_content_types:
 				multi_dict = await request.post()
 				data = {k: v for k, v in multi_dict.items()}


### PR DESCRIPTION
It is mainly a convenience for the API user + YAML is slightly better for AI than JSON.

<img width="674" height="475" alt="image" src="https://github.com/user-attachments/assets/4df8b17d-b6c5-4108-aa9b-cf23be91b0ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for submitting request data in YAML format.
  * YAML payloads are safely parsed and validated alongside JSON and form data.

* **Bug Fixes**
  * Requests with YAML content types now receive the same schema validation as other supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->