### PR TITLE
Aggregate skipped schema fields into a single log

### DIFF
--- a/asab/library/schema.py
+++ b/asab/library/schema.py
@@ -124,17 +124,21 @@ class LibrarySchemaService(Service):
 				)
 				continue
 
+			skipped_fields = []
 			for field_name, field_definition in extension_fields.items():
 				if field_name in merged_fields:
-					L.warning(
-						"Skipping schema extension field: field already exists.",
-						struct_data={
-							"path": item.name,
-							"field": field_name,
-						},
-					)
+					skipped_fields.append(field_name)
 					continue
 				merged_fields[field_name] = copy.deepcopy(field_definition)
+
+			if skipped_fields:
+				L.warning(
+					"Skipping schema extension fields: fields already exist.",
+					struct_data={
+						"path": item.name,
+						"fields": skipped_fields,
+					},
+				)
 
 		return merged_schema
 

--- a/asab/library/schema.py
+++ b/asab/library/schema.py
@@ -131,7 +131,7 @@ class LibrarySchemaService(Service):
 					continue
 				merged_fields[field_name] = copy.deepcopy(field_definition)
 
-			if skipped_fields:
+			if len(skipped_fields) > 0:
 				L.warning(
 					"Skipping schema extension fields: fields already exist.",
 					struct_data={

--- a/test/test_library/test_library_schema_extensions.py
+++ b/test/test_library/test_library_schema_extensions.py
@@ -8,6 +8,7 @@ prefix filtering, duplicate-field precedence, and deterministic merge order.
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from test.test_library.library_schema_test_utils import (
 	make_filesystem_provider,
@@ -17,7 +18,7 @@ from test.test_library.library_schema_test_utils import (
 )
 
 
-DUPLICATE_FIELD_WARNING = "Skipping schema extension field: field already exists."
+DUPLICATE_FIELD_WARNING = "Skipping schema extension fields: fields already exist."
 
 
 class TestLibrarySchemaExtensions(unittest.IsolatedAsyncioTestCase):
@@ -141,7 +142,7 @@ class TestLibrarySchemaExtensions(unittest.IsolatedAsyncioTestCase):
 			write_fixture(root, "/Schemas/Extensions/ECS-Conflict.yaml", "extension_multiple_conflicts.yaml")
 			service = make_schema_service(make_filesystem_provider(root))
 
-			with self.assertLogs("asab.library.schema", level="WARNING") as logs:
+			with mock.patch("asab.library.schema.L.warning") as warning:
 				schema = await service.read_schema("/Schemas/ECS.yaml")
 
 			self.assertEqual(
@@ -159,10 +160,12 @@ class TestLibrarySchemaExtensions(unittest.IsolatedAsyncioTestCase):
 				"bool",
 				"Non-conflicting field from the same extension should still be merged.",
 			)
-			self.assertEqual(
-				sum(DUPLICATE_FIELD_WARNING in message for message in logs.output),
-				2,
-				"Both conflicting extension fields should log duplicate skips.",
+			warning.assert_called_once_with(
+				DUPLICATE_FIELD_WARNING,
+				struct_data={
+					"path": "/Schemas/Extensions/ECS-Conflict.yaml",
+					"fields": ["host.name", "event.created"],
+				},
 			)
 
 	async def test_extension_for_other_schema_is_ignored(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated schema extension conflict warnings into a single notification per extension file.
  * Preserved all non-conflicting fields when merging schema extensions.
  * Improved conflict reporting to include the affected extension and field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->