### PR TITLE
Schedule LeaderService election outside ZooKeeper watch callback

### DIFF
--- a/asab/zookeeper/leader_svc.py
+++ b/asab/zookeeper/leader_svc.py
@@ -261,7 +261,7 @@ class LeaderService(Service):
 		if not self._participating:
 			return
 		if not self.IsLeader():
-			self._election_thread()
+			self.ZkContainer.ProactorService.schedule_threadsafe(self._election_thread)
 
 
 	def _on_tick60(self, event_name):

--- a/test/test_zookeeper/__init__.py
+++ b/test/test_zookeeper/__init__.py
@@ -1,0 +1,1 @@
+"""ZooKeeper service tests."""

--- a/test/test_zookeeper/test_leader_svc.py
+++ b/test/test_zookeeper/test_leader_svc.py
@@ -1,0 +1,41 @@
+import types
+import unittest
+import unittest.mock
+
+import asab.zookeeper.leader_svc
+
+
+class LeaderServiceWatchTest(unittest.TestCase):
+
+	def setUp(self):
+		service = asab.zookeeper.leader_svc.LeaderService.__new__(
+			asab.zookeeper.leader_svc.LeaderService
+		)
+		service._participating = True
+		service._leader_zxid = None
+		service._election_thread = unittest.mock.Mock()
+		self.proactor_service = unittest.mock.Mock()
+		service.ZkContainer = types.SimpleNamespace(ProactorService=self.proactor_service)
+		self.service = service
+
+	def test_watch_schedules_election_on_proactor(self):
+		self.service._on_change_zookeeper_thread(unittest.mock.sentinel.event)
+
+		self.service._election_thread.assert_not_called()
+		self.proactor_service.schedule_threadsafe.assert_called_once_with(
+			self.service._election_thread
+		)
+
+	def test_watch_does_not_schedule_when_not_participating(self):
+		self.service._participating = False
+
+		self.service._on_change_zookeeper_thread(unittest.mock.sentinel.event)
+
+		self.proactor_service.schedule_threadsafe.assert_not_called()
+
+	def test_watch_does_not_schedule_when_already_leader(self):
+		self.service._leader_zxid = unittest.mock.sentinel.zxid
+
+		self.service._on_change_zookeeper_thread(unittest.mock.sentinel.event)
+
+		self.proactor_service.schedule_threadsafe.assert_not_called()


### PR DESCRIPTION
## Problem

`LeaderService._on_change_zookeeper_thread()` ran `_election_thread()` directly. Because election attempts perform synchronous ZooKeeper operations, a watch notification could block Kazoo's callback thread.

## Solution

Schedule the election attempt with `ProactorService.schedule_threadsafe()` when the service is participating and is not already the leader. This preserves the existing participation and leadership gates while moving blocking election work onto the proactor.

Focused tests cover:

- scheduling without executing the election inline
- skipping scheduling when not participating
- skipping scheduling when already leader

## Risk

The change is limited to item 3. Election semantics and the existing gating conditions remain unchanged. Other reliability items described in the issue are intentionally out of scope.

## Testing

- `python -m unittest -v test.test_zookeeper.test_leader_svc` (3 passed)
- `python -m unittest -v test` (142 passed)
- `python -m flake8 asab test/test_zookeeper`
- `git diff --check`

All Python commands ran in the isolated Docker runner.

Addresses item 3 of #809.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZooKeeper leader election handling to run reliably when watch events occur.
  * Prevented unnecessary election scheduling when the service is not participating or is already the leader.

* **Tests**
  * Added coverage for leader election watch-callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->