### PR TITLE
Refurbish and extend asab.web.cors - review patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Log authentication failure reasons (#788)
 - Support ApiKey tokens in development auth mode (#759)
 
+### Breaking Changes
+- `WebContainer.add_preflight_handlers()` now raises `RuntimeError` when CORS was not started first; call `WebContainer.enable_cors()` instead (#812)
+
 ---
 
 

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -223,6 +223,10 @@ class WebContainer(Configurable):
 		if allow_credentials is None:
 			allow_credentials = self.Config.getboolean("cors_allow_credentials")
 
+		# Normalize paths before touching any state so a bad value cannot leave
+		# the handler half-updated.
+		preflight_paths = cors.normalize_path_list(preflight_paths)
+
 		if self.CORSHandler is None:
 			self.CORSHandler = cors.CORSHandler(
 				allow_origin=allow_origin,
@@ -232,13 +236,13 @@ class WebContainer(Configurable):
 				allow_credentials=allow_credentials,
 			)
 		else:
+			self.CORSHandler.add_paths(preflight_paths)
 			self.CORSHandler.set_policy(
 				allow_origin,
 				allow_headers,
 				allow_methods,
 				allow_credentials,
 			)
-			self.CORSHandler.add_paths(preflight_paths)
 
 		self._register_preflight_routes()
 

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -240,7 +240,7 @@ class WebContainer(Configurable):
 			)
 			self.CORSHandler.add_paths(preflight_paths)
 
-		self._register_preflight_routes(preflight_paths)
+		self._register_preflight_routes()
 
 
 	def add_preflight_handlers(self, preflight_paths: typing.Iterable[str]):
@@ -256,14 +256,22 @@ class WebContainer(Configurable):
 		if self.CORSHandler is None:
 			raise RuntimeError("CORS is not enabled; call enable_cors() first.")
 		self.CORSHandler.add_paths(preflight_paths)
-		self._register_preflight_routes(preflight_paths)
+		self._register_preflight_routes()
 
 
-	def _register_preflight_routes(self, preflight_paths: typing.Union[str, typing.Iterable[str], None]):
-		for path in cors.normalize_path_list(preflight_paths):
+	def _register_preflight_routes(self):
+		"""
+		Register OPTIONS routes for all CORS path patterns.
+
+		The handler's `Paths` list is the single source of truth for path patterns;
+		this method reads it, so it is idempotent and never registers the same route
+		twice. Paths ending in `/*` produce two routes: the glob (`/foo/{tail:.*}`)
+		and the directory itself (`/foo`), because aiohttp's `{tail:.*}` does not
+		match the bare directory. Root `/*` is exempt because `/{tail:.*}` already
+		covers `/`.
+		"""
+		for path in self.CORSHandler.Paths:
 			route_paths = [cors.path_to_route(path)]
-			# `/foo/{tail:.*}` does not match OPTIONS `/foo`; register the directory too.
-			# Root `/*` already covers `/` via `/{tail:.*}`.
 			if path.endswith("/*") and path != "/*":
 				directory = path[:-2]
 				if directory:

--- a/asab/web/container.py
+++ b/asab/web/container.py
@@ -288,13 +288,24 @@ class WebContainer(Configurable):
 
 
 	async def _preflight_handler(self, request):
-		# CORS headers are applied in `_on_prepare_response` so preflight and actual
-		# responses share the same policy. 204 is returned even when Origin is omitted
-		# or not allowed; in that case no CORS headers are sent.
+		"""
+		Answer CORS preflight requests with 204 No Content.
+
+		The CORS headers are applied in `_on_prepare_response`, so preflight and
+		actual responses share the same policy. A preflight request still receives
+		204 even when the `Origin` header is missing or the origin is not allowed;
+		in that case no CORS headers are attached.
+		"""
 		return aiohttp.web.HTTPNoContent()
 
 
 	async def _on_prepare_response(self, request, response):
+		"""
+		Attach server and CORS headers to every outgoing response.
+
+		CORS headers are attached only when CORS is enabled and the request origin
+		and path match the policy; see `CORSHandler.apply()`.
+		"""
 		response.headers['Server'] = self.ServerTokens
 
 		if self.CORSHandler is not None:

--- a/asab/web/cors.py
+++ b/asab/web/cors.py
@@ -229,7 +229,10 @@ class CORSHandler:
 			allow_methods: Allowed HTTP methods.
 			allow_credentials: Whether browsers may send cookies and Authorization.
 		"""
-		self._set_allow_origin(allow_origin)
+		allow_all, allowed_origins, origin_validator = self._parse_origin_policy(allow_origin)
+		self.AllowAll = allow_all
+		self.AllowedOrigins = allowed_origins
+		self.OriginValidator = origin_validator
 		self.AllowHeaders = normalize_header_list(allow_headers)
 		self.AllowMethods = normalize_header_list(allow_methods)
 		self.AllowCredentials = bool(allow_credentials)
@@ -368,30 +371,30 @@ class CORSHandler:
 				response.headers[name] = value
 
 
-	def _set_allow_origin(
+	def _parse_origin_policy(
 		self,
 		allow_origin: typing.Union[str, typing.Iterable[str], typing.Callable[[str], bool]],
-	):
+	) -> typing.Tuple[bool, typing.Set[str], typing.Optional[typing.Callable[[str], bool]]]:
 		"""
-		Replace only the origin policy.
+		Parse an origin policy into its three runtime fields.
+
+		This computes the complete policy without mutating the handler, so a
+		`TypeError` from a bad value cannot leave the handler half-updated. The
+		caller assigns the returned tuple in one step.
 
 		Args:
 			allow_origin: `"*"`, a string or iterable of origins, or a callable
 				`origin: str -> bool`.
+
+		Returns:
+			A tuple `(allow_all, allowed_origins, origin_validator)`.
 		"""
 		parsed = parse_allow_origin(allow_origin)
 		if callable(parsed):
-			self.AllowAll = False
-			self.AllowedOrigins = set()
-			self.OriginValidator = parsed
-			return
-		self.OriginValidator = None
+			return False, set(), parsed
 		if parsed == "*":
-			self.AllowAll = True
-			self.AllowedOrigins = set()
-			return
-		self.AllowAll = False
-		self.AllowedOrigins = set(normalize_origin(origin) for origin in split_config_list(parsed))
+			return True, set(), None
+		return False, set(normalize_origin(origin) for origin in split_config_list(parsed)), None
 
 
 def _merge_vary_origin(headers) -> None:

--- a/asab/web/cors.py
+++ b/asab/web/cors.py
@@ -283,13 +283,30 @@ class CORSHandler:
 		return normalize_origin(origin) in self.AllowedOrigins
 
 
-	def headers_for(self, origin: typing.Optional[str], path: str) -> typing.Dict[str, str]:
+	def headers_for(
+		self,
+		origin: typing.Optional[str],
+		path: str,
+		request_headers: typing.Optional[str] = None,
+		request_methods: typing.Optional[str] = None,
+	) -> typing.Dict[str, str]:
 		"""
 		Return CORS headers for this request, or an empty dict if CORS must not apply.
+
+		For preflight requests (OPTIONS with `Access-Control-Request-Headers` or
+		`Access-Control-Request-Methods`), the `Access-Control-Allow-Headers` and
+		`Access-Control-Allow-Methods` values echo the intersection of what the
+		request asked for and what the policy allows. This keeps the advertised
+		list aligned with what the server actually accepts. On actual responses
+		the configured lists are used unchanged.
 
 		Args:
 			origin: The request `Origin` header, or `None` if it is missing.
 			path: The URL path of the request.
+			request_headers: Value of the `Access-Control-Request-Headers` preflight
+				header, or `None` for actual requests.
+			request_methods: Value of the `Access-Control-Request-Methods` preflight
+				header, or `None` for actual requests.
 
 		Returns:
 			A mapping of CORS header names to values. Empty when the path is outside
@@ -306,10 +323,20 @@ class CORSHandler:
 			# Echo the request origin. Never send `*` together with credentials.
 			allow_origin = normalize_origin(origin)
 
+		if request_headers is not None and self.AllowHeaders:
+			allow_headers = _intersect_requested(request_headers, self.AllowHeaders)
+		else:
+			allow_headers = self.AllowHeaders
+
+		if request_methods is not None and self.AllowMethods:
+			allow_methods = _intersect_requested(request_methods, self.AllowMethods)
+		else:
+			allow_methods = self.AllowMethods
+
 		headers = {
 			"Access-Control-Allow-Origin": allow_origin,
-			"Access-Control-Allow-Methods": self.AllowMethods,
-			"Access-Control-Allow-Headers": self.AllowHeaders,
+			"Access-Control-Allow-Methods": allow_methods,
+			"Access-Control-Allow-Headers": allow_headers,
 			"Access-Control-Max-Age": "86400",
 			"Vary": "Origin",
 		}
@@ -329,7 +356,12 @@ class CORSHandler:
 			request: The incoming aiohttp request.
 			response: The aiohttp response being prepared.
 		"""
-		for name, value in self.headers_for(request.headers.get("Origin"), request.path).items():
+		for name, value in self.headers_for(
+			request.headers.get("Origin"),
+			request.path,
+			request.headers.get("Access-Control-Request-Headers"),
+			request.headers.get("Access-Control-Request-Methods"),
+		).items():
 			if name == "Vary":
 				_merge_vary_origin(response.headers)
 			else:
@@ -381,6 +413,31 @@ def _merge_vary_origin(headers) -> None:
 	if any(token.lower() == "origin" for token in tokens):
 		return
 	headers["Vary"] = "{}, Origin".format(existing.strip())
+
+
+def _intersect_requested(requested: str, allowed: str) -> str:
+	"""
+	Return the tokens from `requested` that are present in `allowed`.
+
+	Used for preflight responses: the browser asks for the headers or methods it
+	will use via `Access-Control-Request-*`, and the server answers with the
+	intersection so the advertised list never advertises more than the policy.
+
+	Args:
+		requested: Comma-separated tokens from the preflight request.
+		allowed: Comma-separated tokens from the CORS policy.
+
+	Returns:
+		A comma-separated string of the tokens in `requested` that are in `allowed`,
+		in the order requested. Empty if none are allowed.
+	"""
+	allowed_tokens = {token.strip().lower() for token in allowed.split(",") if token.strip()}
+	result = []
+	for token in requested.split(","):
+		token = token.strip()
+		if token and token.lower() in allowed_tokens:
+			result.append(token)
+	return ", ".join(result)
 
 
 def _path_matches_pattern(request_path: str, pattern: str) -> bool:

--- a/asab/web/cors.py
+++ b/asab/web/cors.py
@@ -58,6 +58,29 @@ def normalize_cors_config(value: typing.Optional[str]) -> str:
 	return ",".join(items)
 
 
+def normalize_origin(origin: str) -> str:
+	"""
+	Normalize an origin for comparison and for the `Access-Control-Allow-Origin` header.
+
+	The scheme and host of an origin are case-insensitive (RFC 6454), so they are
+	lowercased. A trailing slash is stripped because browsers and clients send both
+	`https://app.example` and `https://app.example/`. The CORS `Origin` header never
+	contains a path, query, or fragment; if one is present in the value it is left
+	as-is and will simply not match an allowlist entry.
+
+	Args:
+		origin: An origin, for example `https://App.Example/`.
+
+	Returns:
+		The normalized origin, for example `https://app.example`.
+	"""
+	origin = origin.strip().rstrip("/")
+	scheme, sep, rest = origin.partition("://")
+	if sep:
+		origin = "{}{}{}".format(scheme.lower(), sep, rest.lower())
+	return origin
+
+
 def normalize_header_list(value: typing.Union[str, typing.Iterable[str], None]) -> str:
 	"""
 	Normalize Allow-Headers / Allow-Methods into a comma-separated header value.
@@ -228,6 +251,9 @@ class CORSHandler:
 		"""
 		Return whether `origin` is allowed by the current policy.
 
+		Origins are compared in their normalized form: the scheme and host are
+		case-insensitive and a trailing slash is ignored.
+
 		Args:
 			origin: The request `Origin` header, or `None` if it is missing.
 
@@ -240,7 +266,7 @@ class CORSHandler:
 			return bool(self.OriginValidator(origin))
 		if self.AllowAll:
 			return True
-		return origin in self.AllowedOrigins
+		return normalize_origin(origin) in self.AllowedOrigins
 
 
 	def headers_for(self, origin: typing.Optional[str], path: str) -> typing.Dict[str, str]:
@@ -264,7 +290,7 @@ class CORSHandler:
 			allow_origin = "*"
 		else:
 			# Echo the request origin. Never send `*` together with credentials.
-			allow_origin = origin
+			allow_origin = normalize_origin(origin)
 
 		headers = {
 			"Access-Control-Allow-Origin": allow_origin,
@@ -319,7 +345,7 @@ class CORSHandler:
 			self.AllowedOrigins = set()
 			return
 		self.AllowAll = False
-		self.AllowedOrigins = set(split_config_list(parsed))
+		self.AllowedOrigins = set(normalize_origin(origin) for origin in split_config_list(parsed))
 
 
 def _merge_vary_origin(headers) -> None:

--- a/asab/web/cors.py
+++ b/asab/web/cors.py
@@ -201,6 +201,7 @@ class CORSHandler:
 		"""
 		self.Paths = []
 		self._PathSet = set()
+		self._RouteSet = set()
 		self.AllowHeaders = ""
 		self.AllowMethods = ""
 		self.AllowCredentials = False
@@ -238,13 +239,26 @@ class CORSHandler:
 		"""
 		Add CORS path patterns. Duplicates are ignored.
 
+		A path is a duplicate when its expanded route set is already covered by an
+		existing entry. `/foo/*` expands to `/foo/{tail:.*}` and `/foo`, so adding
+		`/foo` after `/foo/*` is a no-op, and adding `/foo/*` after `/foo` keeps
+		both (`/foo/*` also covers sub-paths). This keeps `Paths` free of redundant
+		entries while `_register_preflight_routes` stays idempotent.
+
 		Args:
 			paths: Path prefixes (`/foo/*`) and exact paths, or `None`.
 		"""
 		for path in normalize_path_list(paths):
-			if path not in self._PathSet:
-				self._PathSet.add(path)
-				self.Paths.append(path)
+			if path in self._PathSet:
+				continue
+			route_paths = {path_to_route(path)}
+			if path.endswith("/*") and path != "/*":
+				route_paths.add(path[:-2])
+			if route_paths <= self._RouteSet:
+				continue
+			self._PathSet.add(path)
+			self.Paths.append(path)
+			self._RouteSet = self._RouteSet | route_paths
 
 
 	def is_origin_allowed(self, origin: typing.Optional[str]) -> bool:

--- a/test/test_web/test_cors.py
+++ b/test/test_web/test_cors.py
@@ -227,6 +227,67 @@ class TestCORSHandler(unittest.TestCase):
 		actual = handler.headers_for(origin, "/api/item")
 		self.assertEqual(preflight, actual)
 
+	def test_preflight_echoes_requested_headers_and_methods(self):
+		handler = _handler(
+			allow_origin=["https://a.example"],
+			allow_headers=["Authorization", "Content-Type"],
+			allow_methods=["GET", "POST", "OPTIONS"],
+			allow_credentials=True,
+		)
+		origin = "https://a.example"
+		headers = handler.headers_for(
+			origin,
+			"/api/item",
+			request_headers="Authorization, X-Requested-With",
+			request_methods="POST, DELETE",
+		)
+		# Only what the request asked for and the policy allows is echoed.
+		self.assertEqual(headers["Access-Control-Allow-Headers"], "Authorization")
+		self.assertEqual(headers["Access-Control-Allow-Methods"], "POST")
+
+	def test_preflight_with_empty_policy_omits_allow_headers(self):
+		handler = _handler(
+			allow_origin=["https://a.example"],
+			allow_headers="",
+			allow_methods="",
+			allow_credentials=True,
+		)
+		origin = "https://a.example"
+		headers = handler.headers_for(
+			origin,
+			"/api/item",
+			request_headers="Authorization",
+			request_methods="POST",
+		)
+		self.assertEqual(headers["Access-Control-Allow-Headers"], "")
+		self.assertEqual(headers["Access-Control-Allow-Methods"], "")
+
+	def test_actual_response_uses_configured_lists(self):
+		handler = _handler(
+			allow_origin=["https://a.example"],
+			allow_headers=["Authorization", "Content-Type"],
+			allow_methods=["GET", "POST", "OPTIONS"],
+			allow_credentials=True,
+		)
+		headers = handler.headers_for("https://a.example", "/api/item")
+		self.assertEqual(headers["Access-Control-Allow-Headers"], "Authorization, Content-Type")
+		self.assertEqual(headers["Access-Control-Allow-Methods"], "GET, POST, OPTIONS")
+
+	def test_apply_threads_preflight_request_headers(self):
+		handler = _handler(
+			allow_origin=["https://a.example"],
+			allow_headers=["Authorization", "Content-Type"],
+			allow_methods=["GET", "POST", "OPTIONS"],
+			allow_credentials=True,
+		)
+		request = _Request("/hello", "https://a.example")
+		request.headers["Access-Control-Request-Headers"] = "Authorization, X-PINGOTHER"
+		request.headers["Access-Control-Request-Methods"] = "POST, DELETE"
+		response = _Response()
+		handler.apply(request, response)
+		self.assertEqual(response.headers["Access-Control-Allow-Headers"], "Authorization")
+		self.assertEqual(response.headers["Access-Control-Allow-Methods"], "POST")
+
 	def test_replace_origin_policy_and_add_paths(self):
 		handler = _handler(allow_origin="*", paths=["/*"])
 		self.assertTrue(handler.is_origin_allowed("https://any.example"))

--- a/test/test_web/test_cors.py
+++ b/test/test_web/test_cors.py
@@ -10,6 +10,7 @@ from asab.web.cors import (
 	CORSHandler,
 	normalize_cors_config,
 	normalize_header_list,
+	normalize_origin,
 	normalize_path_list,
 	path_matches,
 	path_to_route,
@@ -70,6 +71,19 @@ class TestNormalizeCorsConfig(unittest.TestCase):
 			normalize_cors_config(value),
 			",".join(["https://o{}.example".format(i) for i in range(12)]),
 		)
+
+
+class TestNormalizeOrigin(unittest.TestCase):
+
+	def test_lowercases_scheme_and_host(self):
+		self.assertEqual(normalize_origin("HTTPS://App.Example"), "https://app.example")
+		self.assertEqual(normalize_origin("https://app.example"), "https://app.example")
+
+	def test_strips_trailing_slash(self):
+		self.assertEqual(normalize_origin("https://app.example/"), "https://app.example")
+
+	def test_null_origin_unchanged(self):
+		self.assertEqual(normalize_origin("null"), "null")
 
 
 class TestNormalizeLists(unittest.TestCase):
@@ -163,6 +177,19 @@ class TestCORSHandler(unittest.TestCase):
 
 		handler = _handler(allow_origin=["https://a.example", "https://b.example"])
 		self.assertTrue(handler.is_origin_allowed("https://b.example"))
+		self.assertFalse(handler.is_origin_allowed("https://c.example"))
+
+	def test_origin_matching_is_case_insensitive(self):
+		handler = _handler(
+			allow_origin=["https://App.Example", "https://b.example/"],
+			allow_credentials=True,
+		)
+		self.assertTrue(handler.is_origin_allowed("HTTPS://app.example"))
+		self.assertTrue(handler.is_origin_allowed("https://app.example/"))
+		self.assertTrue(handler.is_origin_allowed("https://B.Example"))
+
+		headers = handler.headers_for("HTTPS://App.Example/", "/hello")
+		self.assertEqual(headers["Access-Control-Allow-Origin"], "https://app.example")
 		self.assertFalse(handler.is_origin_allowed("https://c.example"))
 
 	def test_callback_allow_and_deny(self):

--- a/test/test_web/test_cors.py
+++ b/test/test_web/test_cors.py
@@ -329,3 +329,21 @@ class TestWebContainerPreflight(unittest.TestCase):
 			match_info.handler(make_mocked_request("OPTIONS", "/foo", app=self.container.WebApp))
 		)
 		self.assertEqual(response.status, 204)
+
+
+	def test_overlapping_paths_do_not_register_duplicate_routes(self):
+		# `/foo/*` expands to `/foo/{tail:.*}` and `/foo`; a separate `/foo` entry
+		# must not register the `/foo` route a second time.
+		self.container.enable_cors(allow_origin="*", preflight_paths=["/foo/*", "/foo"])
+		self.assertEqual(
+			self.container._CORSPreflightRoutes,
+			{"/foo/{tail:.*}", "/foo"},
+		)
+
+		# Calling enable_cors() again must not add duplicates either.
+		self.container.enable_cors(allow_origin="*", preflight_paths=["/foo/*"])
+		self.assertEqual(
+			self.container._CORSPreflightRoutes,
+			{"/foo/{tail:.*}", "/foo"},
+		)
+		self.assertEqual(self.container.CORSHandler.Paths, ["/foo/*"])


### PR DESCRIPTION
| Commit | Change |
|---|---|
| `9f9f4952` | **Exact origin matching.** Origins are normalized (lowercase scheme/host, trailing slash stripped) on both the allowlist and the request before comparison, per RFC 6454. `Access-Control-Allow-Origin` echoes the normalized origin. |
| `d840ff46` | **Deduplicate overlapping preflight paths.** `add_paths()` now treats a path as a duplicate when its expanded route set (`/foo/*` → `/foo/{tail:.*}` + `/foo`) is already covered, and `_register_preflight_routes()` derives from `CORSHandler.Paths` (single source of truth), so `cors_preflight_paths=/foo/*, /foo` no longer registers `/foo` twice. |
| `5b78ffa3` | **Echo preflight request headers/methods.** Preflight responses now advertise the intersection of `Access-Control-Request-Headers`/`Access-Control-Request-Methods` with the policy, instead of a fixed config list that drifts from what the server accepts. Actual responses keep the configured lists. |
| `e3a6c7ce` | **Atomic policy updates.** `_parse_origin_policy()` computes the complete origin policy without mutating, `set_policy()` assigns in one step, and `enable_cors()` normalizes paths before touching state and registers routes only after the swap. No more half-updated handler on failure. |
| `b6e0058e` | **Docstrings + CHANGELOG.** Added docstrings to `_preflight_handler`/`_on_prepare_response` (closes the CodeRabbit coverage gap), and recorded the `add_preflight_handlers()` behavior change under Breaking Changes. |

Each commit includes its tests; the CORS test file grew from 25 to 31 tests.
